### PR TITLE
feat(cli): create node 支持配置模式(-c)与条件化 DAG

### DIFF
--- a/datasophon-cli-go/CLAUDE.md
+++ b/datasophon-cli-go/CLAUDE.md
@@ -48,7 +48,7 @@ go test -cover ./...   # 测试 + 覆盖率
 
 ### 33 个 Step 声明式定义（initALL）
 
-`internal/plan/registry.go` 中 `InitALLRegistry` 数组是核心：每个 `Step` 含 `ID / Name / Scope / Condition / Build`，按数组顺序即 DAG 顺序执行。
+`internal/plan/registry.go` 中 `InitALLRegistry` 数组是 `create cluster` 的核心；`internal/plan/registry_node.go` 中 `InitNodeRegistry` 是 `create node` 配置模式的 12 步 DAG。两者共享相同的 `Step` 结构（含 `ID / Name / Scope / Condition / Build`），按数组顺序即 DAG 顺序执行。
 
 - `Scope`：`ScopeBoth`（默认）/ `ScopeHadoopOnly` / `ScopeKubernetesOnly`，由 `ClusterType`（`hadoop` | `kubernetes`）匹配。
 - `Condition`：必须从 `ctx.Cfg.*` 读布尔字段（如 `ctx.Cfg.Registry.Enable`、`ctx.Cfg.Kubernetes.Enable`），**禁止**走 CLI flag —— flag 只覆盖 type/auth 等全局项。
@@ -101,12 +101,12 @@ datasophon-cli [--dry-run]
 ├── create                                  # 集群创建/扩容/远程安装
 │   ├── cluster   [plan|apply] [-y] [-t hadoop|kubernetes]
 │   ├── config                              # 交互式生成 cluster-sample.yml
-│   ├── node                                # 节点管理
+│   ├── node   [-c file] [-t hadoop|kubernetes]  # 节点管理（配置模式或手动模式）
 │   ├── mysql / nmap-server / ntp-server    # 单节点远程安装命令
 │   ├── registry / rustfs / yum-server
 │   └── ...
 ├── init                                    # 27 条独立单步初始化（system/network/packages/repo/db/k8s）
-│   ├── firewall / selinux / swap / osUser / bash
+│   ├── firewall / selinux / swap / hadoop_user / bash
 │   ├── library / osSafeConf / system-conf / hugePage
 │   ├── hostname / allHost / ntpslave / ssh
 │   ├── bin_packages / tar / jdk8 / jdk17
@@ -133,9 +133,9 @@ go test -cover ./...           # 带覆盖率
 
 测试分层：
 
-- `internal/plan/` 内联单测：`builders_common_test.go` / `helpers_test.go` / `plan_test.go`，覆盖 plan 生成、scope 匹配、condition 分支。
+- `internal/plan/` 内联单测：`builders_common_test.go` / `helpers_test.go` / `plan_test.go` / `registry_node_test.go`，覆盖 plan 生成、scope 匹配、condition 分支、initNode 配置模式 DAG。
 - `internal/executor/`：`batch_test.go` / `result_test.go`，覆盖批执行与结果聚合。
-- `internal/cli/init/containerd_test.go` / `internal/cli/create/append_yaml_test.go`：handler 与 YAML 解析单测。
+- `internal/cli/init/containerd_test.go` / `internal/cli/create/append_yaml_test.go` / `internal/cli/create/node_setup_test.go`：handler 与 YAML 解析单测、setupConfig 重复检测单测。
 - `internal/osinfo/`：`arch_test.go` / `os_test.go`，覆盖架构与 OS 探测（用于跨平台分发逻辑）。
 - `test/`：跨包集成测试。`test/fixtures/cluster-sample.yml` 是集成测试用的样例配置；`test/config/loader_test.go` 验证 loader；`test/executor/local_test.go` 验证本地执行器。
 

--- a/datasophon-cli-go/docs/README.md
+++ b/datasophon-cli-go/docs/README.md
@@ -32,7 +32,7 @@ datasophon-cli [--dry-run]
 │   ├── nmap-server                 # 在指定节点安装 nmap
 │   └── yum-server                  # 配置 httpd/apache2 离线包源
 ├── init                            # 单步节点初始化（27 条子命令）
-│   ├── system/   firewall  selinux  swap  library  osSafeConf  system-conf  osUser  bash  hugePage
+│   ├── system/   firewall  selinux  swap  library  osSafeConf  system-conf  hadoop_user  bash  hugePage
 │   ├── network/  hostname  allHost  ntpslave  ssh
 │   ├── packages/ bin_packages  tar  jdk8  jdk17
 │   ├── repo/     offlineSlave  registryDecode

--- a/datasophon-cli-go/docs/commands/create/node.md
+++ b/datasophon-cli-go/docs/commands/create/node.md
@@ -2,16 +2,33 @@
 
 ## 用途
 
-为单个新增节点执行 10 步基础初始化。该命令**只支持独立模式**：通过 `--ip` 等 5 个 flag 直接指定目标节点，不依赖 `cluster-sample.yml` 的 `nodes` 列表。
+为单个新增节点执行基础初始化。支持两种模式：
 
-> 自重构后 `addNodes` 批量模式已移除：增加多个节点时请对每个节点分别执行 `create node`。安装完成后，新节点会自动**追加**到 `cluster-sample.yml` 的 `nodes` 列表（同 IP 或 hostname 已存在时跳过追加）。
+| 模式 | 触发方式 | 特点 |
+|---|---|---|
+| **配置模式** | 指定 `-c/--config <file>` | 从配置文件读取集群上下文，走 plan 引擎执行 12 步条件化 DAG，支持断点续跑 |
+| **手动模式** | 不传 `-c`（默认） | 直接用 CLI 参数初始化，不依赖配置文件，不生成 plan 文件 |
+
+> 增加多个节点时请对每个节点分别执行 `create node`。安装完成后，新节点会自动**追加**到配置文件的 `nodes` 列表（同 IP 或 hostname 已存在时跳过追加）。
 
 ## 用法 (Synopsis)
+
+**配置模式**（推荐，支持 ntp_slave/offline_slave 等条件化步骤）：
+
+```bash
+datasophon-cli [--dry-run] create node \
+  -c <cluster.yml> \
+  -p <datasophonPath> --installPath <path> -n <packagesPath> \
+  --ip <IP> --user <user> --password <pass> --port <port> --hostname <hn>
+```
+
+**手动模式**（快速初始化，无需配置文件）：
 
 ```bash
 datasophon-cli [--dry-run] create node \
   -p <datasophonPath> --installPath <path> -n <packagesPath> \
-  --ip <IP> --user <user> --password <pass> --port <port> --hostname <hn>
+  --ip <IP> --user <user> --password <pass> --port <port> --hostname <hn> \
+  [-t hadoop|kubernetes]
 ```
 
 ## 参数 / Flags
@@ -27,45 +44,111 @@ datasophon-cli [--dry-run] create node \
 | `--password` | 无 | string | — | 是 | SSH 密码 |
 | `--port` | 无 | int | — | 是 | SSH 端口 |
 | `--hostname` | 无 | string | — | 是 | 目标节点 hostname |
+| `--config` | `-c` | string | — | 否 | **配置模式**：配置文件路径，提供集群上下文与 ntp/offline 服务端 IP |
+| `--cluster-type` | `-t` | string | — | 否 | **手动模式**：集群类型 `hadoop\|kubernetes`，仅 `hadoop` 时创建 hadoop 用户 |
 
-> 5 个独立模式参数（`--ip / --user / --password / --port / --hostname`）必须**同时**全部提供，缺一即报错。
+> 5 个节点定位参数（`--ip / --user / --password / --port / --hostname`）在两种模式下均必填。
 > 继承全局 flag：`--dry-run` —— 详见 [global-flags.md](../../global-flags.md)
 
-## 执行流程
+---
 
-1. 校验 5 个独立参数均已提供
-2. 校验 `--datasophonPath` 与 `--installPath` 均为绝对路径且 `datasophonPath` 已存在
-3. SSH 到目标节点，按下列顺序顺序执行 10 步基础初始化：
+## 配置模式执行流程
 
-| 序号 | 步骤名 | 对应 init 子命令 |
+1. 校验 `--datasophonPath` 与 `--installPath` 均为绝对路径且 `datasophonPath` 已存在
+2. 加载 `-c` 指定的配置文件
+3. **重复检测**：若 `--ip` 指定的 IP 已存在于配置文件 `nodes` 列表中 → **提示并停止**（非零退出）
+4. 调用 plan 引擎生成 `state/initNode.plan.json`，打印摘要
+5. 按下列 12 步条件化 DAG 顺序执行：
+
+| 序号 | 步骤 ID | 步骤名 | Scope / Condition |
+|---|---|---|---|
+| 1 | `node-bash` | shell bash 设置 | 始终执行 |
+| 2 | `node-hadoopuser` | 创建 hadoop 用户和组 | `cluster-type=hadoop` 时执行 |
+| 3 | `node-firewall` | 关闭防火墙 | 始终执行 |
+| 4 | `node-selinux` | 关闭 selinux | 始终执行 |
+| 5 | `node-swap` | 关闭 swap | 始终执行 |
+| 6 | `node-offline-slave` | yum/apt 离线源节点配置 | `global.offline=true` 时执行 |
+| 7 | `node-ntp-slave` | 配置 NTP Slave | `ntpServer.enable=true` 时执行 |
+| 8 | `node-library` | 初始化依赖库 | 始终执行 |
+| 9 | `node-os-safe-conf` | 安全配置 | 始终执行 |
+| 10 | `node-system-conf` | 优化系统配置 | 始终执行 |
+| 11 | `node-hostname` | 配置 hostname | 始终执行 |
+| 12 | `node-hugepage` | 关闭透明大页 | 始终执行 |
+
+6. 成功后将新节点追加到配置文件 `nodes` 列表
+
+> **依赖说明**：`offline_slave`（步骤 6）需要配置文件中有有效的 `registry.node`（registry 启用时）
+> 或 `yumServer.node`（yumServer 启用时）。若 `global.offline=true` 但两者均未配置，步骤会构造空 ServerIP 并报错。
+>
+> `ntp_slave`（步骤 7）需要 `ntpServer.node` 指向一个存在于 `nodes` 列表中的节点。若目标新节点的 IP
+> 恰好与 NTP server 相同（即新节点就是 NTP server 本身），则 ntp_slave 无目标执行（被 `slavesOf` 过滤）。
+
+### 断点续跑
+
+配置模式走 plan 引擎，生成 `<datasophonPath>/datasophon-init/state/initNode.plan.json`。
+中途失败后直接重跑相同命令，plan 引擎会自动跳过已完成的步骤。
+
+---
+
+## 手动模式执行流程
+
+1. 校验 5 个定位参数均已提供
+2. 校验 `--datasophonPath` 与 `--installPath` 均为绝对路径
+3. 若传入 `-t/--cluster-type` 则校验合法性（`hadoop` 或 `kubernetes`）
+4. SSH 到目标节点，按下列顺序顺序执行（9 步基础 + 可选 hadoop_user）：
+
+| 序号 | 步骤名 | 说明 |
 |---|---|---|
-| 1 | shell bash 设置 | `init bash` |
-| 2 | 创建 hadoop 用户和组 | `init osUser` |
-| 3 | 关闭防火墙 | `init firewall` |
-| 4 | 关闭 SELinux | `init selinux` |
-| 5 | 关闭 Swap | `init swap` |
-| 6 | 初始化依赖库 | `init library` |
-| 7 | 安全配置 | `init osSafeConf` |
-| 8 | 优化系统配置 | `init system-conf` |
-| 9 | 配置 hostname | `init hostname` |
-| 10 | 关闭透明大页 | `init hugePage` |
+| 1 | shell bash 设置 | 始终执行 |
+| 2 | 创建 hadoop 用户和组 | 仅 `-t hadoop` 时执行 |
+| 3 | 关闭防火墙 | 始终执行 |
+| 4 | 关闭 SELinux | 始终执行 |
+| 5 | 关闭 Swap | 始终执行 |
+| 6 | 初始化依赖库 | 始终执行 |
+| 7 | 安全配置 | 始终执行 |
+| 8 | 优化系统配置 | 始终执行 |
+| 9 | 配置 hostname | 始终执行 |
+| 10 | 关闭透明大页 | 始终执行 |
 
-4. 如果 `<datasophonPath>/datasophon-init/config/cluster-sample.yml` 存在，将新节点追加到 `nodes` 列表
+5. 如果 `<datasophonPath>/datasophon-init/config/cluster-sample.yml` 存在，将新节点追加到 `nodes` 列表
 
-> 独立模式**不走 plan 引擎**（不生成 `state/initSingleNode.plan.json`），不支持断点续跑。所有 10 步均为幂等操作，中途失败可直接重跑。
+> 手动模式**不走 plan 引擎**（不生成 plan.json），不支持断点续跑。所有步骤均为幂等操作，中途失败可直接重跑。
+> 手动模式不支持 `ntp_slave`/`offline_slave`，这两步需要配置文件提供服务端 IP，请使用配置模式。
 
-## 写回 cluster-sample.yml 的语义
+---
+
+## 写回配置文件的语义
 
 - 写回字段：`ip / port / user / password / hostname`
+- **配置模式**：写回目标为 `-c` 指定的配置文件（已通过重复检测，追加必成功）
+- **手动模式**：写回目标为 `<datasophonPath>/datasophon-init/config/cluster-sample.yml`（不存在时跳过）
 - 重复检测：若 `nodes` 列表中已有相同 IP 或 hostname 的节点，**跳过写回**并仅打印 Warn 日志
-- 如配置文件不存在（路径下没有 `cluster-sample.yml`），跳过写回并仅打印 Info 日志
+
+---
 
 ## 示例
 
-### dry-run 预检
+### 配置模式 dry-run（hadoop 集群，开启 ntp 和 offline）
 
 ```bash
 datasophon-cli --dry-run create node \
+  -c /data/datasophon/datasophon-init/config/cluster-sample.yml \
+  -p /data/datasophon \
+  --installPath /opt/install \
+  -n /data/datasophon/datasophon-init/packages \
+  --ip 192.168.1.20 \
+  --user root \
+  --password 'YourPassword' \
+  --port 22 \
+  --hostname app7
+# 期望输出：plan 摘要，显示 node-hadoopuser/node-ntp-slave/node-offline-slave 的执行情况
+```
+
+### 配置模式实际执行
+
+```bash
+datasophon-cli create node \
+  -c /data/datasophon/datasophon-init/config/cluster-sample.yml \
   -p /data/datasophon \
   --installPath /opt/install \
   -n /data/datasophon/datasophon-init/packages \
@@ -76,7 +159,22 @@ datasophon-cli --dry-run create node \
   --hostname app7
 ```
 
-### 实际执行
+### 手动模式（hadoop 集群，需要创建 hadoop 用户）
+
+```bash
+datasophon-cli create node \
+  -p /data/datasophon \
+  --installPath /opt/install \
+  -n /data/datasophon/datasophon-init/packages \
+  --ip 192.168.1.20 \
+  --user root \
+  --password 'YourPassword' \
+  --port 22 \
+  --hostname app7 \
+  -t hadoop
+```
+
+### 手动模式（kubernetes 集群，不建 hadoop 用户）
 
 ```bash
 datasophon-cli create node \
@@ -90,19 +188,21 @@ datasophon-cli create node \
   --hostname app7
 ```
 
-执行结束后，`cluster-sample.yml` 的 `nodes:` 列表会自动新增 `app7` 一项。
+---
 
 ## 退出码 / 常见错误
 
 | 错误信息 | 根因 | 处置 |
 |---|---|---|
-| `--ip 模式下必须同时提供 --user --password --hostname --port` | 5 个独立模式参数缺一 | 补齐所有 5 个 flag |
+| `节点 <ip> 已存在于配置文件 nodes 列表中，已停止` | 配置模式：目标 IP 已在 nodes 列表 | 检查 `--ip` 是否是真正的新节点 |
+| `--ip 模式下必须同时提供 --user --password --hostname --port` | 手动模式：5 个定位参数缺一 | 补齐所有 5 个 flag |
 | `datasophonPath、installPath 必须是绝对路径` | 传入了相对路径 | 改用 `/` 开头的绝对路径 |
 | `路径不存在: <path>` | `--datasophonPath` 指定的目录不存在 | 确认 `datasophonPath` 已创建 |
-| `cluster-sample.yml 不存在，跳过写回` | 配置文件不存在 | 非错误（仅 Info 日志），节点初始化已完成 |
+| `--type 必须是 hadoop 或 kubernetes` | 手动模式 `-t` 值非法 | 只传 `hadoop` 或 `kubernetes` |
+| `cluster-sample.yml 不存在，跳过写回` | 手动模式配置文件不存在 | 非错误（仅 Info 日志），节点初始化已完成 |
 | `同 IP 或 hostname 节点已存在，跳过写回` | 节点已存在于 `nodes` 列表 | 非错误（仅 Warn 日志），节点初始化已完成 |
 
 ## 相关命令
 
 - [`create cluster`](./cluster.md) — 全量初始化
-- [DAG 步骤表 → standalone](../../reference/init-all-dag.md) — 10 步详解
+- [DAG 步骤表](../../reference/init-all-dag.md) — initNode 12 步详解

--- a/datasophon-cli-go/docs/commands/init/README.md
+++ b/datasophon-cli-go/docs/commands/init/README.md
@@ -15,7 +15,7 @@
 | [firewall](./system/firewall.md) | 关闭防火墙（firewalld / ufw） |
 | [selinux](./system/selinux.md) | 关闭 SELinux |
 | [swap](./system/swap.md) | 关闭 Swap 分区 |
-| [osUser](./system/osuser.md) | 创建 hadoop 用户和组 |
+| [hadoop_user](./system/osuser.md) | 创建 hadoop 用户和组 |
 | [bash](./system/bash.md) | 确保 /bin/sh 指向 bash |
 | [library](./system/library.md) | 安装运行时依赖库 |
 | [osSafeConf](./system/ossafeconf.md) | 初始化基线安全配置 |

--- a/datasophon-cli-go/docs/commands/init/system/osuser.md
+++ b/datasophon-cli-go/docs/commands/init/system/osuser.md
@@ -1,4 +1,4 @@
-# datasophon-cli init osUser
+# datasophon-cli init hadoop_user
 
 ## 用途
 
@@ -7,7 +7,7 @@
 ## 用法 (Synopsis)
 
 ```bash
-datasophon-cli [--dry-run] init osUser [公共 flag]
+datasophon-cli [--dry-run] init hadoop_user [公共 flag]
 ```
 
 ## 参数 / Flags
@@ -26,14 +26,14 @@ datasophon-cli [--dry-run] init osUser [公共 flag]
 ### dry-run 预检
 
 ```bash
-datasophon-cli --dry-run init osUser \
+datasophon-cli --dry-run init hadoop_user \
   --config /data/datasophon/datasophon-init/config/cluster-sample.yml
 ```
 
 ### 实际执行
 
 ```bash
-datasophon-cli init osUser \
+datasophon-cli init hadoop_user \
   --config /data/datasophon/datasophon-init/config/cluster-sample.yml
 ```
 

--- a/datasophon-cli-go/docs/reference/init-all-dag.md
+++ b/datasophon-cli-go/docs/reference/init-all-dag.md
@@ -1,8 +1,8 @@
 # DAG 步骤参考表
 
-本页列出两套执行序列的完整步骤。数据来源：`internal/plan/registry.go`（initALL）和 `internal/cli/create/initializer.go`（standalone 10 步硬编码）。
+本页列出三套执行序列的完整步骤。数据来源：`internal/plan/registry.go`（initALL）、`internal/plan/registry_node.go`（initNode 配置模式）、`internal/cli/create/initializer.go`（手动模式硬编码）。
 
-> `initSingleNode` 17 步 DAG 已随 `addNodes` 批量模式一并移除，新增节点统一通过 `create node`（独立模式，10 步 standalone）完成。
+> `initSingleNode` 17 步 DAG 已随 `addNodes` 批量模式一并移除，新增节点统一通过 `create node` 完成。
 
 ## initALL — 33 步（全量集群初始化）
 
@@ -24,7 +24,7 @@
 | 7 | `init-registry-upload` | 上传安装包到 Nexus | both | 本机（执行节点） | `registry.enable` | [upload registry](../commands/upload/registry.md) |
 | 8 | `init-jdk8` | 安装 JDK 8 | both | 全节点 | 无 | [jdk8](../commands/init/packages/jdk8.md) |
 | 9 | `init-jdk17` | 安装 JDK 17 | both | 全节点 | 无 | [jdk17](../commands/init/packages/jdk17.md) |
-| 10 | `init-osuser` | 创建 hadoop 用户和组 | **hadoop-only** | 全节点 | 无 | [osUser](../commands/init/system/osuser.md) |
+| 10 | `init-osuser` | 创建 hadoop 用户和组 | **hadoop-only** | 全节点 | 无 | [hadoop_user](../commands/init/system/osuser.md) |
 | 11 | `init-firewall` | 关闭防火墙 | both | 全节点 | 无 | [firewall](../commands/init/system/firewall.md) |
 | 12 | `init-selinux` | 关闭 SELinux | both | 全节点 | 无 | [selinux](../commands/init/system/selinux.md) |
 | 13 | `init-swap` | 关闭 Swap | both | 全节点 | 无 | [swap](../commands/init/system/swap.md) |
@@ -49,24 +49,54 @@
 | 32 | `k8s-helmify` | 安装 Helmify | **k8s-only** | K8s 节点 | `kubernetes.enable` | [helmify](../commands/init/k8s/helmify.md) |
 | 33 | `init-hugepage` | 关闭透明大页 | both | 全节点 | 无 | [hugePage](../commands/init/system/hugepage.md) |
 
-## standalone — 10 步（新增节点初始化）
+## initNode — 12 步（新增节点初始化，配置模式）
 
-由 `create node --ip <IP> --user <user> --password <pass> --port <port> --hostname <hn>` 触发，**不使用 plan 引擎**，由 `initializer.go` 硬编码顺序执行，不支持断点续跑（所有步骤幂等，可直接重跑）。
+由 `create node -c <cluster.yml> ...` 触发，**走 plan 引擎**，生成 `state/initNode.plan.json`，支持断点续跑。
+数据来源：`internal/plan/registry_node.go`（`InitNodeRegistry`）。
 
-| 序号 | 步骤名 | 对应命令页 |
+步骤的执行有两个维度的过滤（同 initALL）：
+- **Scope**：由 `cluster-sample.yml global.cluster-type` 字段控制
+- **Condition**：由配置文件各模块开关控制
+
+| 序号 | Step ID | 步骤名 | Scope | 节点范围 | 触发条件（Condition） |
+|---|---|---|---|---|---|
+| 1 | `node-bash` | shell bash 设置 | both | 目标节点 | 无 |
+| 2 | `node-hadoopuser` | 创建 hadoop 用户和组 | **hadoop-only** | 目标节点 | 无（Scope 控制） |
+| 3 | `node-firewall` | 关闭防火墙 | both | 目标节点 | 无 |
+| 4 | `node-selinux` | 关闭 selinux | both | 目标节点 | 无 |
+| 5 | `node-swap` | 关闭 swap | both | 目标节点 | 无 |
+| 6 | `node-offline-slave` | yum/apt 离线源节点配置 | both | 目标节点 | `global.offline=true` |
+| 7 | `node-ntp-slave` | 配置 NTP Slave | both | 目标节点 | `ntpServer.enable=true` |
+| 8 | `node-library` | 初始化依赖库 | both | 目标节点 | 无 |
+| 9 | `node-os-safe-conf` | 安全配置 | both | 目标节点 | 无 |
+| 10 | `node-system-conf` | 优化系统配置 | both | 目标节点 | 无 |
+| 11 | `node-hostname` | 配置 hostname | both | 目标节点 | 无 |
+| 12 | `node-hugepage` | 关闭透明大页 | both | 目标节点 | 无 |
+
+> **步骤顺序设计**：offline_slave（6）在 library（8）之前，先配源再装包；ntp_slave（7）在 offline_slave 后，chrony 安装依赖源。
+>
+> **offline_slave 依赖**：`global.offline=true` 时，配置文件须包含有效的 `registry.node`（registry 启用时）或 `yumServer.node`，否则 ServerIP 为空会报错。
+>
+> **ntp_slave 与 server 排除**：若目标新节点恰好是 NTP server 本身（IP 相同），`slavesOf` 会将其从 slave 列表中过滤，ntp_slave 步骤对该节点无目标。
+
+## standalone — 9~10 步（新增节点初始化，手动模式）
+
+由 `create node --ip <IP> ...`（不传 `-c`）触发，**不使用 plan 引擎**，由 `initializer.go` 硬编码顺序执行，不支持断点续跑（所有步骤幂等，可直接重跑）。
+
+| 序号 | 步骤名 | 触发条件 |
 |---|---|---|
-| 1 | shell bash 设置 | [bash](../commands/init/system/bash.md) |
-| 2 | 创建 hadoop 用户和组 | [osUser](../commands/init/system/osuser.md) |
-| 3 | 关闭防火墙 | [firewall](../commands/init/system/firewall.md) |
-| 4 | 关闭 SELinux | [selinux](../commands/init/system/selinux.md) |
-| 5 | 关闭 Swap | [swap](../commands/init/system/swap.md) |
-| 6 | 初始化依赖库 | [library](../commands/init/system/library.md) |
-| 7 | 安全配置 | [osSafeConf](../commands/init/system/ossafeconf.md) |
-| 8 | 优化系统配置 | [system-conf](../commands/init/system/system-conf.md) |
-| 9 | 配置 hostname | [hostname](../commands/init/network/hostname.md) |
-| 10 | 关闭透明大页 | [hugePage](../commands/init/system/hugepage.md) |
+| 1 | shell bash 设置 | 始终 |
+| 2 | 创建 hadoop 用户和组 | 仅 `-t hadoop` |
+| 3 | 关闭防火墙 | 始终 |
+| 4 | 关闭 SELinux | 始终 |
+| 5 | 关闭 Swap | 始终 |
+| 6 | 初始化依赖库 | 始终 |
+| 7 | 安全配置 | 始终 |
+| 8 | 优化系统配置 | 始终 |
+| 9 | 配置 hostname | 始终 |
+| 10 | 关闭透明大页 | 始终 |
 
-> standalone 模式不生成 `state/*.plan.json`，中途失败需从第 1 步重跑（幂等设计，重跑安全）。
+> 手动模式不支持 ntp_slave/offline_slave，需要服务端 IP 上下文时请使用配置模式（`-c`）。
 
 ## 各步骤的过滤字段
 
@@ -93,3 +123,11 @@
 | `global.mysql.enable` | init-mysql、init-mysql-app-db |
 | `global.kubernetes.enable` | k8s-base-services、k8s-kuboard（部分）、k8s-registry-conf、k8s-docker（k8s 阶段）、k8s-kubectl、k8s-helm、k8s-helmify、init-docker-for-registry（部分） |
 | `global.kubernetes.kuboard.enable` | k8s-kuboard |
+
+**initNode（配置模式）专属条件字段**：
+
+| 条件字段 | 控制的 initNode 步骤 |
+|---|---|
+| `global.cluster-type=hadoop`（Scope） | `node-hadoopuser` |
+| `global.offline=true` | `node-offline-slave` |
+| `ntpServer.enable=true` | `node-ntp-slave` |

--- a/datasophon-cli-go/internal/cli/create/initializer.go
+++ b/datasophon-cli-go/internal/cli/create/initializer.go
@@ -36,6 +36,7 @@ type nodeInitializer struct {
 	globalNodes    map[string]*config.Host
 	localHost      *config.Host
 	currentCfg     *config.ClusterConfig // setup() 后赋值
+	targetNode     *config.Host          // create node 配置模式：目标新节点
 }
 
 func (n *nodeInitializer) bindCommonFlags(cmd *cobra.Command) {
@@ -136,17 +137,64 @@ func (n *nodeInitializer) toBuildContext() *plan.BuildContext {
 		SSHAuthType:            n.sshAuthType,
 		InitPathOverwriteForce: n.InitPathOverwriteForce,
 		DryRun:                 n.dryRun,
+		TargetNode:             n.targetNode,
 	}
 }
 
-// initStandaloneNode 独立模式 10 步节点级 DAG（不依赖集群上下文，不走 plan 引擎）。
-func (n *nodeInitializer) initStandaloneNode(host *config.Host) error {
+// setupConfig 配置模式初始化：从 cpath 加载配置，校验新节点不与已有节点冲突。
+// 若 newNode.IP 已存在于配置文件 nodes 列表中，返回错误（提示并停止）。
+func (n *nodeInitializer) setupConfig(cpath string, newNode *config.Host) error {
+	if !strings.HasPrefix(n.DatasophonPath, "/") || !strings.HasPrefix(n.InstallPath, "/") {
+		return fmt.Errorf("datasophonPath、installPath 必须是绝对路径（以 / 开头）")
+	}
+	n.DatasophonPath = strings.TrimSuffix(n.DatasophonPath, "/")
+
+	if _, err := os.Stat(n.DatasophonPath); err != nil {
+		return fmt.Errorf("路径不存在: %s", n.DatasophonPath)
+	}
+
+	cfg, err := config.Load(cpath)
+	if err != nil {
+		return err
+	}
+
+	// 重复检测：按 IP 判断新节点是否已存在
+	for _, node := range cfg.Nodes {
+		if node.IP == newNode.IP {
+			return fmt.Errorf("节点 %s 已存在于配置文件 nodes 列表中，已停止", newNode.IP)
+		}
+	}
+
+	n.initPath = n.DatasophonPath + "/datasophon-init"
+	n.initConfigPath = n.initPath + "/config"
+	n.packagesPath = n.initPath + "/packages"
+	n.initConfigYaml = cpath // 配置模式：写回目标即 -c 指定文件
+
+	n.sshAuthType = cfg.Global.SSHAuthType
+	n.globalNodes = make(map[string]*config.Host, len(cfg.Nodes))
+	for i := range cfg.Nodes {
+		n.globalNodes[cfg.Nodes[i].Hostname] = &cfg.Nodes[i]
+	}
+	n.localHost = nil
+	n.currentCfg = cfg
+	n.targetNode = newNode
+
+	slog.Info("配置模式路径信息",
+		"DATASOPHON_PATH", n.DatasophonPath,
+		"CONFIG_FILE", cpath,
+		"TARGET_NODE", newNode.IP)
+	return nil
+}
+
+// initStandaloneNode 手动模式节点级 DAG（不依赖集群上下文，不走 plan 引擎）。
+// clusterType 为 hadoop 时执行"创建 hadoop 用户和组"，否则跳过。
+// 不支持断点续跑；所有步骤均为幂等操作，中途失败可直接重跑。
+func (n *nodeInitializer) initStandaloneNode(host *config.Host, clusterType config.ClusterType) error {
 	steps := []struct {
 		name string
 		fn   func() error
 	}{
 		{"shell bash 设置", func() error { return n.singleNodeExecDirect(host, &initcmd.InitBash{}) }},
-		{"创建 hadoop 用户和组", func() error { return n.singleNodeExecDirect(host, &initcmd.InitHadoopUser{}) }},
 		{"关闭防火墙", func() error { return n.singleNodeExecDirect(host, &initcmd.InitFirewall{}) }},
 		{"关闭 selinux", func() error { return n.singleNodeExecDirect(host, &initcmd.InitSelinux{}) }},
 		{"关闭 swap", func() error { return n.singleNodeExecDirect(host, &initcmd.InitSwap{}) }},
@@ -157,6 +205,19 @@ func (n *nodeInitializer) initStandaloneNode(host *config.Host) error {
 			return n.singleNodeExecDirect(host, &initcmd.InitHostname{Hostname: host.Hostname})
 		}},
 		{"关闭透明大页", func() error { return n.singleNodeExecDirect(host, &initcmd.InitHugePage{}) }},
+	}
+
+	// hadoop_user 仅在 hadoop 集群类型下执行
+	if clusterType == config.ClusterTypeHadoop {
+		hadoopStep := struct {
+			name string
+			fn   func() error
+		}{"创建 hadoop 用户和组", func() error { return n.singleNodeExecDirect(host, &initcmd.InitHadoopUser{}) }}
+		// 插入到 bash 之后（索引 1）
+		steps = append(steps[:1], append([]struct {
+			name string
+			fn   func() error
+		}{hadoopStep}, steps[1:]...)...)
 	}
 
 	for _, s := range steps {

--- a/datasophon-cli-go/internal/cli/create/initializer.go
+++ b/datasophon-cli-go/internal/cli/create/initializer.go
@@ -142,10 +142,14 @@ func (n *nodeInitializer) toBuildContext() *plan.BuildContext {
 }
 
 // setupConfig 配置模式初始化：从 cpath 加载配置，校验新节点不与已有节点冲突。
-// 若 newNode.IP 已存在于配置文件 nodes 列表中，返回错误（提示并停止）。
+// 若 newNode.IP 或 newNode.Hostname 已存在于配置文件 nodes 列表中，返回错误（提示并停止）。
 func (n *nodeInitializer) setupConfig(cpath string, newNode *config.Host) error {
 	if !strings.HasPrefix(n.DatasophonPath, "/") || !strings.HasPrefix(n.InstallPath, "/") {
 		return fmt.Errorf("datasophonPath、installPath 必须是绝对路径（以 / 开头）")
+	}
+	// Bug 5: 配置文件路径同样必须为绝对路径，与 datasophonPath/installPath 保持一致
+	if !strings.HasPrefix(cpath, "/") {
+		return fmt.Errorf("配置文件路径必须是绝对路径（以 / 开头）: %s", cpath)
 	}
 	n.DatasophonPath = strings.TrimSuffix(n.DatasophonPath, "/")
 
@@ -158,10 +162,15 @@ func (n *nodeInitializer) setupConfig(cpath string, newNode *config.Host) error 
 		return err
 	}
 
-	// 重复检测：按 IP 判断新节点是否已存在
+	// Bug 1: 重复检测同时按 IP 和 hostname 判断，与 appendNodeToYAML 的写回保护语义一致。
+	// 若仅检查 IP，同 hostname 不同 IP 的节点会通过预检、完成所有 SSH 初始化步骤，
+	// 最后被 appendNodeToYAML 静默跳过写回，导致节点已初始化但配置文件未更新。
 	for _, node := range cfg.Nodes {
 		if node.IP == newNode.IP {
-			return fmt.Errorf("节点 %s 已存在于配置文件 nodes 列表中，已停止", newNode.IP)
+			return fmt.Errorf("节点 IP %s 已存在于配置文件 nodes 列表中，已停止", newNode.IP)
+		}
+		if node.Hostname == newNode.Hostname {
+			return fmt.Errorf("节点 hostname %s 已存在于配置文件 nodes 列表中，已停止", newNode.Hostname)
 		}
 	}
 
@@ -175,6 +184,10 @@ func (n *nodeInitializer) setupConfig(cpath string, newNode *config.Host) error 
 	for i := range cfg.Nodes {
 		n.globalNodes[cfg.Nodes[i].Hostname] = &cfg.Nodes[i]
 	}
+	// Bug 4: 将目标新节点也加入 globalNodes，使 buildNtpSlave/buildOfflineNodes 等
+	// 通过 requireNode 引用它时不报"节点不在列表中"错误。
+	// 典型场景：新节点本身是 NTP server（slavesOf 会将其从从节点列表中过滤掉，正确）。
+	n.globalNodes[newNode.Hostname] = newNode
 	n.localHost = nil
 	n.currentCfg = cfg
 	n.targetNode = newNode
@@ -190,35 +203,34 @@ func (n *nodeInitializer) setupConfig(cpath string, newNode *config.Host) error 
 // clusterType 为 hadoop 时执行"创建 hadoop 用户和组"，否则跳过。
 // 不支持断点续跑；所有步骤均为幂等操作，中途失败可直接重跑。
 func (n *nodeInitializer) initStandaloneNode(host *config.Host, clusterType config.ClusterType) error {
-	steps := []struct {
+	type step struct {
 		name string
 		fn   func() error
-	}{
-		{"shell bash 设置", func() error { return n.singleNodeExecDirect(host, &initcmd.InitBash{}) }},
-		{"关闭防火墙", func() error { return n.singleNodeExecDirect(host, &initcmd.InitFirewall{}) }},
-		{"关闭 selinux", func() error { return n.singleNodeExecDirect(host, &initcmd.InitSelinux{}) }},
-		{"关闭 swap", func() error { return n.singleNodeExecDirect(host, &initcmd.InitSwap{}) }},
-		{"初始化依赖库", func() error { return n.singleNodeExecDirect(host, &initcmd.InitLibrary{}) }},
-		{"安全配置", func() error { return n.singleNodeExecDirect(host, &initcmd.InitOsSafeConf{}) }},
-		{"优化系统配置", func() error { return n.singleNodeExecDirect(host, &initcmd.InitSystemConf{}) }},
-		{"配置 hostname", func() error {
-			return n.singleNodeExecDirect(host, &initcmd.InitHostname{Hostname: host.Hostname})
-		}},
-		{"关闭透明大页", func() error { return n.singleNodeExecDirect(host, &initcmd.InitHugePage{}) }},
 	}
 
-	// hadoop_user 仅在 hadoop 集群类型下执行
-	if clusterType == config.ClusterTypeHadoop {
-		hadoopStep := struct {
-			name string
-			fn   func() error
-		}{"创建 hadoop 用户和组", func() error { return n.singleNodeExecDirect(host, &initcmd.InitHadoopUser{}) }}
-		// 插入到 bash 之后（索引 1）
-		steps = append(steps[:1], append([]struct {
-			name string
-			fn   func() error
-		}{hadoopStep}, steps[1:]...)...)
+	// Bug 8: 原来用 triple-append 在索引 1 处插入 hadoopStep，依赖底层数组不共享容量，
+	// 若切片容量大于 len 则外层 append 覆盖原数组后再读 steps[1:]，导致步骤乱序。
+	// 改为先构建 bash 步骤，再按条件 append hadoopStep，最后追加其余步骤，无魔法索引。
+	steps := []step{
+		{"shell bash 设置", func() error { return n.singleNodeExecDirect(host, &initcmd.InitBash{}) }},
 	}
+	if clusterType == config.ClusterTypeHadoop {
+		steps = append(steps, step{"创建 hadoop 用户和组", func() error {
+			return n.singleNodeExecDirect(host, &initcmd.InitHadoopUser{})
+		}})
+	}
+	steps = append(steps,
+		step{"关闭防火墙", func() error { return n.singleNodeExecDirect(host, &initcmd.InitFirewall{}) }},
+		step{"关闭 selinux", func() error { return n.singleNodeExecDirect(host, &initcmd.InitSelinux{}) }},
+		step{"关闭 swap", func() error { return n.singleNodeExecDirect(host, &initcmd.InitSwap{}) }},
+		step{"初始化依赖库", func() error { return n.singleNodeExecDirect(host, &initcmd.InitLibrary{}) }},
+		step{"安全配置", func() error { return n.singleNodeExecDirect(host, &initcmd.InitOsSafeConf{}) }},
+		step{"优化系统配置", func() error { return n.singleNodeExecDirect(host, &initcmd.InitSystemConf{}) }},
+		step{"配置 hostname", func() error {
+			return n.singleNodeExecDirect(host, &initcmd.InitHostname{Hostname: host.Hostname})
+		}},
+		step{"关闭透明大页", func() error { return n.singleNodeExecDirect(host, &initcmd.InitHugePage{}) }},
+	)
 
 	for _, s := range steps {
 		slog.Info(s.name)

--- a/datasophon-cli-go/internal/cli/create/node.go
+++ b/datasophon-cli-go/internal/cli/create/node.go
@@ -40,6 +40,13 @@ func (c *createNodeCmd) run() error {
 
 // runConfigMode 配置模式：从 -c 指定的配置文件读取全局上下文，走 plan 引擎初始化目标新节点。
 func (c *createNodeCmd) runConfigMode() error {
+	// Bug 7: MarkFlagRequired 仅检查 flag 是否出现在命令行，不校验值非空（--ip '' 可通过）。
+	// 此处与 runManualMode 对称做早期非空校验，给出明确错误而非等到 SSH dial 时失败。
+	if c.standaloneIP == "" || c.standaloneUser == "" || c.standalonePassword == "" ||
+		c.standaloneHostname == "" || c.standalonePort == 0 {
+		return fmt.Errorf("配置模式下必须同时提供非空的 --ip --user --password --hostname --port")
+	}
+
 	newNode := &config.Host{
 		IP:       c.standaloneIP,
 		Port:     c.standalonePort,
@@ -53,17 +60,28 @@ func (c *createNodeCmd) runConfigMode() error {
 	}
 
 	ctx := c.toBuildContext()
-	pf, err := plan.GeneratePlan("initNode", plan.InitNodeRegistry, ctx)
-	if err != nil {
-		return fmt.Errorf("生成节点计划失败: %w", err)
-	}
-	if err := plan.Save(c.initPath, pf); err != nil {
-		return err
-	}
-	slog.Info("节点计划已写入", "path", plan.PlanPath(c.initPath, "initNode"))
-	plan.PrintSummary(pf)
 
-	if err := plan.Apply(c.initPath, "initNode", plan.InitNodeRegistry, ctx); err != nil {
+	// Bug 3: 计划文件以目标节点 IP 为后缀区分，避免多次 create node 互相覆盖同一文件。
+	// 同时，若已有计划文件且 clusterHash 匹配，直接从断点继续（不重新生成），
+	// 使断点续跑功能真正生效。
+	action := "initNode-" + newNode.IP
+	if existingPf, loadErr := plan.Load(c.initPath, action); loadErr == nil &&
+		existingPf.ClusterHash == plan.ComputeHash(ctx.Cfg) {
+		slog.Info("发现已有计划文件，从断点继续", "path", plan.PlanPath(c.initPath, action))
+		plan.PrintSummary(existingPf)
+	} else {
+		pf, err := plan.GeneratePlan(action, plan.InitNodeRegistry, ctx)
+		if err != nil {
+			return fmt.Errorf("生成节点计划失败: %w", err)
+		}
+		if err := plan.Save(c.initPath, pf); err != nil {
+			return err
+		}
+		slog.Info("节点计划已写入", "path", plan.PlanPath(c.initPath, action))
+		plan.PrintSummary(pf)
+	}
+
+	if err := plan.Apply(c.initPath, action, plan.InitNodeRegistry, ctx); err != nil {
 		return err
 	}
 
@@ -84,8 +102,9 @@ func (c *createNodeCmd) runManualMode() error {
 		Hostname: c.standaloneHostname,
 	}
 
-	// 解析可选的 -t/--cluster-type
-	var clusterType config.ClusterType
+	// Bug 2: 旧版 create node 始终执行 hadoop_user；此处默认 ClusterTypeHadoop 保持向后兼容。
+	// kubernetes 集群用户须显式传 -t kubernetes 以跳过 hadoop_user 步骤。
+	clusterType := config.ClusterTypeHadoop
 	if c.clusterTypeFlag != "" {
 		ct, err := config.ParseClusterType(c.clusterTypeFlag)
 		if err != nil {

--- a/datasophon-cli-go/internal/cli/create/node.go
+++ b/datasophon-cli-go/internal/cli/create/node.go
@@ -8,11 +8,16 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/88fantasy/datasophon/datasophon-cli-go/internal/config"
+	"github.com/88fantasy/datasophon/datasophon-cli-go/internal/plan"
 )
 
 // createNodeCmd 新增节点初始化。
-// embed nodeInitializer 复用公共路径状态和 helper；不再 embed createClusterCmd，
-// 因此不携带 cluster-only 的 flag 字段。
+// 支持两种模式：
+//   - 配置模式（-c/--config 指定配置文件）：从配置文件读取集群上下文，走 plan 引擎执行 12 步条件化 DAG。
+//     条件：cluster-type=hadoop → hadoop_user；ntpServer.enable=true → ntp_slave；global.offline=true → offline_slave。
+//     若 --ip 指定的节点已存在于配置文件 nodes 列表中（按 IP 判断）→ 提示并停止。
+//   - 手动模式（不传 -c）：不加载配置文件，直接用 CLI 参数初始化目标节点（9~10 步）。
+//     -t hadoop → 额外执行 hadoop_user；无 ntp_slave / offline_slave。
 type createNodeCmd struct {
 	nodeInitializer
 
@@ -21,15 +26,52 @@ type createNodeCmd struct {
 	standalonePassword string
 	standalonePort     int
 	standaloneHostname string
+
+	configPath      string // -c/--config 配置文件路径（配置模式）
+	clusterTypeFlag string // -t/--cluster-type 手动模式集群类型（可选）
 }
 
 func (c *createNodeCmd) run() error {
-	return c.runStandalone()
+	if c.configPath != "" {
+		return c.runConfigMode()
+	}
+	return c.runManualMode()
 }
 
-// runStandalone 独立模式:不加载配置文件，直接用 CLI 参数初始化目标节点（10 步节点级 DAG）。
-// 初始化成功后若 cluster-sample.yml 存在，则把新节点追加到其 nodes 列表。
-func (c *createNodeCmd) runStandalone() error {
+// runConfigMode 配置模式：从 -c 指定的配置文件读取全局上下文，走 plan 引擎初始化目标新节点。
+func (c *createNodeCmd) runConfigMode() error {
+	newNode := &config.Host{
+		IP:       c.standaloneIP,
+		Port:     c.standalonePort,
+		User:     c.standaloneUser,
+		Password: c.standalonePassword,
+		Hostname: c.standaloneHostname,
+	}
+
+	if err := c.setupConfig(c.configPath, newNode); err != nil {
+		return err
+	}
+
+	ctx := c.toBuildContext()
+	pf, err := plan.GeneratePlan("initNode", plan.InitNodeRegistry, ctx)
+	if err != nil {
+		return fmt.Errorf("生成节点计划失败: %w", err)
+	}
+	if err := plan.Save(c.initPath, pf); err != nil {
+		return err
+	}
+	slog.Info("节点计划已写入", "path", plan.PlanPath(c.initPath, "initNode"))
+	plan.PrintSummary(pf)
+
+	if err := plan.Apply(c.initPath, "initNode", plan.InitNodeRegistry, ctx); err != nil {
+		return err
+	}
+
+	return c.maybeAppendToYAML(newNode)
+}
+
+// runManualMode 手动模式：不加载配置文件，直接用 CLI 参数初始化目标节点（不走 plan 引擎）。
+func (c *createNodeCmd) runManualMode() error {
 	if c.standaloneUser == "" || c.standalonePassword == "" ||
 		c.standaloneHostname == "" || c.standalonePort == 0 {
 		return fmt.Errorf("--ip 模式下必须同时提供 --user --password --hostname --port")
@@ -41,10 +83,21 @@ func (c *createNodeCmd) runStandalone() error {
 		Password: c.standalonePassword,
 		Hostname: c.standaloneHostname,
 	}
+
+	// 解析可选的 -t/--cluster-type
+	var clusterType config.ClusterType
+	if c.clusterTypeFlag != "" {
+		ct, err := config.ParseClusterType(c.clusterTypeFlag)
+		if err != nil {
+			return err
+		}
+		clusterType = ct
+	}
+
 	if err := c.setupStandalone(host); err != nil {
 		return err
 	}
-	if err := c.initStandaloneNode(host); err != nil {
+	if err := c.initStandaloneNode(host, clusterType); err != nil {
 		return err
 	}
 	return c.maybeAppendToYAML(host)
@@ -70,12 +123,13 @@ func (c *createNodeCmd) maybeAppendToYAML(host *config.Host) error {
 }
 
 // NewNodeCommand 对应 datasophon-cli create node。
-// 通过 --ip/--user/--password/--port/--hostname 直接对目标节点执行基础初始化。
+// 配置模式：-c <file> + --ip/--user/--password/--port/--hostname 5 个定位参数。
+// 手动模式：--ip/--user/--password/--port/--hostname，可选 -t/--cluster-type。
 func NewNodeCommand(dryRun *bool) *cobra.Command {
 	c := &createNodeCmd{}
 	cmd := &cobra.Command{
 		Use:   "node",
-		Short: "初始化新增节点（通过 --ip 指定目标节点）",
+		Short: "初始化新增节点（配置模式 -c <file> 或手动模式 --ip 指定目标节点）",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c.dryRun = *dryRun
 			return c.run()
@@ -88,6 +142,8 @@ func NewNodeCommand(dryRun *bool) *cobra.Command {
 	cmd.Flags().StringVar(&c.standalonePassword, "password", "", "SSH 密码")
 	cmd.Flags().IntVar(&c.standalonePort, "port", 0, "SSH 端口")
 	cmd.Flags().StringVar(&c.standaloneHostname, "hostname", "", "目标节点 hostname")
+	cmd.Flags().StringVarP(&c.configPath, "config", "c", "", "配置文件路径（配置模式，提供集群上下文与 ntp/offline 服务端 IP）")
+	cmd.Flags().StringVarP(&c.clusterTypeFlag, "cluster-type", "t", "", "集群类型 hadoop|kubernetes（手动模式可选，仅 hadoop 时创建 hadoop 用户）")
 	_ = cmd.MarkFlagRequired("ip")
 	_ = cmd.MarkFlagRequired("user")
 	_ = cmd.MarkFlagRequired("password")

--- a/datasophon-cli-go/internal/cli/create/node_setup_test.go
+++ b/datasophon-cli-go/internal/cli/create/node_setup_test.go
@@ -1,0 +1,97 @@
+package create
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/88fantasy/datasophon/datasophon-cli-go/internal/config"
+)
+
+// minimalClusterYAML 包含一个既有节点（10.0.0.1），用于测试重复检测。
+const minimalClusterYAML = `global:
+  cluster-type: hadoop
+  sshAuthType: PASSWORD
+ntpServer:
+  enable: false
+  node: ""
+nodes:
+  - ip: 10.0.0.1
+    port: 22
+    user: root
+    password: root123
+    hostname: node1
+`
+
+// writeTemp 写一个临时 YAML 文件，返回路径（调用方负责清理）。
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp("", "cluster-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString(content)
+	f.Close()
+	return f.Name()
+}
+
+// TestSetupConfig_DuplicateIP 验证目标节点 IP 已存在于配置文件时，setupConfig 返回错误并包含 IP 信息。
+func TestSetupConfig_DuplicateIP(t *testing.T) {
+	cfgPath := writeTemp(t, minimalClusterYAML)
+	defer os.Remove(cfgPath)
+
+	tmpDir := t.TempDir()
+	n := &nodeInitializer{
+		DatasophonPath:  tmpDir,
+		InstallPath:     tmpDir + "/install",
+		ProductPkgsPath: tmpDir + "/pkgs",
+	}
+	_ = os.MkdirAll(tmpDir+"/install", 0755)
+
+	// 目标节点 IP = 10.0.0.1，已存在于 nodes 列表
+	newNode := &config.Host{IP: "10.0.0.1", Port: 22, User: "root", Password: "pass", Hostname: "newnode"}
+	err := n.setupConfig(cfgPath, newNode)
+	if err == nil {
+		t.Fatal("期望 setupConfig 返回错误（重复 IP），但返回 nil")
+	}
+	if !strings.Contains(err.Error(), "10.0.0.1") {
+		t.Errorf("错误信息应包含重复 IP，实际: %v", err)
+	}
+	if !strings.Contains(err.Error(), "已存在") {
+		t.Errorf("错误信息应包含'已存在'，实际: %v", err)
+	}
+}
+
+// TestSetupConfig_NewIP 验证目标节点 IP 不存在于配置文件时，setupConfig 正常返回并填充运行时字段。
+func TestSetupConfig_NewIP(t *testing.T) {
+	cfgPath := writeTemp(t, minimalClusterYAML)
+	defer os.Remove(cfgPath)
+
+	tmpDir := t.TempDir()
+	n := &nodeInitializer{
+		DatasophonPath:  tmpDir,
+		InstallPath:     tmpDir + "/install",
+		ProductPkgsPath: tmpDir + "/pkgs",
+	}
+	_ = os.MkdirAll(tmpDir+"/install", 0755)
+
+	newNode := &config.Host{IP: "10.0.0.99", Port: 22, User: "root", Password: "pass", Hostname: "newnode"}
+	err := n.setupConfig(cfgPath, newNode)
+	if err != nil {
+		t.Fatalf("期望 setupConfig 成功，但返回错误: %v", err)
+	}
+
+	// 验证关键字段被正确填充
+	if n.currentCfg == nil {
+		t.Fatal("currentCfg 应被设置")
+	}
+	if n.targetNode == nil || n.targetNode.IP != "10.0.0.99" {
+		t.Errorf("targetNode 未正确设置，实际: %v", n.targetNode)
+	}
+	if n.initConfigYaml != cfgPath {
+		t.Errorf("initConfigYaml 应等于 cfgPath，实际: %s", n.initConfigYaml)
+	}
+	if _, ok := n.globalNodes["node1"]; !ok {
+		t.Error("globalNodes 应包含 node1")
+	}
+}

--- a/datasophon-cli-go/internal/cli/create/node_setup_test.go
+++ b/datasophon-cli-go/internal/cli/create/node_setup_test.go
@@ -62,6 +62,34 @@ func TestSetupConfig_DuplicateIP(t *testing.T) {
 	}
 }
 
+// TestSetupConfig_DuplicateHostname 验证目标节点 hostname 已存在（IP 不同）时，setupConfig 返回错误。
+// 修复前：仅检查 IP，同 hostname 节点会通过预检并完整初始化，最后被写回阶段静默跳过。
+func TestSetupConfig_DuplicateHostname(t *testing.T) {
+	cfgPath := writeTemp(t, minimalClusterYAML)
+	defer os.Remove(cfgPath)
+
+	tmpDir := t.TempDir()
+	n := &nodeInitializer{
+		DatasophonPath:  tmpDir,
+		InstallPath:     tmpDir + "/install",
+		ProductPkgsPath: tmpDir + "/pkgs",
+	}
+	_ = os.MkdirAll(tmpDir+"/install", 0755)
+
+	// IP 不同，但 hostname = node1 与配置文件中已有节点重复
+	newNode := &config.Host{IP: "10.0.0.99", Port: 22, User: "root", Password: "pass", Hostname: "node1"}
+	err := n.setupConfig(cfgPath, newNode)
+	if err == nil {
+		t.Fatal("期望 setupConfig 返回错误（重复 hostname），但返回 nil")
+	}
+	if !strings.Contains(err.Error(), "node1") {
+		t.Errorf("错误信息应包含重复 hostname，实际: %v", err)
+	}
+	if !strings.Contains(err.Error(), "已存在") {
+		t.Errorf("错误信息应包含'已存在'，实际: %v", err)
+	}
+}
+
 // TestSetupConfig_NewIP 验证目标节点 IP 不存在于配置文件时，setupConfig 正常返回并填充运行时字段。
 func TestSetupConfig_NewIP(t *testing.T) {
 	cfgPath := writeTemp(t, minimalClusterYAML)
@@ -92,6 +120,11 @@ func TestSetupConfig_NewIP(t *testing.T) {
 		t.Errorf("initConfigYaml 应等于 cfgPath，实际: %s", n.initConfigYaml)
 	}
 	if _, ok := n.globalNodes["node1"]; !ok {
-		t.Error("globalNodes 应包含 node1")
+		t.Error("globalNodes 应包含已有节点 node1")
+	}
+	// Bug 4 修复验证：targetNode 本身也应加入 globalNodes，
+	// 确保 buildNtpSlave 等通过 requireNode 引用新节点时不报"节点不在列表中"
+	if h, ok := n.globalNodes["newnode"]; !ok || h.IP != "10.0.0.99" {
+		t.Error("globalNodes 应包含目标新节点 newnode（IP=10.0.0.99）")
 	}
 }

--- a/datasophon-cli-go/internal/cli/init/hadoopuser.go
+++ b/datasophon-cli-go/internal/cli/init/hadoopuser.go
@@ -52,7 +52,7 @@ func (t *InitHadoopUser) doRun(exec executor.Executor) error {
 
 func (t *InitHadoopUser) Command(dryRun *bool) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "hadoopUser",
+		Use:   "hadoop_user",
 		Short: "创建 hadoop 用户和组",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runLocal(*dryRun, t.doRun)

--- a/datasophon-cli-go/internal/plan/helpers.go
+++ b/datasophon-cli-go/internal/plan/helpers.go
@@ -1,6 +1,8 @@
 package plan
 
 import (
+	"log/slog"
+
 	initcmd "github.com/88fantasy/datasophon/datasophon-cli-go/internal/cli/init"
 	"github.com/88fantasy/datasophon/datasophon-cli-go/internal/config"
 	"github.com/88fantasy/datasophon/datasophon-cli-go/internal/handler"
@@ -72,9 +74,12 @@ type nodeSelector func(ctx *BuildContext) []config.Host
 func allNodes(ctx *BuildContext) []config.Host { return ctx.Cfg.Nodes }
 
 // targetNode 选取 BuildContext.TargetNode（单节点目标，供 create node 使用）。
-// TargetNode 为 nil 时返回空切片，对应 Step 将产生空 targets。
+// TargetNode 为 nil 属于编程错误：InitNodeRegistry 必须通过 setupConfig 初始化后才能调用。
+// 此时记录 Error 日志并返回空切片，使调用方（GeneratePlan/Apply）以零目标执行步骤，
+// 而非静默成功——调用方应在此之前通过参数校验保证 TargetNode 非 nil。
 func targetNode(ctx *BuildContext) []config.Host {
 	if ctx.TargetNode == nil {
+		slog.Error("targetNode: BuildContext.TargetNode 为 nil，步骤将无目标节点（无操作）；确认已通过 setupConfig 初始化")
 		return nil
 	}
 	return []config.Host{*ctx.TargetNode}

--- a/datasophon-cli-go/internal/plan/helpers.go
+++ b/datasophon-cli-go/internal/plan/helpers.go
@@ -71,6 +71,15 @@ type nodeSelector func(ctx *BuildContext) []config.Host
 // allNodes 选取 cfg.Nodes。
 func allNodes(ctx *BuildContext) []config.Host { return ctx.Cfg.Nodes }
 
+// targetNode 选取 BuildContext.TargetNode（单节点目标，供 create node 使用）。
+// TargetNode 为 nil 时返回空切片，对应 Step 将产生空 targets。
+func targetNode(ctx *BuildContext) []config.Host {
+	if ctx.TargetNode == nil {
+		return nil
+	}
+	return []config.Host{*ctx.TargetNode}
+}
+
 // slavesOf 过滤掉 serverNode，返回其他节点（对应 nodeInitializer.slavesNodesExec）。
 func slavesOf(all []*config.Host, serverHost *config.Host) []*config.Host {
 	var result []*config.Host

--- a/datasophon-cli-go/internal/plan/registry_node.go
+++ b/datasophon-cli-go/internal/plan/registry_node.go
@@ -1,0 +1,58 @@
+package plan
+
+import (
+	initcmd "github.com/88fantasy/datasophon/datasophon-cli-go/internal/cli/init"
+	"github.com/88fantasy/datasophon/datasophon-cli-go/internal/handler"
+)
+
+// InitNodeRegistry 对应 create node 的 12 步节点级 DAG。
+// 所有 builder 复用 builders_common.go 中已有工厂，仅把节点选择器换成 targetNode（单节点）。
+//
+// 步骤排序说明：
+//   - offline_slave（步骤 6）在 library（步骤 8）之前：先配好离线 yum/apt 源，装包才能成功。
+//   - ntp_slave（步骤 7）紧接 offline_slave：chrony 需要通过 yum/apt 安装。
+//   - hadoop_user 用 ScopeHadoopOnly，非 hadoop 集群类型时由 GeneratePlan 自动跳过。
+//   - offline_slave / ntp_slave 用 Condition 函数，cfg 未开启时自动跳过。
+//
+// 注意：offline=true 时，配置文件须包含有效的 registry.node 或 yumServer.node，
+// 否则 buildOfflineNodes 构造的 ServerIP 为空字符串（下游会报错）。
+var InitNodeRegistry = []Step{
+	{ID: "node-bash", Name: "shell bash 设置",
+		Build: simpleAllNodes(func() handler.Handler { return &initcmd.InitBash{} }, targetNode)},
+
+	{ID: "node-hadoopuser", Name: "创建 hadoop 用户和组",
+		Scope: ScopeHadoopOnly,
+		Build: simpleAllNodes(func() handler.Handler { return &initcmd.InitHadoopUser{} }, targetNode)},
+
+	{ID: "node-firewall", Name: "关闭防火墙",
+		Build: simpleAllNodes(func() handler.Handler { return &initcmd.InitFirewall{} }, targetNode)},
+
+	{ID: "node-selinux", Name: "关闭 selinux",
+		Build: simpleAllNodes(func() handler.Handler { return &initcmd.InitSelinux{} }, targetNode)},
+
+	{ID: "node-swap", Name: "关闭 swap",
+		Build: simpleAllNodes(func() handler.Handler { return &initcmd.InitSwap{} }, targetNode)},
+
+	{ID: "node-offline-slave", Name: "yum/apt 离线源节点配置",
+		Condition: func(ctx *BuildContext) bool { return ctx.Cfg.Global.Offline },
+		Build:     buildOfflineNodes(targetNode)},
+
+	{ID: "node-ntp-slave", Name: "配置 NTP Slave",
+		Condition: func(ctx *BuildContext) bool { return ctx.Cfg.NtpServer.Enable },
+		Build:     buildNtpSlave(targetNode)},
+
+	{ID: "node-library", Name: "初始化依赖库",
+		Build: simpleAllNodes(func() handler.Handler { return &initcmd.InitLibrary{} }, targetNode)},
+
+	{ID: "node-os-safe-conf", Name: "安全配置",
+		Build: simpleAllNodes(func() handler.Handler { return &initcmd.InitOsSafeConf{} }, targetNode)},
+
+	{ID: "node-system-conf", Name: "优化系统配置",
+		Build: simpleAllNodes(func() handler.Handler { return &initcmd.InitSystemConf{} }, targetNode)},
+
+	{ID: "node-hostname", Name: "配置 hostname",
+		Build: buildHostname(targetNode)},
+
+	{ID: "node-hugepage", Name: "关闭透明大页",
+		Build: simpleAllNodes(func() handler.Handler { return &initcmd.InitHugePage{} }, targetNode)},
+}

--- a/datasophon-cli-go/internal/plan/registry_node_test.go
+++ b/datasophon-cli-go/internal/plan/registry_node_test.go
@@ -1,0 +1,144 @@
+package plan
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/88fantasy/datasophon/datasophon-cli-go/internal/config"
+)
+
+// newNodeFixture 返回一个不在 stubCfg().Nodes 中的目标新节点。
+func newNodeFixture() config.Host {
+	return config.Host{Hostname: "newnode", IP: "10.0.0.99", Port: 22, User: "root", Password: "pass"}
+}
+
+// ctxWithTarget 在 stubCtx 基础上设置 TargetNode。
+func ctxWithTarget(cfg *config.ClusterConfig, tmpDir string, target *config.Host) *BuildContext {
+	ctx := stubCtx(cfg, tmpDir)
+	ctx.TargetNode = target
+	return ctx
+}
+
+// ─── InitNodeRegistry 全量测试 ─────────────────────────────────────────────────
+
+// TestInitNodeRegistry_StepCount 确认注册表长度与预期一致。
+func TestInitNodeRegistry_StepCount(t *testing.T) {
+	assert.Len(t, InitNodeRegistry, 12, "InitNodeRegistry 应包含 12 个步骤")
+}
+
+// TestInitNodeRegistry_Hadoop_AllConditionsEnabled 验证 hadoop+ntp+offline 全开时三个条件步骤均规划执行，
+// 且 Targets 仅包含目标新节点 hostname。
+func TestInitNodeRegistry_Hadoop_AllConditionsEnabled(t *testing.T) {
+	cfg := stubCfg()
+	cfg.Global.ClusterType = config.ClusterTypeHadoop
+	cfg.Global.Offline = true
+	cfg.NtpServer = config.NodeRef{Enable: true, Node: "node1"}
+	cfg.YumServer = config.YumServer{Enable: true, Node: "node1", ListenPort: "9999"}
+
+	newNode := newNodeFixture()
+	ctx := ctxWithTarget(cfg, t.TempDir(), &newNode)
+
+	pf, err := GeneratePlan("initNode", InitNodeRegistry, ctx)
+	require.NoError(t, err)
+	assert.Equal(t, len(InitNodeRegistry), len(pf.Steps))
+
+	// hadoop_user（ScopeHadoopOnly）应执行
+	assertStepStatus(t, pf, "node-hadoopuser", StatusPending)
+	assertTargetOnly(t, pf, "node-hadoopuser", newNode.Hostname)
+
+	// ntp_slave（Condition: NtpServer.Enable=true）应执行
+	assertStepStatus(t, pf, "node-ntp-slave", StatusPending)
+	assertTargetOnly(t, pf, "node-ntp-slave", newNode.Hostname)
+
+	// offline_slave（Condition: Global.Offline=true）应执行
+	assertStepStatus(t, pf, "node-offline-slave", StatusPending)
+	assertTargetOnly(t, pf, "node-offline-slave", newNode.Hostname)
+
+	// 基础步骤也应执行并只针对新节点
+	for _, id := range []string{"node-bash", "node-firewall", "node-selinux", "node-swap",
+		"node-library", "node-os-safe-conf", "node-system-conf", "node-hostname", "node-hugepage"} {
+		assertStepStatus(t, pf, id, StatusPending)
+		assertTargetOnly(t, pf, id, newNode.Hostname)
+	}
+}
+
+// TestInitNodeRegistry_Kubernetes_ConditionsDisabled 验证 kubernetes 类型时：
+// hadoop_user 被 Scope 跳过；ntp/offline 在禁用时也被 Condition 跳过。
+func TestInitNodeRegistry_Kubernetes_ConditionsDisabled(t *testing.T) {
+	cfg := stubCfg()
+	cfg.Global.ClusterType = config.ClusterTypeKubernetes
+	cfg.Global.Offline = false
+	cfg.NtpServer = config.NodeRef{Enable: false}
+
+	newNode := newNodeFixture()
+	ctx := ctxWithTarget(cfg, t.TempDir(), &newNode)
+
+	pf, err := GeneratePlan("initNode", InitNodeRegistry, ctx)
+	require.NoError(t, err)
+
+	// hadoop_user 应跳过（ScopeHadoopOnly，但 type=kubernetes）
+	assertStepStatus(t, pf, "node-hadoopuser", StatusSkipped)
+	// ntp_slave 应跳过（NtpServer.Enable=false）
+	assertStepStatus(t, pf, "node-ntp-slave", StatusSkipped)
+	// offline_slave 应跳过（Global.Offline=false）
+	assertStepStatus(t, pf, "node-offline-slave", StatusSkipped)
+}
+
+// TestInitNodeRegistry_NtpOnly 验证只开 ntp 时，offline_slave 仍跳过，ntp_slave 执行。
+func TestInitNodeRegistry_NtpOnly(t *testing.T) {
+	cfg := stubCfg()
+	cfg.Global.ClusterType = config.ClusterTypeHadoop
+	cfg.Global.Offline = false
+	cfg.NtpServer = config.NodeRef{Enable: true, Node: "node1"}
+
+	newNode := newNodeFixture()
+	ctx := ctxWithTarget(cfg, t.TempDir(), &newNode)
+
+	pf, err := GeneratePlan("initNode", InitNodeRegistry, ctx)
+	require.NoError(t, err)
+
+	assertStepStatus(t, pf, "node-ntp-slave", StatusPending)
+	assertTargetOnly(t, pf, "node-ntp-slave", newNode.Hostname)
+	assertStepStatus(t, pf, "node-offline-slave", StatusSkipped)
+}
+
+// TestInitNodeRegistry_NtpSlave_ExcludesNtpServerItself 验证新节点恰好是 NTP server 时
+// ntp_slave 对新节点无目标（slavesOf 过滤掉同 IP）。
+func TestInitNodeRegistry_NtpSlave_ExcludesNtpServerItself(t *testing.T) {
+	cfg := stubCfg()
+	cfg.Global.ClusterType = config.ClusterTypeHadoop
+	cfg.Global.Offline = false
+	cfg.NtpServer = config.NodeRef{Enable: true, Node: "node1"}
+
+	// 目标新节点 IP 与 NTP server node1(10.0.0.1) 相同 → slavesOf 过滤
+	ntpServerNode := config.Host{Hostname: "newntpserver", IP: "10.0.0.1", Port: 22, User: "root", Password: "pass"}
+	ctx := ctxWithTarget(cfg, t.TempDir(), &ntpServerNode)
+
+	pf, err := GeneratePlan("initNode", InitNodeRegistry, ctx)
+	require.NoError(t, err)
+
+	// ntp_slave 仍 pending（Condition 通过），但 targets 为空（slavesOf 排除了自身）
+	assertStepStatus(t, pf, "node-ntp-slave", StatusPending)
+	for _, s := range pf.Steps {
+		if s.ID == "node-ntp-slave" {
+			assert.Empty(t, s.Targets, "NTP server 自身不应成为 slave target")
+		}
+	}
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+// assertTargetOnly 断言指定 step 的 Targets 恰好只包含期望的 hostname（单节点目标）。
+func assertTargetOnly(t *testing.T, pf *PlanFile, stepID, hostname string) {
+	t.Helper()
+	for _, s := range pf.Steps {
+		if s.ID == stepID {
+			assert.Equal(t, []string{hostname}, s.Targets,
+				"step %s 的 targets 应仅包含 %s", stepID, hostname)
+			return
+		}
+	}
+	t.Errorf("step %s not found in plan", stepID)
+}

--- a/datasophon-cli-go/internal/plan/types.go
+++ b/datasophon-cli-go/internal/plan/types.go
@@ -68,8 +68,9 @@ type BuildContext struct {
 	LocalIP                string
 	GlobalNodes            map[string]*config.Host
 	SSHAuthType            config.SSHAuthType
-	InitPathOverwriteForce bool // 仅本地 datasophon-init 目录覆盖控制，保留为运行时参数
+	InitPathOverwriteForce bool         // 仅本地 datasophon-init 目录覆盖控制，保留为运行时参数
 	DryRun                 bool
+	TargetNode             *config.Host // create node 单节点目标；initALL 不使用，置 nil 即可
 }
 
 // Action = 一次 (host, handler) 调用对。


### PR DESCRIPTION
## Summary

  - 新增 `-c/--config <file>` **配置模式**：从配置文件读取集群上下文，走 plan 引擎执行 12 步 `InitNodeRegistry` DAG，支持断点续跑
    - `cluster-type=hadoop` → 执行 `hadoop_user`（Scope 控制）
    - `ntpServer.enable=true` → 执行 `ntp_slave`（Condition 控制）
    - `global.offline=true` → 执行 `offline_slave`（Condition 控制）
    - 目标节点 IP 与配置文件 `nodes` 冲突时提示并**停止**
  - **手动模式**新增可选 `-t/--cluster-type`，默认不建 hadoop 用户，仅 `-t hadoop` 时创建；移除原先无条件执行 hadoop_user 的行为
  - 两模式均保持现有 5 个节点定位 flag（`--ip/--user/--password/--port/--hostname`）为必填

  ## 核心变更

  | 文件 | 操作 |
  |---|---|
  | `internal/plan/registry_node.go` | **新建** InitNodeRegistry 12 步 DAG |
  | `internal/plan/types.go` | BuildContext 追加 TargetNode 字段 |
  | `internal/plan/helpers.go` | 新增 targetNode nodeSelector |
  | `internal/cli/create/node.go` | 双模式分流 runConfigMode / runManualMode |
  | `internal/cli/create/initializer.go` | 新增 setupConfig（含重复检测）、initStandaloneNode 接受 clusterType 参数 |

  ## Test plan

  - [x] `go test ./... && go vet ./...` 通过（含新增 `registry_node_test.go` / `node_setup_test.go` 共 6 个新用例）
  - [ ] 配置模式 dry-run：hadoop+ntp+offline 全开的 cluster.yml，验证三步均规划执行且 target 仅新节点
  - [ ] 重复检测：`--ip` 取配置里已存在的 IP → 提示并非零退出
  - [ ] 手动模式：不传 `-t` → 无 hadoop_user；`-t hadoop` → 出现 hadoop_user