### PR TITLE
feat: 部署包下载清单、批量下载与解压目录校验

### DIFF
--- a/datasophon-api/src/main/resources/meta/datacluster/GRAFANA/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/datacluster/GRAFANA/service_ddl.json
@@ -5,7 +5,7 @@
   "version": "13.0.1",
   "sortNum": 17,
   "dependencies": [],
-  "decompressPackageName": "grafana-v13.0.1",
+  "decompressPackageName": "grafana-13.0.1",
   "arch": {
     "x86_64": {
       "packageName": "grafana-13.0.1.linux-amd64.tar.gz"

--- a/datasophon-api/src/main/resources/meta/datacluster/NACOS/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/datacluster/NACOS/service_ddl.json
@@ -5,7 +5,7 @@
   "version": "3.2.2",
   "sortNum": 80,
   "dependencies": [],
-  "decompressPackageName": "nacos-3.2.2",
+  "decompressPackageName": "nacos",
   "roles": [
     {
       "name": "NacosServer",

--- a/datasophon-api/src/main/resources/meta/datacluster/USCHEDULER/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/datacluster/USCHEDULER/service_ddl.json
@@ -778,7 +778,7 @@
   ],
   "arch": {
     "common": {
-      "packageName": "uscheduler3-3.0.2-3.4.0-bin.tar.gz"
+      "packageName": "uscheduler3-3.0.2-3.11.0-bin.tar.gz"
     }
   }
 }

--- a/datasophon-api/src/main/resources/meta/datacluster/ZOOKEEPER/service_ddl.json
+++ b/datasophon-api/src/main/resources/meta/datacluster/ZOOKEEPER/service_ddl.json
@@ -5,7 +5,7 @@
   "version": "3.8.6",
   "sortNum": 3,
   "dependencies": [],
-  "decompressPackageName": "apache-zookeeper-3.8.6",
+  "decompressPackageName": "apache-zookeeper-3.8.6-bin",
   "roles": [
     {
       "name": "ZkServer",

--- a/package/.gitignore
+++ b/package/.gitignore
@@ -1,0 +1,6 @@
+# 部署包二进制文件，不纳入版本控制
+# 使用 download.sh 脚本按需下载
+*.tar.gz
+*.tgz
+*.zip
+__pycache__/

--- a/package/README.md
+++ b/package/README.md
@@ -1,0 +1,85 @@
+# Datasophon 部署包管理
+
+本目录用于管理 Datasophon 各组件的部署包，包含下载清单、批量下载脚本和解压目录校验工具。
+
+## 目录结构
+
+```
+package/
+├── manifest.json          # 部署包清单（服务名、架构、下载地址）
+├── download.sh            # 批量下载脚本
+├── verify_decompress.py   # 解压目录校验工具
+└── <packageName>.tar.gz   # 下载后的部署包（已加入 .gitignore，不入库）
+```
+
+## 快速开始
+
+### 1. 下载所有公有包
+
+```bash
+bash package/download.sh
+```
+
+- 已存在且完整的文件（本地大小 ≥ Content-Length）自动跳过
+- 私有包自动跳过并在末尾列出提示
+- 下载失败以非零状态码退出，可重复执行直到全部完成
+
+### 2. 校验解压目录名
+
+```bash
+python3 package/verify_decompress.py
+```
+
+对每个已下载的包：
+- 读取压缩包内实际顶层目录名
+- 与 `service_ddl.json` 中的 `decompressPackageName` 比对
+- 不一致时自动写回 JSON 文件（多架构服务的归一化名称不修改）
+
+### 3. 手动下载单个包
+
+```bash
+# 示例：手动重试 flink（代理环境可能需要）
+curl -L --max-time 3600 -C - \
+  -o package/flink-2.2.1-bin-scala_2.12.tgz \
+  "https://archive.apache.org/dist/flink/flink-2.2.1/flink-2.2.1-bin-scala_2.12.tgz"
+```
+
+## manifest.json 字段说明
+
+| 字段 | 说明 |
+|---|---|
+| `service` | 服务名（对应 `meta/datacluster/<SERVICE>/`） |
+| `arch` | 架构（`x86_64` / `aarch64` / `common`） |
+| `packageName` | 包文件名，同时作为下载目标文件名 |
+| `decompressPackageName` | 解压后安装目录名，对应 `service_ddl.json` 中同名字段 |
+| `downloadUrl` | 下载地址；`null` 表示私有包，需手动上传 |
+| `status` | `public`（可自动下载）/ `private`（需手动上传） |
+| `note` | 备注（私有包说明、镜像地址等） |
+
+## 私有包
+
+以下包为内部构建，无公开下载地址，需从内部 Nexus 手动上传到本目录：
+
+| 包文件名 | 说明 |
+|---|---|
+| `datart-server.tar.gz` | 内部 BI 服务 |
+| `executor-3.11.0.tar.gz` | 内部调度执行器 |
+| `minio-9.0.1.tar.gz` / `minio-9.0.1-arm.tar.gz` | 自定义 MinIO 封装 |
+| `portal-application-3.1.0-RELEASE-install.tar.gz` | 内部门户服务 |
+| `redis-8.6.tar.gz` / `redis-8.6-arm.tar.gz` | 自定义构建（非官方版本号） |
+| `uscheduler3-3.0.2-3.4.0-bin.tar.gz` | 内部调度器 |
+| `ustream-3.4.0-bin.tar.gz` | 内部流处理 |
+| `usync-3.0.0-3.10.0.tar.gz` | 内部数据同步 |
+
+## 多架构包说明
+
+ALERTMANAGER、DORIS、PROMETHEUS 各有 x86_64 和 aarch64 两个包，包内顶层目录名含架构后缀（如 `alertmanager-0.32.1.linux-amd64`）。Worker 安装时使用 `tar --strip-components=1` 剥除顶层目录，因此 `decompressPackageName` 使用归一化名称（如 `alertmanager-0.32.1`），与实际架构无关。
+
+## 更新清单
+
+如需新增或修改组件版本：
+
+1. 编辑 `manifest.json`，更新 `packageName` / `downloadUrl` / `decompressPackageName`
+2. 同步修改对应的 `datasophon-api/src/main/resources/meta/datacluster/<SERVICE>/service_ddl.json`
+3. 运行 `download.sh` 下载新包
+4. 运行 `verify_decompress.py` 校验目录名是否一致

--- a/package/download.sh
+++ b/package/download.sh
@@ -4,19 +4,15 @@ set -euo pipefail
 MANIFEST="$(cd "$(dirname "$0")" && pwd)/manifest.json"
 PKG_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-if ! command -v wget &>/dev/null && ! command -v curl &>/dev/null; then
-  echo "ERROR: 需要 wget 或 curl"
+if ! command -v curl &>/dev/null; then
+  echo "ERROR: 需要 curl"
   exit 1
 fi
 
-export DATASOPHON_MANIFEST="$MANIFEST"
-export DATASOPHON_PKG_DIR="$PKG_DIR"
-
-python3 - <<'PYEOF'
+python3 - "$MANIFEST" "$PKG_DIR" <<'PYEOF'
 import json, os, subprocess, sys
 
-manifest_path = os.environ["DATASOPHON_MANIFEST"]
-pkg_dir = os.environ["DATASOPHON_PKG_DIR"]
+manifest_path, pkg_dir = sys.argv[1], sys.argv[2]
 
 with open(manifest_path) as f:
     pkgs = json.load(f)
@@ -49,22 +45,26 @@ for pkg in pkgs:
                 ["curl", "-sI", "--max-time", "15", "--location", url],
                 capture_output=True, text=True
             )
+            if head.returncode != 0:
+                # HEAD 请求失败，保守跳过，不删除已有文件
+                print(f"[EXISTS?] {name}  ({local_size / 1024 / 1024:.1f} MB, HEAD 失败 exit={head.returncode}) → 跳过")
+                continue
             content_length = None
             for line in head.stdout.splitlines():
                 if line.lower().startswith("content-length:"):
                     content_length = int(line.split(":", 1)[1].strip())
-            if content_length and local_size >= content_length:
-                size_mb = local_size / 1024 / 1024
-                print(f"[EXISTS] {name}  ({size_mb:.1f} MB)")
+            if content_length is None or content_length == 0:
+                # 服务端未返回有效 Content-Length（chunked 或重定向中间值），无法比对，保守跳过
+                print(f"[EXISTS?] {name}  ({local_size / 1024 / 1024:.1f} MB, 无 Content-Length) → 跳过")
                 continue
-            else:
-                size_mb = local_size / 1024 / 1024
-                remote_mb = (content_length or 0) / 1024 / 1024
-                print(f"[PARTIAL] {name}  (本地 {size_mb:.1f} MB / 远端 {remote_mb:.1f} MB) → 重新下载")
-                os.remove(dest)
+            if local_size >= content_length:
+                print(f"[EXISTS] {name}  ({local_size / 1024 / 1024:.1f} MB)")
+                continue
+            remote_mb = content_length / 1024 / 1024
+            print(f"[PARTIAL] {name}  (本地 {local_size / 1024 / 1024:.1f} MB / 远端 {remote_mb:.1f} MB) → 重新下载")
+            os.remove(dest)
         except Exception:
-            size_mb = local_size / 1024 / 1024
-            print(f"[EXISTS?] {name}  ({size_mb:.1f} MB, 无法验证大小) → 跳过")
+            print(f"[EXISTS?] {name}  ({local_size / 1024 / 1024:.1f} MB, 无法验证大小) → 跳过")
             continue
 
     print(f"[DOWNLOAD] {service}/{arch} → {name}")

--- a/package/download.sh
+++ b/package/download.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MANIFEST="$(cd "$(dirname "$0")" && pwd)/manifest.json"
+PKG_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if ! command -v wget &>/dev/null && ! command -v curl &>/dev/null; then
+  echo "ERROR: 需要 wget 或 curl"
+  exit 1
+fi
+
+export DATASOPHON_MANIFEST="$MANIFEST"
+export DATASOPHON_PKG_DIR="$PKG_DIR"
+
+python3 - <<'PYEOF'
+import json, os, subprocess, sys
+
+manifest_path = os.environ["DATASOPHON_MANIFEST"]
+pkg_dir = os.environ["DATASOPHON_PKG_DIR"]
+
+with open(manifest_path) as f:
+    pkgs = json.load(f)
+
+seen = set()
+skipped_private = []
+download_errors = []
+
+for pkg in pkgs:
+    name = pkg["packageName"]
+    url = pkg.get("downloadUrl")
+    service = pkg["service"]
+    arch = pkg["arch"]
+
+    if name in seen:
+        continue
+    seen.add(name)
+
+    if not url:
+        skipped_private.append(f"  [SKIP-PRIVATE] {name}  # {pkg.get('note', '')}")
+        continue
+
+    dest = os.path.join(pkg_dir, name)
+    if os.path.exists(dest):
+        size_mb = os.path.getsize(dest) / 1024 / 1024
+        print(f"[EXISTS] {name}  ({size_mb:.1f} MB)")
+        continue
+
+    print(f"[DOWNLOAD] {service}/{arch} → {name}")
+    print(f"           {url}")
+    try:
+        has_wget = subprocess.run(["wget", "--version"], capture_output=True).returncode == 0
+        if has_wget:
+            cmd = ["wget", "--continue", "--timeout=1800", "--tries=3",
+                   "--show-progress", "-O", dest, url]
+        else:
+            cmd = ["curl", "-L", "--continue-at", "-", "--max-time", "1800",
+                   "--retry", "3", "--progress-bar", "-o", dest, url]
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            download_errors.append(f"  [ERROR] {name}: 下载失败，exit={result.returncode}")
+            if os.path.exists(dest) and os.path.getsize(dest) == 0:
+                os.remove(dest)
+        else:
+            size_mb = os.path.getsize(dest) / 1024 / 1024
+            print(f"  [DONE]  {name}  ({size_mb:.1f} MB)")
+    except Exception as e:
+        download_errors.append(f"  [ERROR] {name}: {e}")
+
+print("\n===== 下载完成 =====")
+if skipped_private:
+    print("\n[私有包，需手动上传到 package/]")
+    for m in skipped_private:
+        print(m)
+if download_errors:
+    print("\n[下载失败]")
+    for m in download_errors:
+        print(m)
+    sys.exit(1)
+PYEOF

--- a/package/download.sh
+++ b/package/download.sh
@@ -40,21 +40,38 @@ for pkg in pkgs:
         continue
 
     dest = os.path.join(pkg_dir, name)
+
+    # 用 HEAD 请求获取 Content-Length，与本地文件对比，跳过完整文件
     if os.path.exists(dest):
-        size_mb = os.path.getsize(dest) / 1024 / 1024
-        print(f"[EXISTS] {name}  ({size_mb:.1f} MB)")
-        continue
+        local_size = os.path.getsize(dest)
+        try:
+            head = subprocess.run(
+                ["curl", "-sI", "--max-time", "15", "--location", url],
+                capture_output=True, text=True
+            )
+            content_length = None
+            for line in head.stdout.splitlines():
+                if line.lower().startswith("content-length:"):
+                    content_length = int(line.split(":", 1)[1].strip())
+            if content_length and local_size >= content_length:
+                size_mb = local_size / 1024 / 1024
+                print(f"[EXISTS] {name}  ({size_mb:.1f} MB)")
+                continue
+            else:
+                size_mb = local_size / 1024 / 1024
+                remote_mb = (content_length or 0) / 1024 / 1024
+                print(f"[PARTIAL] {name}  (本地 {size_mb:.1f} MB / 远端 {remote_mb:.1f} MB) → 重新下载")
+                os.remove(dest)
+        except Exception:
+            size_mb = local_size / 1024 / 1024
+            print(f"[EXISTS?] {name}  ({size_mb:.1f} MB, 无法验证大小) → 跳过")
+            continue
 
     print(f"[DOWNLOAD] {service}/{arch} → {name}")
     print(f"           {url}")
     try:
-        has_wget = subprocess.run(["wget", "--version"], capture_output=True).returncode == 0
-        if has_wget:
-            cmd = ["wget", "--continue", "--timeout=1800", "--tries=3",
-                   "--show-progress", "-O", dest, url]
-        else:
-            cmd = ["curl", "-L", "--continue-at", "-", "--max-time", "1800",
-                   "--retry", "3", "--progress-bar", "-o", dest, url]
+        cmd = ["curl", "-L", "--max-time", "1800", "--retry", "3",
+               "--progress-bar", "-o", dest, url]
         result = subprocess.run(cmd)
         if result.returncode != 0:
             download_errors.append(f"  [ERROR] {name}: 下载失败，exit={result.returncode}")

--- a/package/manifest.json
+++ b/package/manifest.json
@@ -71,7 +71,8 @@
     "packageName": "flink-2.2.1-bin-scala_2.12.tgz",
     "decompressPackageName": "flink-2.2.1",
     "downloadUrl": "https://downloads.apache.org/flink/flink-2.2.1/flink-2.2.1-bin-scala_2.12.tgz",
-    "status": "public"
+    "status": "public",
+    "note": "备用镜像：https://archive.apache.org/dist/flink/flink-2.2.1/flink-2.2.1-bin-scala_2.12.tgz（代理环境下连接易中断，可直接使用此链接重试）"
   },
   {
     "service": "GRAFANA",

--- a/package/manifest.json
+++ b/package/manifest.json
@@ -1,0 +1,287 @@
+[
+  {
+    "service": "ALERTMANAGER", "arch": "x86_64",
+    "packageName": "alertmanager-0.32.1.linux-amd64.tar.gz",
+    "decompressPackageName": "alertmanager-0.32.1",
+    "downloadUrl": "https://github.com/prometheus/alertmanager/releases/download/v0.32.1/alertmanager-0.32.1.linux-amd64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "ALERTMANAGER", "arch": "aarch64",
+    "packageName": "alertmanager-0.32.1.linux-arm64.tar.gz",
+    "decompressPackageName": "alertmanager-0.32.1",
+    "downloadUrl": "https://github.com/prometheus/alertmanager/releases/download/v0.32.1/alertmanager-0.32.1.linux-arm64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "APISIX", "arch": "common",
+    "packageName": "apache-apisix-3.16.0-src.tgz",
+    "decompressPackageName": "apache-apisix-3.16.0",
+    "downloadUrl": "https://downloads.apache.org/apisix/3.16.0/apache-apisix-3.16.0-src.tgz",
+    "status": "public"
+  },
+  {
+    "service": "DATART", "arch": "common",
+    "packageName": "datart-server.tar.gz",
+    "decompressPackageName": "datart-server",
+    "downloadUrl": null,
+    "status": "private",
+    "note": "内部 BI 服务，需手动上传到 package/"
+  },
+  {
+    "service": "DORIS", "arch": "x86_64",
+    "packageName": "apache-doris-4.0.5-bin-x64.tar.gz",
+    "decompressPackageName": "apache-doris-4.0.5",
+    "downloadUrl": "https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-4.0.5-bin-x64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "DORIS", "arch": "aarch64",
+    "packageName": "apache-doris-4.0.5-bin-arm64.tar.gz",
+    "decompressPackageName": "apache-doris-4.0.5",
+    "downloadUrl": "https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-4.0.5-bin-arm64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "ELASTICSEARCH", "arch": "common",
+    "packageName": "elasticsearch-9.4.2-linux-x86_64.tar.gz",
+    "decompressPackageName": "elasticsearch-9.4.2",
+    "downloadUrl": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-9.4.2-linux-x86_64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "EXECUTOR", "arch": "common",
+    "packageName": "executor-3.11.0.tar.gz",
+    "decompressPackageName": "executor-3.11.0",
+    "downloadUrl": null,
+    "status": "private",
+    "note": "内部调度执行器，需手动上传到 package/"
+  },
+  {
+    "service": "FLINK", "arch": "common",
+    "packageName": "flink-2.2.1-bin-scala_2.12.tgz",
+    "decompressPackageName": "flink-2.2.1",
+    "downloadUrl": "https://downloads.apache.org/flink/flink-2.2.1/flink-2.2.1-bin-scala_2.12.tgz",
+    "status": "public"
+  },
+  {
+    "service": "GRAFANA", "arch": "x86_64",
+    "packageName": "grafana-13.0.1.linux-amd64.tar.gz",
+    "decompressPackageName": "grafana-v13.0.1",
+    "downloadUrl": "https://dl.grafana.com/oss/release/grafana-13.0.1.linux-amd64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "GRAFANA", "arch": "aarch64",
+    "packageName": "grafana-13.0.1.linux-arm64.tar.gz",
+    "decompressPackageName": "grafana-v13.0.1",
+    "downloadUrl": "https://dl.grafana.com/oss/release/grafana-13.0.1.linux-arm64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "HDFS", "arch": "x86_64",
+    "packageName": "hadoop-3.5.0.tar.gz",
+    "decompressPackageName": "hadoop-3.5.0",
+    "downloadUrl": "https://downloads.apache.org/hadoop/common/hadoop-3.5.0/hadoop-3.5.0.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "HDFS", "arch": "aarch64",
+    "packageName": "hadoop-3.5.0-aarch64.tar.gz",
+    "decompressPackageName": "hadoop-3.5.0",
+    "downloadUrl": "https://downloads.apache.org/hadoop/common/hadoop-3.5.0/hadoop-3.5.0-aarch64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "HIVE", "arch": "common",
+    "packageName": "apache-hive-4.2.0-bin.tar.gz",
+    "decompressPackageName": "apache-hive-4.2.0-bin",
+    "downloadUrl": "https://downloads.apache.org/hive/hive-4.2.0/apache-hive-4.2.0-bin.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "JUICEFS", "arch": "x86_64",
+    "packageName": "juicefs-1.3.1-linux-amd64.tar.gz",
+    "decompressPackageName": "juicefs-1.3.1",
+    "downloadUrl": "https://github.com/juicedata/juicefs/releases/download/v1.3.1/juicefs-1.3.1-linux-amd64.tar.gz",
+    "status": "public",
+    "note": "单二进制包，tarball 内无顶层目录，decompressPackageName 由 datasophon 自行创建"
+  },
+  {
+    "service": "JUICEFS", "arch": "aarch64",
+    "packageName": "juicefs-1.3.1-linux-arm64.tar.gz",
+    "decompressPackageName": "juicefs-1.3.1",
+    "downloadUrl": "https://github.com/juicedata/juicefs/releases/download/v1.3.1/juicefs-1.3.1-linux-arm64.tar.gz",
+    "status": "public",
+    "note": "单二进制包"
+  },
+  {
+    "service": "KAFKA", "arch": "common",
+    "packageName": "kafka_2.13-4.3.0.tgz",
+    "decompressPackageName": "kafka_2.13-4.3.0",
+    "downloadUrl": "https://downloads.apache.org/kafka/4.3.0/kafka_2.13-4.3.0.tgz",
+    "status": "public"
+  },
+  {
+    "service": "KYUUBI", "arch": "common",
+    "packageName": "apache-kyuubi-1.11.1-bin.tgz",
+    "decompressPackageName": "apache-kyuubi-1.11.1-bin",
+    "downloadUrl": "https://downloads.apache.org/kyuubi/kyuubi-1.11.1/apache-kyuubi-1.11.1-bin.tgz",
+    "status": "public"
+  },
+  {
+    "service": "LOKI", "arch": "x86_64",
+    "packageName": "loki-linux-amd64.zip",
+    "decompressPackageName": "loki-3.7.2",
+    "downloadUrl": "https://github.com/grafana/loki/releases/download/v3.7.2/loki-linux-amd64.zip",
+    "status": "public",
+    "note": "单二进制 zip，无顶层目录，verify 步跳过目录校验"
+  },
+  {
+    "service": "LOKI", "arch": "aarch64",
+    "packageName": "loki-linux-arm64.zip",
+    "decompressPackageName": "loki-3.7.2",
+    "downloadUrl": "https://github.com/grafana/loki/releases/download/v3.7.2/loki-linux-arm64.zip",
+    "status": "public",
+    "note": "单二进制 zip，无顶层目录"
+  },
+  {
+    "service": "MINIO", "arch": "x86_64",
+    "packageName": "minio-9.0.1.tar.gz",
+    "decompressPackageName": "minio-9.0.1",
+    "downloadUrl": null,
+    "status": "private",
+    "note": "自定义 MinIO 封装，版本号非官方，需手动上传到 package/"
+  },
+  {
+    "service": "MINIO", "arch": "aarch64",
+    "packageName": "minio-9.0.1-arm.tar.gz",
+    "decompressPackageName": "minio-9.0.1",
+    "downloadUrl": null,
+    "status": "private",
+    "note": "自定义 MinIO ARM 版，需手动上传到 package/"
+  },
+  {
+    "service": "NACOS", "arch": "common",
+    "packageName": "nacos-server-3.2.2.tar.gz",
+    "decompressPackageName": "nacos-3.2.2",
+    "downloadUrl": "https://github.com/alibaba/nacos/releases/download/3.2.2/nacos-server-3.2.2.tar.gz",
+    "status": "public",
+    "note": "注意：Nacos 官方包实际解压目录为 nacos/（无版本号），需 verify 步确认并修正"
+  },
+  {
+    "service": "NGINX", "arch": "common",
+    "packageName": "nginx-1.30.2.tar.gz",
+    "decompressPackageName": "nginx-1.30.2",
+    "downloadUrl": "https://nginx.org/download/nginx-1.30.2.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "PORTAL", "arch": "common",
+    "packageName": "portal-application-3.1.0-RELEASE-install.tar.gz",
+    "decompressPackageName": "portal-application-3.1.0-RELEASE",
+    "downloadUrl": null,
+    "status": "private",
+    "note": "内部门户服务，需手动上传到 package/"
+  },
+  {
+    "service": "PROMETHEUS", "arch": "x86_64",
+    "packageName": "prometheus-3.12.0.linux-amd64.tar.gz",
+    "decompressPackageName": "prometheus-3.12.0",
+    "downloadUrl": "https://github.com/prometheus/prometheus/releases/download/v3.12.0/prometheus-3.12.0.linux-amd64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "PROMETHEUS", "arch": "aarch64",
+    "packageName": "prometheus-3.12.0.linux-arm64.tar.gz",
+    "decompressPackageName": "prometheus-3.12.0",
+    "downloadUrl": "https://github.com/prometheus/prometheus/releases/download/v3.12.0/prometheus-3.12.0.linux-arm64.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "PROMTAIL", "arch": "x86_64",
+    "packageName": "promtail-linux-amd64.zip",
+    "decompressPackageName": "promtail-2.8.11",
+    "downloadUrl": "https://github.com/grafana/loki/releases/download/v2.8.11/promtail-linux-amd64.zip",
+    "status": "public",
+    "note": "单二进制 zip，无顶层目录，verify 步跳过目录校验"
+  },
+  {
+    "service": "PROMTAIL", "arch": "aarch64",
+    "packageName": "promtail-linux-arm64.zip",
+    "decompressPackageName": "promtail-2.8.11",
+    "downloadUrl": "https://github.com/grafana/loki/releases/download/v2.8.11/promtail-linux-arm64.zip",
+    "status": "public",
+    "note": "单二进制 zip，无顶层目录"
+  },
+  {
+    "service": "REDIS", "arch": "x86_64",
+    "packageName": "redis-8.6.tar.gz",
+    "decompressPackageName": "redis-8.6",
+    "downloadUrl": "https://download.redis.io/releases/redis-8.6.tar.gz",
+    "status": "public"
+  },
+  {
+    "service": "REDIS", "arch": "aarch64",
+    "packageName": "redis-8.6-arm.tar.gz",
+    "decompressPackageName": "redis-8.6",
+    "downloadUrl": null,
+    "status": "private",
+    "note": "自定义 ARM 构建，需手动上传到 package/"
+  },
+  {
+    "service": "SPARK3", "arch": "common",
+    "packageName": "spark-3.5.8-bin-hadoop3.tgz",
+    "decompressPackageName": "spark-3.5.8-bin-hadoop3",
+    "downloadUrl": "https://downloads.apache.org/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3.tgz",
+    "status": "public"
+  },
+  {
+    "service": "USCHEDULER", "arch": "common",
+    "packageName": "uscheduler3-3.0.2-3.4.0-bin.tar.gz",
+    "decompressPackageName": "uscheduler3-3.0.2-3.11.0",
+    "downloadUrl": null,
+    "status": "private",
+    "note": "内部调度器，需手动上传到 package/"
+  },
+  {
+    "service": "USTREAM", "arch": "common",
+    "packageName": "ustream-3.4.0-bin.tar.gz",
+    "decompressPackageName": "ustream-3.4.0",
+    "downloadUrl": null,
+    "status": "private",
+    "note": "内部流处理，需手动上传到 package/"
+  },
+  {
+    "service": "USYNC", "arch": "common",
+    "packageName": "usync-3.0.0-3.10.0.tar.gz",
+    "decompressPackageName": "usync-3.0.0-3.10.0",
+    "downloadUrl": null,
+    "status": "private",
+    "note": "内部数据同步，需手动上传到 package/"
+  },
+  {
+    "service": "YARN", "arch": "x86_64",
+    "packageName": "hadoop-3.5.0.tar.gz",
+    "decompressPackageName": "hadoop-3.5.0",
+    "downloadUrl": "https://downloads.apache.org/hadoop/common/hadoop-3.5.0/hadoop-3.5.0.tar.gz",
+    "status": "public",
+    "note": "与 HDFS 共用同一包，download.sh 按 packageName 去重，不重复下载"
+  },
+  {
+    "service": "YARN", "arch": "aarch64",
+    "packageName": "hadoop-3.5.0-aarch64.tar.gz",
+    "decompressPackageName": "hadoop-3.5.0",
+    "downloadUrl": "https://downloads.apache.org/hadoop/common/hadoop-3.5.0/hadoop-3.5.0-aarch64.tar.gz",
+    "status": "public",
+    "note": "与 HDFS 共用同一包"
+  },
+  {
+    "service": "ZOOKEEPER", "arch": "common",
+    "packageName": "apache-zookeeper-3.8.6-bin.tar.gz",
+    "decompressPackageName": "apache-zookeeper-3.8.6",
+    "downloadUrl": "https://downloads.apache.org/zookeeper/zookeeper-3.8.6/apache-zookeeper-3.8.6-bin.tar.gz",
+    "status": "public",
+    "note": "注意：包名含 -bin 后缀，实际解压顶层目录为 apache-zookeeper-3.8.6-bin，需 verify 步确认"
+  }
+]

--- a/package/manifest.json
+++ b/package/manifest.json
@@ -1,27 +1,31 @@
 [
   {
-    "service": "ALERTMANAGER", "arch": "x86_64",
+    "service": "ALERTMANAGER",
+    "arch": "x86_64",
     "packageName": "alertmanager-0.32.1.linux-amd64.tar.gz",
     "decompressPackageName": "alertmanager-0.32.1",
     "downloadUrl": "https://github.com/prometheus/alertmanager/releases/download/v0.32.1/alertmanager-0.32.1.linux-amd64.tar.gz",
     "status": "public"
   },
   {
-    "service": "ALERTMANAGER", "arch": "aarch64",
+    "service": "ALERTMANAGER",
+    "arch": "aarch64",
     "packageName": "alertmanager-0.32.1.linux-arm64.tar.gz",
     "decompressPackageName": "alertmanager-0.32.1",
     "downloadUrl": "https://github.com/prometheus/alertmanager/releases/download/v0.32.1/alertmanager-0.32.1.linux-arm64.tar.gz",
     "status": "public"
   },
   {
-    "service": "APISIX", "arch": "common",
+    "service": "APISIX",
+    "arch": "common",
     "packageName": "apache-apisix-3.16.0-src.tgz",
     "decompressPackageName": "apache-apisix-3.16.0",
     "downloadUrl": "https://downloads.apache.org/apisix/3.16.0/apache-apisix-3.16.0-src.tgz",
     "status": "public"
   },
   {
-    "service": "DATART", "arch": "common",
+    "service": "DATART",
+    "arch": "common",
     "packageName": "datart-server.tar.gz",
     "decompressPackageName": "datart-server",
     "downloadUrl": null,
@@ -29,28 +33,32 @@
     "note": "内部 BI 服务，需手动上传到 package/"
   },
   {
-    "service": "DORIS", "arch": "x86_64",
+    "service": "DORIS",
+    "arch": "x86_64",
     "packageName": "apache-doris-4.0.5-bin-x64.tar.gz",
     "decompressPackageName": "apache-doris-4.0.5",
     "downloadUrl": "https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-4.0.5-bin-x64.tar.gz",
     "status": "public"
   },
   {
-    "service": "DORIS", "arch": "aarch64",
+    "service": "DORIS",
+    "arch": "aarch64",
     "packageName": "apache-doris-4.0.5-bin-arm64.tar.gz",
     "decompressPackageName": "apache-doris-4.0.5",
     "downloadUrl": "https://apache-doris-releases.oss-accelerate.aliyuncs.com/apache-doris-4.0.5-bin-arm64.tar.gz",
     "status": "public"
   },
   {
-    "service": "ELASTICSEARCH", "arch": "common",
+    "service": "ELASTICSEARCH",
+    "arch": "common",
     "packageName": "elasticsearch-9.4.2-linux-x86_64.tar.gz",
     "decompressPackageName": "elasticsearch-9.4.2",
     "downloadUrl": "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-9.4.2-linux-x86_64.tar.gz",
     "status": "public"
   },
   {
-    "service": "EXECUTOR", "arch": "common",
+    "service": "EXECUTOR",
+    "arch": "common",
     "packageName": "executor-3.11.0.tar.gz",
     "decompressPackageName": "executor-3.11.0",
     "downloadUrl": null,
@@ -58,49 +66,56 @@
     "note": "内部调度执行器，需手动上传到 package/"
   },
   {
-    "service": "FLINK", "arch": "common",
+    "service": "FLINK",
+    "arch": "common",
     "packageName": "flink-2.2.1-bin-scala_2.12.tgz",
     "decompressPackageName": "flink-2.2.1",
     "downloadUrl": "https://downloads.apache.org/flink/flink-2.2.1/flink-2.2.1-bin-scala_2.12.tgz",
     "status": "public"
   },
   {
-    "service": "GRAFANA", "arch": "x86_64",
+    "service": "GRAFANA",
+    "arch": "x86_64",
     "packageName": "grafana-13.0.1.linux-amd64.tar.gz",
     "decompressPackageName": "grafana-v13.0.1",
     "downloadUrl": "https://dl.grafana.com/oss/release/grafana-13.0.1.linux-amd64.tar.gz",
     "status": "public"
   },
   {
-    "service": "GRAFANA", "arch": "aarch64",
+    "service": "GRAFANA",
+    "arch": "aarch64",
     "packageName": "grafana-13.0.1.linux-arm64.tar.gz",
     "decompressPackageName": "grafana-v13.0.1",
     "downloadUrl": "https://dl.grafana.com/oss/release/grafana-13.0.1.linux-arm64.tar.gz",
     "status": "public"
   },
   {
-    "service": "HDFS", "arch": "x86_64",
+    "service": "HDFS",
+    "arch": "x86_64",
     "packageName": "hadoop-3.5.0.tar.gz",
     "decompressPackageName": "hadoop-3.5.0",
     "downloadUrl": "https://downloads.apache.org/hadoop/common/hadoop-3.5.0/hadoop-3.5.0.tar.gz",
     "status": "public"
   },
   {
-    "service": "HDFS", "arch": "aarch64",
+    "service": "HDFS",
+    "arch": "aarch64",
     "packageName": "hadoop-3.5.0-aarch64.tar.gz",
     "decompressPackageName": "hadoop-3.5.0",
     "downloadUrl": "https://downloads.apache.org/hadoop/common/hadoop-3.5.0/hadoop-3.5.0-aarch64.tar.gz",
     "status": "public"
   },
   {
-    "service": "HIVE", "arch": "common",
+    "service": "HIVE",
+    "arch": "common",
     "packageName": "apache-hive-4.2.0-bin.tar.gz",
     "decompressPackageName": "apache-hive-4.2.0-bin",
     "downloadUrl": "https://downloads.apache.org/hive/hive-4.2.0/apache-hive-4.2.0-bin.tar.gz",
     "status": "public"
   },
   {
-    "service": "JUICEFS", "arch": "x86_64",
+    "service": "JUICEFS",
+    "arch": "x86_64",
     "packageName": "juicefs-1.3.1-linux-amd64.tar.gz",
     "decompressPackageName": "juicefs-1.3.1",
     "downloadUrl": "https://github.com/juicedata/juicefs/releases/download/v1.3.1/juicefs-1.3.1-linux-amd64.tar.gz",
@@ -108,7 +123,8 @@
     "note": "单二进制包，tarball 内无顶层目录，decompressPackageName 由 datasophon 自行创建"
   },
   {
-    "service": "JUICEFS", "arch": "aarch64",
+    "service": "JUICEFS",
+    "arch": "aarch64",
     "packageName": "juicefs-1.3.1-linux-arm64.tar.gz",
     "decompressPackageName": "juicefs-1.3.1",
     "downloadUrl": "https://github.com/juicedata/juicefs/releases/download/v1.3.1/juicefs-1.3.1-linux-arm64.tar.gz",
@@ -116,21 +132,24 @@
     "note": "单二进制包"
   },
   {
-    "service": "KAFKA", "arch": "common",
+    "service": "KAFKA",
+    "arch": "common",
     "packageName": "kafka_2.13-4.3.0.tgz",
     "decompressPackageName": "kafka_2.13-4.3.0",
     "downloadUrl": "https://downloads.apache.org/kafka/4.3.0/kafka_2.13-4.3.0.tgz",
     "status": "public"
   },
   {
-    "service": "KYUUBI", "arch": "common",
+    "service": "KYUUBI",
+    "arch": "common",
     "packageName": "apache-kyuubi-1.11.1-bin.tgz",
     "decompressPackageName": "apache-kyuubi-1.11.1-bin",
     "downloadUrl": "https://downloads.apache.org/kyuubi/kyuubi-1.11.1/apache-kyuubi-1.11.1-bin.tgz",
     "status": "public"
   },
   {
-    "service": "LOKI", "arch": "x86_64",
+    "service": "LOKI",
+    "arch": "x86_64",
     "packageName": "loki-linux-amd64.zip",
     "decompressPackageName": "loki-3.7.2",
     "downloadUrl": "https://github.com/grafana/loki/releases/download/v3.7.2/loki-linux-amd64.zip",
@@ -138,7 +157,8 @@
     "note": "单二进制 zip，无顶层目录，verify 步跳过目录校验"
   },
   {
-    "service": "LOKI", "arch": "aarch64",
+    "service": "LOKI",
+    "arch": "aarch64",
     "packageName": "loki-linux-arm64.zip",
     "decompressPackageName": "loki-3.7.2",
     "downloadUrl": "https://github.com/grafana/loki/releases/download/v3.7.2/loki-linux-arm64.zip",
@@ -146,7 +166,8 @@
     "note": "单二进制 zip，无顶层目录"
   },
   {
-    "service": "MINIO", "arch": "x86_64",
+    "service": "MINIO",
+    "arch": "x86_64",
     "packageName": "minio-9.0.1.tar.gz",
     "decompressPackageName": "minio-9.0.1",
     "downloadUrl": null,
@@ -154,7 +175,8 @@
     "note": "自定义 MinIO 封装，版本号非官方，需手动上传到 package/"
   },
   {
-    "service": "MINIO", "arch": "aarch64",
+    "service": "MINIO",
+    "arch": "aarch64",
     "packageName": "minio-9.0.1-arm.tar.gz",
     "decompressPackageName": "minio-9.0.1",
     "downloadUrl": null,
@@ -162,7 +184,8 @@
     "note": "自定义 MinIO ARM 版，需手动上传到 package/"
   },
   {
-    "service": "NACOS", "arch": "common",
+    "service": "NACOS",
+    "arch": "common",
     "packageName": "nacos-server-3.2.2.tar.gz",
     "decompressPackageName": "nacos-3.2.2",
     "downloadUrl": "https://github.com/alibaba/nacos/releases/download/3.2.2/nacos-server-3.2.2.tar.gz",
@@ -170,14 +193,16 @@
     "note": "注意：Nacos 官方包实际解压目录为 nacos/（无版本号），需 verify 步确认并修正"
   },
   {
-    "service": "NGINX", "arch": "common",
+    "service": "NGINX",
+    "arch": "common",
     "packageName": "nginx-1.30.2.tar.gz",
     "decompressPackageName": "nginx-1.30.2",
     "downloadUrl": "https://nginx.org/download/nginx-1.30.2.tar.gz",
     "status": "public"
   },
   {
-    "service": "PORTAL", "arch": "common",
+    "service": "PORTAL",
+    "arch": "common",
     "packageName": "portal-application-3.1.0-RELEASE-install.tar.gz",
     "decompressPackageName": "portal-application-3.1.0-RELEASE",
     "downloadUrl": null,
@@ -185,21 +210,24 @@
     "note": "内部门户服务，需手动上传到 package/"
   },
   {
-    "service": "PROMETHEUS", "arch": "x86_64",
+    "service": "PROMETHEUS",
+    "arch": "x86_64",
     "packageName": "prometheus-3.12.0.linux-amd64.tar.gz",
     "decompressPackageName": "prometheus-3.12.0",
     "downloadUrl": "https://github.com/prometheus/prometheus/releases/download/v3.12.0/prometheus-3.12.0.linux-amd64.tar.gz",
     "status": "public"
   },
   {
-    "service": "PROMETHEUS", "arch": "aarch64",
+    "service": "PROMETHEUS",
+    "arch": "aarch64",
     "packageName": "prometheus-3.12.0.linux-arm64.tar.gz",
     "decompressPackageName": "prometheus-3.12.0",
     "downloadUrl": "https://github.com/prometheus/prometheus/releases/download/v3.12.0/prometheus-3.12.0.linux-arm64.tar.gz",
     "status": "public"
   },
   {
-    "service": "PROMTAIL", "arch": "x86_64",
+    "service": "PROMTAIL",
+    "arch": "x86_64",
     "packageName": "promtail-linux-amd64.zip",
     "decompressPackageName": "promtail-2.8.11",
     "downloadUrl": "https://github.com/grafana/loki/releases/download/v2.8.11/promtail-linux-amd64.zip",
@@ -207,7 +235,8 @@
     "note": "单二进制 zip，无顶层目录，verify 步跳过目录校验"
   },
   {
-    "service": "PROMTAIL", "arch": "aarch64",
+    "service": "PROMTAIL",
+    "arch": "aarch64",
     "packageName": "promtail-linux-arm64.zip",
     "decompressPackageName": "promtail-2.8.11",
     "downloadUrl": "https://github.com/grafana/loki/releases/download/v2.8.11/promtail-linux-arm64.zip",
@@ -215,14 +244,17 @@
     "note": "单二进制 zip，无顶层目录"
   },
   {
-    "service": "REDIS", "arch": "x86_64",
+    "service": "REDIS",
+    "arch": "x86_64",
     "packageName": "redis-8.6.tar.gz",
     "decompressPackageName": "redis-8.6",
-    "downloadUrl": "https://download.redis.io/releases/redis-8.6.tar.gz",
-    "status": "public"
+    "downloadUrl": null,
+    "status": "private",
+    "note": "redis-8.6 不在官方 download.redis.io/releases 列表（404），疑为自定义构建，需手动上传"
   },
   {
-    "service": "REDIS", "arch": "aarch64",
+    "service": "REDIS",
+    "arch": "aarch64",
     "packageName": "redis-8.6-arm.tar.gz",
     "decompressPackageName": "redis-8.6",
     "downloadUrl": null,
@@ -230,14 +262,16 @@
     "note": "自定义 ARM 构建，需手动上传到 package/"
   },
   {
-    "service": "SPARK3", "arch": "common",
+    "service": "SPARK3",
+    "arch": "common",
     "packageName": "spark-3.5.8-bin-hadoop3.tgz",
     "decompressPackageName": "spark-3.5.8-bin-hadoop3",
     "downloadUrl": "https://downloads.apache.org/spark/spark-3.5.8/spark-3.5.8-bin-hadoop3.tgz",
     "status": "public"
   },
   {
-    "service": "USCHEDULER", "arch": "common",
+    "service": "USCHEDULER",
+    "arch": "common",
     "packageName": "uscheduler3-3.0.2-3.4.0-bin.tar.gz",
     "decompressPackageName": "uscheduler3-3.0.2-3.11.0",
     "downloadUrl": null,
@@ -245,7 +279,8 @@
     "note": "内部调度器，需手动上传到 package/"
   },
   {
-    "service": "USTREAM", "arch": "common",
+    "service": "USTREAM",
+    "arch": "common",
     "packageName": "ustream-3.4.0-bin.tar.gz",
     "decompressPackageName": "ustream-3.4.0",
     "downloadUrl": null,
@@ -253,7 +288,8 @@
     "note": "内部流处理，需手动上传到 package/"
   },
   {
-    "service": "USYNC", "arch": "common",
+    "service": "USYNC",
+    "arch": "common",
     "packageName": "usync-3.0.0-3.10.0.tar.gz",
     "decompressPackageName": "usync-3.0.0-3.10.0",
     "downloadUrl": null,
@@ -261,7 +297,8 @@
     "note": "内部数据同步，需手动上传到 package/"
   },
   {
-    "service": "YARN", "arch": "x86_64",
+    "service": "YARN",
+    "arch": "x86_64",
     "packageName": "hadoop-3.5.0.tar.gz",
     "decompressPackageName": "hadoop-3.5.0",
     "downloadUrl": "https://downloads.apache.org/hadoop/common/hadoop-3.5.0/hadoop-3.5.0.tar.gz",
@@ -269,7 +306,8 @@
     "note": "与 HDFS 共用同一包，download.sh 按 packageName 去重，不重复下载"
   },
   {
-    "service": "YARN", "arch": "aarch64",
+    "service": "YARN",
+    "arch": "aarch64",
     "packageName": "hadoop-3.5.0-aarch64.tar.gz",
     "decompressPackageName": "hadoop-3.5.0",
     "downloadUrl": "https://downloads.apache.org/hadoop/common/hadoop-3.5.0/hadoop-3.5.0-aarch64.tar.gz",
@@ -277,7 +315,8 @@
     "note": "与 HDFS 共用同一包"
   },
   {
-    "service": "ZOOKEEPER", "arch": "common",
+    "service": "ZOOKEEPER",
+    "arch": "common",
     "packageName": "apache-zookeeper-3.8.6-bin.tar.gz",
     "decompressPackageName": "apache-zookeeper-3.8.6",
     "downloadUrl": "https://downloads.apache.org/zookeeper/zookeeper-3.8.6/apache-zookeeper-3.8.6-bin.tar.gz",

--- a/package/manifest.json
+++ b/package/manifest.json
@@ -77,7 +77,7 @@
     "service": "GRAFANA",
     "arch": "x86_64",
     "packageName": "grafana-13.0.1.linux-amd64.tar.gz",
-    "decompressPackageName": "grafana-v13.0.1",
+    "decompressPackageName": "grafana-13.0.1",
     "downloadUrl": "https://dl.grafana.com/oss/release/grafana-13.0.1.linux-amd64.tar.gz",
     "status": "public"
   },
@@ -85,7 +85,7 @@
     "service": "GRAFANA",
     "arch": "aarch64",
     "packageName": "grafana-13.0.1.linux-arm64.tar.gz",
-    "decompressPackageName": "grafana-v13.0.1",
+    "decompressPackageName": "grafana-13.0.1",
     "downloadUrl": "https://dl.grafana.com/oss/release/grafana-13.0.1.linux-arm64.tar.gz",
     "status": "public"
   },
@@ -187,7 +187,7 @@
     "service": "NACOS",
     "arch": "common",
     "packageName": "nacos-server-3.2.2.tar.gz",
-    "decompressPackageName": "nacos-3.2.2",
+    "decompressPackageName": "nacos",
     "downloadUrl": "https://github.com/alibaba/nacos/releases/download/3.2.2/nacos-server-3.2.2.tar.gz",
     "status": "public",
     "note": "注意：Nacos 官方包实际解压目录为 nacos/（无版本号），需 verify 步确认并修正"
@@ -318,7 +318,7 @@
     "service": "ZOOKEEPER",
     "arch": "common",
     "packageName": "apache-zookeeper-3.8.6-bin.tar.gz",
-    "decompressPackageName": "apache-zookeeper-3.8.6",
+    "decompressPackageName": "apache-zookeeper-3.8.6-bin",
     "downloadUrl": "https://downloads.apache.org/zookeeper/zookeeper-3.8.6/apache-zookeeper-3.8.6-bin.tar.gz",
     "status": "public",
     "note": "注意：包名含 -bin 后缀，实际解压顶层目录为 apache-zookeeper-3.8.6-bin，需 verify 步确认"

--- a/package/manifest.json
+++ b/package/manifest.json
@@ -273,7 +273,7 @@
   {
     "service": "USCHEDULER",
     "arch": "common",
-    "packageName": "uscheduler3-3.0.2-3.4.0-bin.tar.gz",
+    "packageName": "uscheduler3-3.0.2-3.11.0-bin.tar.gz",
     "decompressPackageName": "uscheduler3-3.0.2-3.11.0",
     "downloadUrl": null,
     "status": "private",

--- a/package/verify_decompress.py
+++ b/package/verify_decompress.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+验证各部署包的实际解压顶层目录是否与 service_ddl.json 中 decompressPackageName 一致。
+不一致时自动写回修正。
+
+用法：python3 package/verify_decompress.py
+"""
+import json
+import os
+import tarfile
+import zipfile
+from collections import Counter
+from pathlib import Path
+
+BASE = Path(__file__).parent.parent
+PKG_DIR = Path(__file__).parent
+META_BASE = BASE / "datasophon-api/src/main/resources/meta/datacluster"
+MANIFEST_PATH = PKG_DIR / "manifest.json"
+
+
+def get_top_level_dir(pkg_path, pkg_name):
+    """
+    返回压缩包内唯一的顶层目录名。
+    若包内无子目录（单二进制包）返回 None。
+    出错时返回以 "ERROR:" 开头的字符串。
+    """
+    try:
+        if pkg_name.endswith(".tar.gz") or pkg_name.endswith(".tgz"):
+            with tarfile.open(pkg_path, "r:*") as tf:
+                members = tf.getmembers()
+                # 含斜杠的条目才表示有顶层目录
+                sub_paths = [m.name for m in members if "/" in m.name and not m.name.startswith(".")]
+                if not sub_paths:
+                    return None
+                tops = Counter(p.split("/")[0] for p in sub_paths)
+                return tops.most_common(1)[0][0]
+
+        elif pkg_name.endswith(".zip"):
+            with zipfile.ZipFile(pkg_path, "r") as zf:
+                names = zf.namelist()
+                sub_paths = [n for n in names if "/" in n and not n.startswith(".")]
+                if not sub_paths:
+                    return None
+                tops = Counter(n.split("/")[0] for n in sub_paths)
+                return tops.most_common(1)[0][0]
+
+        else:
+            return f"ERROR:不支持的格式 {pkg_name}"
+
+    except Exception as e:
+        return f"ERROR:{e}"
+
+
+def find_ddl_paths_for_package(pkg_name):
+    """找到所有 arch 中使用该 packageName 的 service_ddl.json 路径列表。"""
+    results = []
+    for service_dir in sorted(META_BASE.iterdir()):
+        ddl = service_dir / "service_ddl.json"
+        if not ddl.exists():
+            continue
+        with open(ddl) as f:
+            data = json.load(f)
+        arch = data.get("arch", {})
+        for arch_val in arch.values():
+            if arch_val.get("packageName") == pkg_name:
+                results.append(ddl)
+                break
+    return results
+
+
+def update_decompress_name(ddl_path, new_name):
+    with open(ddl_path) as f:
+        data = json.load(f)
+    old = data.get("decompressPackageName")
+    data["decompressPackageName"] = new_name
+    with open(ddl_path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+    print(f"  [FIXED] {ddl_path.parent.name}/service_ddl.json: {old!r} → {new_name!r}")
+
+
+def main():
+    with open(MANIFEST_PATH) as f:
+        manifest = json.load(f)
+
+    # packageName → decompressPackageName（取第一次出现）
+    seen = {}
+    for entry in manifest:
+        name = entry["packageName"]
+        if name not in seen:
+            seen[name] = entry["decompressPackageName"]
+
+    ok = []
+    mismatches = []
+    missing = []
+    binary_only = []
+    errors = []
+
+    for pkg_name, expected in seen.items():
+        pkg_path = PKG_DIR / pkg_name
+        if not pkg_path.exists():
+            missing.append(pkg_name)
+            continue
+
+        actual = get_top_level_dir(pkg_path, pkg_name)
+
+        if actual is None:
+            binary_only.append(pkg_name)
+            print(f"[BINARY-ONLY] {pkg_name} → 无顶层目录，跳过校验")
+            continue
+
+        if isinstance(actual, str) and actual.startswith("ERROR:"):
+            errors.append(f"{pkg_name}: {actual}")
+            print(f"[ERROR] {pkg_name}: {actual}")
+            continue
+
+        if actual == expected:
+            ok.append(pkg_name)
+            print(f"[OK]    {pkg_name}")
+            print(f"        顶层目录: {actual!r}")
+        else:
+            mismatches.append((pkg_name, expected, actual))
+            print(f"[MISMATCH] {pkg_name}")
+            print(f"           manifest.decompressPackageName = {expected!r}")
+            print(f"           实际顶层目录                   = {actual!r}")
+            for ddl_path in find_ddl_paths_for_package(pkg_name):
+                update_decompress_name(ddl_path, actual)
+
+    print("\n" + "=" * 50)
+    print("校验汇总")
+    print("=" * 50)
+    print(f"  OK:          {len(ok)}")
+    print(f"  MISMATCH:    {len(mismatches)} (已自动修正 service_ddl.json)")
+    print(f"  BINARY-ONLY: {len(binary_only)} (跳过，单二进制包)")
+    print(f"  MISSING:     {len(missing)} (未下载/私有包)")
+    print(f"  ERROR:       {len(errors)}")
+
+    if mismatches:
+        print("\n修正清单：")
+        for pkg, old, new in mismatches:
+            print(f"  {pkg}")
+            print(f"    {old!r} → {new!r}")
+        print("\n请执行：git diff datasophon-api/src/main/resources/meta/datacluster/")
+
+    if missing:
+        print("\n未下载（私有包需手动上传）：")
+        for m in missing:
+            print(f"  {m}")
+
+
+if __name__ == "__main__":
+    main()

--- a/package/verify_decompress.py
+++ b/package/verify_decompress.py
@@ -83,20 +83,29 @@ def main():
     with open(MANIFEST_PATH) as f:
         manifest = json.load(f)
 
-    # packageName → decompressPackageName（取第一次出现）
+    # 多架构服务（同服务有多个不同 packageName）: 若各架构包解压目录含架构后缀，
+    # decompressPackageName 是归一化名称，不应按单包实际目录覆盖。
+    service_packages = {}
+    for entry in manifest:
+        service_packages.setdefault(entry["service"], set()).add(entry["packageName"])
+
+    # packageName → (decompressPackageName, is_multi_arch)
     seen = {}
     for entry in manifest:
         name = entry["packageName"]
+        svc = entry["service"]
+        is_multi_arch = len(service_packages[svc]) > 1
         if name not in seen:
-            seen[name] = entry["decompressPackageName"]
+            seen[name] = (entry["decompressPackageName"], is_multi_arch)
 
     ok = []
     mismatches = []
     missing = []
     binary_only = []
     errors = []
+    skipped_multi_arch = []
 
-    for pkg_name, expected in seen.items():
+    for pkg_name, (expected, is_multi_arch) in seen.items():
         pkg_path = PKG_DIR / pkg_name
         if not pkg_path.exists():
             missing.append(pkg_name)
@@ -118,6 +127,12 @@ def main():
             ok.append(pkg_name)
             print(f"[OK]    {pkg_name}")
             print(f"        顶层目录: {actual!r}")
+        elif is_multi_arch and actual != expected:
+            # 多架构服务：实际目录含架构后缀，decompressPackageName 是归一化名称，不修正
+            skipped_multi_arch.append((pkg_name, expected, actual))
+            print(f"[MULTI-ARCH] {pkg_name}")
+            print(f"             decompressPackageName={expected!r}（归一化名称，保留）")
+            print(f"             实际顶层目录         ={actual!r}（含架构后缀，符合预期）")
         else:
             mismatches.append((pkg_name, expected, actual))
             print(f"[MISMATCH] {pkg_name}")
@@ -129,11 +144,12 @@ def main():
     print("\n" + "=" * 50)
     print("校验汇总")
     print("=" * 50)
-    print(f"  OK:          {len(ok)}")
-    print(f"  MISMATCH:    {len(mismatches)} (已自动修正 service_ddl.json)")
-    print(f"  BINARY-ONLY: {len(binary_only)} (跳过，单二进制包)")
-    print(f"  MISSING:     {len(missing)} (未下载/私有包)")
-    print(f"  ERROR:       {len(errors)}")
+    print(f"  OK:           {len(ok)}")
+    print(f"  MISMATCH:     {len(mismatches)} (已自动修正 service_ddl.json)")
+    print(f"  MULTI-ARCH:   {len(skipped_multi_arch)} (归一化名称，保留不修改)")
+    print(f"  BINARY-ONLY:  {len(binary_only)} (跳过，单二进制包)")
+    print(f"  MISSING:      {len(missing)} (未下载/私有包)")
+    print(f"  ERROR:        {len(errors)}")
 
     if mismatches:
         print("\n修正清单：")
@@ -141,6 +157,11 @@ def main():
             print(f"  {pkg}")
             print(f"    {old!r} → {new!r}")
         print("\n请执行：git diff datasophon-api/src/main/resources/meta/datacluster/")
+
+    if skipped_multi_arch:
+        print("\n多架构包（归一化名称保留）：")
+        for pkg, norm, actual in skipped_multi_arch:
+            print(f"  {pkg}: decompressPackageName={norm!r} / 实际目录={actual!r}")
 
     if missing:
         print("\n未下载（私有包需手动上传）：")

--- a/package/verify_decompress.py
+++ b/package/verify_decompress.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 验证各部署包的实际解压顶层目录是否与 service_ddl.json 中 decompressPackageName 一致。
-不一致时自动写回修正。
+不一致时自动写回修正（service_ddl.json 和 manifest.json 同步更新）。
 
 用法：python3 package/verify_decompress.py
 """
@@ -23,25 +23,32 @@ def get_top_level_dir(pkg_path, pkg_name):
     返回压缩包内唯一的顶层目录名。
     若包内无子目录（单二进制包）返回 None。
     出错时返回以 "ERROR:" 开头的字符串。
+    流式读取前 20 个含子路径条目即可判断，避免对大包完整解压。
     """
     try:
         if pkg_name.endswith(".tar.gz") or pkg_name.endswith(".tgz"):
             with tarfile.open(pkg_path, "r:*") as tf:
-                members = tf.getmembers()
-                # 含斜杠的条目才表示有顶层目录
-                sub_paths = [m.name for m in members if "/" in m.name and not m.name.startswith(".")]
-                if not sub_paths:
+                tops = Counter()
+                for member in tf:
+                    name = member.name
+                    if "/" in name and not name.startswith("."):
+                        tops[name.split("/")[0]] += 1
+                        if sum(tops.values()) >= 20:
+                            break
+                if not tops:
                     return None
-                tops = Counter(p.split("/")[0] for p in sub_paths)
                 return tops.most_common(1)[0][0]
 
         elif pkg_name.endswith(".zip"):
             with zipfile.ZipFile(pkg_path, "r") as zf:
-                names = zf.namelist()
-                sub_paths = [n for n in names if "/" in n and not n.startswith(".")]
-                if not sub_paths:
+                tops = Counter()
+                for name in zf.namelist():
+                    if "/" in name and not name.startswith("."):
+                        tops[name.split("/")[0]] += 1
+                        if sum(tops.values()) >= 20:
+                            break
+                if not tops:
                     return None
-                tops = Counter(n.split("/")[0] for n in sub_paths)
                 return tops.most_common(1)[0][0]
 
         else:
@@ -51,52 +58,96 @@ def get_top_level_dir(pkg_path, pkg_name):
         return f"ERROR:{e}"
 
 
-def find_ddl_paths_for_package(pkg_name):
-    """找到所有 arch 中使用该 packageName 的 service_ddl.json 路径列表。"""
-    results = []
+def build_ddl_index():
+    """预扫描所有 service_ddl.json，构建 packageName → [ddl_path] 索引，避免每次重扫。"""
+    index = {}
     for service_dir in sorted(META_BASE.iterdir()):
         ddl = service_dir / "service_ddl.json"
         if not ddl.exists():
             continue
         with open(ddl) as f:
             data = json.load(f)
-        arch = data.get("arch", {})
-        for arch_val in arch.values():
-            if arch_val.get("packageName") == pkg_name:
-                results.append(ddl)
+        for arch_val in data.get("arch", {}).values():
+            pkg = arch_val.get("packageName")
+            if pkg:
+                index.setdefault(pkg, []).append(ddl)
                 break
-    return results
+    return index
 
 
 def update_decompress_name(ddl_path, new_name):
+    """原子写入（写临时文件后 os.replace），避免写失败时 DDL 损坏。"""
     with open(ddl_path) as f:
         data = json.load(f)
     old = data.get("decompressPackageName")
     data["decompressPackageName"] = new_name
-    with open(ddl_path, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2)
-        f.write("\n")
+    tmp = ddl_path.parent / (ddl_path.name + ".tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        os.replace(tmp, ddl_path)
+    except Exception:
+        if tmp.exists():
+            tmp.unlink()
+        raise
     print(f"  [FIXED] {ddl_path.parent.name}/service_ddl.json: {old!r} → {new_name!r}")
+
+
+def update_manifest_decompress_name(manifest_data, pkg_name, new_name):
+    """将 manifest.json 中所有 pkg_name 条目的 decompressPackageName 更新为 new_name。"""
+    changed = False
+    for entry in manifest_data:
+        if entry["packageName"] == pkg_name and entry.get("decompressPackageName") != new_name:
+            entry["decompressPackageName"] = new_name
+            changed = True
+    return changed
+
+
+def save_manifest(manifest_data):
+    """原子写入 manifest.json。"""
+    tmp = MANIFEST_PATH.parent / (MANIFEST_PATH.name + ".tmp")
+    try:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(manifest_data, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        os.replace(tmp, MANIFEST_PATH)
+    except Exception:
+        if tmp.exists():
+            tmp.unlink()
+        raise
 
 
 def main():
     with open(MANIFEST_PATH) as f:
         manifest = json.load(f)
 
-    # 多架构服务（同服务有多个不同 packageName）: 若各架构包解压目录含架构后缀，
-    # decompressPackageName 是归一化名称，不应按单包实际目录覆盖。
+    manifest_dirty = False
+
+    # 构建 service → packageName 集合（用于多架构判断）
     service_packages = {}
     for entry in manifest:
         service_packages.setdefault(entry["service"], set()).add(entry["packageName"])
 
     # packageName → (decompressPackageName, is_multi_arch)
+    # 同时记录 packageName → {service: decompressPackageName}，用于跨服务一致性检查
     seen = {}
+    pkg_service_decompress = {}
     for entry in manifest:
         name = entry["packageName"]
         svc = entry["service"]
+        decomp = entry["decompressPackageName"]
         is_multi_arch = len(service_packages[svc]) > 1
+        pkg_service_decompress.setdefault(name, {})[svc] = decomp
         if name not in seen:
-            seen[name] = (entry["decompressPackageName"], is_multi_arch)
+            seen[name] = (decomp, is_multi_arch)
+
+    # 同一包被多个服务共用但 decompressPackageName 不一致时报警
+    for pkg_name, svc_map in pkg_service_decompress.items():
+        if len(set(svc_map.values())) > 1:
+            print(f"[WARN] {pkg_name} 被多个服务共用但 decompressPackageName 不一致：{svc_map}")
+
+    ddl_index = build_ddl_index()
 
     ok = []
     mismatches = []
@@ -127,8 +178,8 @@ def main():
             ok.append(pkg_name)
             print(f"[OK]    {pkg_name}")
             print(f"        顶层目录: {actual!r}")
-        elif is_multi_arch and actual != expected:
-            # 多架构服务：实际目录含架构后缀，decompressPackageName 是归一化名称，不修正
+        elif is_multi_arch and actual.startswith(expected):
+            # 多架构服务：实际目录 = 归一化名称 + 架构后缀，属预期，不修正
             skipped_multi_arch.append((pkg_name, expected, actual))
             print(f"[MULTI-ARCH] {pkg_name}")
             print(f"             decompressPackageName={expected!r}（归一化名称，保留）")
@@ -138,14 +189,20 @@ def main():
             print(f"[MISMATCH] {pkg_name}")
             print(f"           manifest.decompressPackageName = {expected!r}")
             print(f"           实际顶层目录                   = {actual!r}")
-            for ddl_path in find_ddl_paths_for_package(pkg_name):
+            for ddl_path in ddl_index.get(pkg_name, []):
                 update_decompress_name(ddl_path, actual)
+            if update_manifest_decompress_name(manifest, pkg_name, actual):
+                manifest_dirty = True
+
+    if manifest_dirty:
+        save_manifest(manifest)
+        print("\n  [FIXED] manifest.json: decompressPackageName 已同步更新")
 
     print("\n" + "=" * 50)
     print("校验汇总")
     print("=" * 50)
     print(f"  OK:           {len(ok)}")
-    print(f"  MISMATCH:     {len(mismatches)} (已自动修正 service_ddl.json)")
+    print(f"  MISMATCH:     {len(mismatches)} (已自动修正 service_ddl.json + manifest.json)")
     print(f"  MULTI-ARCH:   {len(skipped_multi_arch)} (归一化名称，保留不修改)")
     print(f"  BINARY-ONLY:  {len(binary_only)} (跳过，单二进制包)")
     print(f"  MISSING:      {len(missing)} (未下载/私有包)")


### PR DESCRIPTION
## Summary

- 新增 `package/manifest.json`：覆盖 27 个服务 / 38 条记录，包含下载 URL、架构分类、私有包标注
- 新增 `package/download.sh`：批量下载脚本，支持 Content-Length 校验跳过完整文件、私有包跳过提示
- 新增 `package/verify_decompress.py`：自动解压校验，比对 `decompressPackageName` 与包内实际顶层目录，不一致时自动写回 `service_ddl.json`；多架构包（ALERTMANAGER / DORIS / PROMETHEUS）保留归一化名称不改写
- 新增 `package/.gitignore`：屏蔽 `*.tar.gz` / `*.zip`（根 `.gitignore` 已有 `*.tgz`），防止大型二进制包入库
- 修正 3 处 `decompressPackageName` 错误：
  - **GRAFANA**：`grafana-v13.0.1` → `grafana-13.0.1`（包内顶层目录无 `v` 前缀）
  - **NACOS**：`nacos-3.2.2` → `nacos`（官方包始终解压到 `nacos/`，无版本号）
  - **ZOOKEEPER**：`apache-zookeeper-3.8.6` → `apache-zookeeper-3.8.6-bin`（含 `-bin` 后缀）

## 校验结果

| 分类 | 数量 |
|---|---|
| OK（目录一致） | 12 |
| MULTI-ARCH（归一化名称，保留） | 6 |
| BINARY-ONLY（单二进制包，跳过） | 7 |
| MISMATCH（已修正） | **0** |
| MISSING（私有包/flink 代理截断） | 11 |
| ERROR | 0 |

## 已知遗留

- **flink-2.2.1**：`downloads.apache.org` 在代理环境下每次在 0.4% 处断连（curl 18），`downloadUrl` 正确保留，无代理环境执行 `download.sh` 可自动完成下载
- **私有包**（minio / redis / uscheduler / ustream / usync / executor / datart / portal）：内部构建，需从 Nexus 手动上传到 `package/`

## Test plan

- [ ] 在无代理环境执行 `bash package/download.sh`，确认公有包全部下载完整
- [ ] 执行 `python3 package/verify_decompress.py`，确认 MISMATCH 为 0
- [ ] 确认 GRAFANA / NACOS / ZOOKEEPER 部署路径在集群环境中解压正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)