### PR TITLE
feat(monitoring): ZooKeeper 监控看板迁移至 OTel+Doris

### DIFF
--- a/datasophon-api/src/main/java/com/datasophon/api/observability/OtelMetricsQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/observability/OtelMetricsQueryService.java
@@ -88,12 +88,12 @@ public class OtelMetricsQueryService {
     static final Set<String> ALLOWED_ATTR_FILTER_KEYS =
             Set.of("group", "type", "mode", "path", "device", "fstype", "mountpoint", "state",
                     "code", "service", "route", "node", "consumer", "name",
-                    "op", "drive", "server", "status_class", "vol_name", "mp", "method");
+                    "op", "drive", "server", "status_class", "vol_name", "mp", "method", "pool", "gc");
 
     private static final List<String> INSTANT_SERIES_ATTR_KEYS =
             List.of("group", "type", "mode", "path", "device", "fstype", "mountpoint", "state",
                     "code", "service", "route", "node", "consumer", "name",
-                    "op", "drive", "server", "status_class", "vol_name", "mp", "method");
+                    "op", "drive", "server", "status_class", "vol_name", "mp", "method", "pool", "gc");
 
     private final ClusterServiceRoleInstanceService roleService;
     private final OtelDorisReaderFactory readerFactory;
@@ -188,7 +188,7 @@ public class OtelMetricsQueryService {
     /**
      * Range 查询，返回 Prometheus matrix 格式。
      *
-     * @param field histogram 表专用："count"/"sum" 表示对 histogram count/sum 列做 counter-rate；
+     * @param field histogram/summary 表专用："count"/"sum" 表示对 count/sum 列做 counter-rate；
      *              缺省或 "quantile" 表示按 {@code quantile} 查询分位数。
      */
     public PrometheusMatrixResult queryRange(Integer clusterId, String metric,
@@ -200,6 +200,29 @@ public class OtelMetricsQueryService {
                                              long start, long end, long step,
                                              String table, double quantile, String field) {
         JdbcClient client = createReader(clusterId);
+
+        List<String> validGroupBy = toValidGroupBy(groupByKeys);
+        boolean fieldRate = "count".equalsIgnoreCase(field) || "sum".equalsIgnoreCase(field);
+
+        if ("summary".equalsIgnoreCase(table) && fieldRate) {
+            String sql = buildRangeFieldRateSql(field.toLowerCase(), needsFilter(instance), needsFilter(job),
+                    filters, filtersNe, validGroupBy, "otel_metrics_summary");
+            JdbcClient.StatementSpec spec = client.sql(sql)
+                    .param("metric", metric)
+                    .param("start", start)
+                    .param("end", end)
+                    .param("step", step)
+                    .param("rateWindow", parseRateWindow(rateWindow));
+            if (needsFilter(instance)) {
+                spec = spec.param("instance", instance);
+            }
+            if (needsFilter(job)) {
+                spec = spec.param("job", job);
+            }
+            spec = bindAttrFilterParams(spec, filters, filtersNe);
+            List<Map<String, Object>> rows = spec.query().listOfRows();
+            return buildMatrix(rows, scale);
+        }
 
         if ("summary".equalsIgnoreCase(table)) {
             String sql = buildRangeSummarySql();
@@ -214,11 +237,9 @@ public class OtelMetricsQueryService {
         }
 
         if ("histogram".equalsIgnoreCase(table)) {
-            List<String> validGroupBy = toValidGroupBy(groupByKeys);
-            boolean fieldRate = "count".equalsIgnoreCase(field) || "sum".equalsIgnoreCase(field);
             String sql = fieldRate
-                    ? buildRangeHistogramFieldRateSql(field.toLowerCase(), needsFilter(instance), needsFilter(job),
-                            filters, filtersNe, validGroupBy)
+                    ? buildRangeFieldRateSql(field.toLowerCase(), needsFilter(instance), needsFilter(job),
+                            filters, filtersNe, validGroupBy, "otel_metrics_histogram")
                     : buildRangeHistogramSql(needsFilter(instance), needsFilter(job),
                             filters, filtersNe, validGroupBy);
             JdbcClient.StatementSpec spec = client.sql(sql)
@@ -241,7 +262,6 @@ public class OtelMetricsQueryService {
             return buildMatrix(rows, scale);
         }
 
-        List<String> validGroupBy = toValidGroupBy(groupByKeys);
         boolean hasRate = rateWindow != null && !rateWindow.isBlank();
         String otelTable = "sum".equalsIgnoreCase(table) ? "otel_metrics_sum" : "otel_metrics_gauge";
         String sql = hasRate
@@ -560,18 +580,18 @@ public class OtelMetricsQueryService {
     }
 
     /**
-     * histogram 表 {@code count}/{@code sum} 列的 counter-rate 查询。
+     * histogram/summary 表 {@code count}/{@code sum} 列的 counter-rate 查询。
      *
-     * <p>用于 Prometheus 经典 histogram 的 {@code rate(metric_count[...])} /
+     * <p>用于 Prometheus 经典 histogram/summary 的 {@code rate(metric_count[...])} /
      * {@code rate(metric_sum[...])} 语义。分区仍包含 {@code series_key}，先 per-series
-     * 求 rate，再按调用方 groupBy 粒度 SUM；reset 守卫统一使用 histogram {@code count} 列，
+     * 求 rate，再按调用方 groupBy 粒度 SUM；reset 守卫统一使用 {@code count} 列，
      * 即使请求的是 {@code sum} 字段也一样。
      */
-    static String buildRangeHistogramFieldRateSql(String field, boolean filterInstance, boolean filterJob,
-                                                  Map<String, String> filters, Map<String, String> filtersNe,
-                                                  List<String> groupByKeys) {
+    static String buildRangeFieldRateSql(String field, boolean filterInstance, boolean filterJob,
+                                         Map<String, String> filters, Map<String, String> filtersNe,
+                                         List<String> groupByKeys, String otelTable) {
         if (!"count".equals(field) && !"sum".equals(field)) {
-            throw new IllegalArgumentException("Unsupported histogram field: " + field);
+            throw new IllegalArgumentException("Unsupported field-rate field: " + field);
         }
         String extraSelect = buildExtraSelect(groupByKeys);
         String extraCols = buildExtraCols(groupByKeys);
@@ -586,7 +606,7 @@ public class OtelMetricsQueryService {
                 + extraSelect
                 + ",\n         CAST(attributes AS STRING) AS series_key,\n"
                 + "         UNIX_TIMESTAMP(timestamp) AS ts, count AS reset_count, " + field + " AS value\n"
-                + "  FROM otel.otel_metrics_histogram\n"
+                + "  FROM otel." + otelTable + "\n"
                 + "  WHERE metric_name = :metric\n"
                 + "    AND timestamp BETWEEN FROM_UNIXTIME(:start - :rateWindow) AND FROM_UNIXTIME(:end)\n"
                 + filterStr
@@ -719,9 +739,15 @@ public class OtelMetricsQueryService {
     static PrometheusVectorResult buildVector(List<Map<String, Object>> rows, double scale) {
         List<VectorSample> samples = new ArrayList<>(rows.size());
         for (Map<String, Object> row : rows) {
+            Object rawValue = row.get("value");
+            // 聚合查询（如 buildInstantAggSql 的 SUM/MAX）在无匹配行时仍返回一行，value 列为 SQL NULL；
+            // 与"无数据"同义，跳过该行而非抛异常，交给前端按空 vector 统一处理为 NaN。
+            if (rawValue == null) {
+                continue;
+            }
             Map<String, String> labels = extractLabels(row, Set.of("ts", "value"));
             long ts = ((Number) row.get("ts")).longValue();
-            double val = ((Number) row.get("value")).doubleValue() * scale;
+            double val = ((Number) rawValue).doubleValue() * scale;
             samples.add(new VectorSample(labels, new Object[]{ts, String.valueOf(val)}));
         }
         return PrometheusVectorResult.of(samples);
@@ -735,9 +761,13 @@ public class OtelMetricsQueryService {
     static PrometheusMatrixResult buildMatrix(List<Map<String, Object>> rows, double scale) {
         Map<String, MatrixSeries> seriesMap = new LinkedHashMap<>();
         for (Map<String, Object> row : rows) {
+            Object rawValue = row.get("value");
+            if (rawValue == null) {
+                continue;
+            }
             Map<String, String> labels = extractLabels(row, Set.of("bucket", "value"));
             long bucket = ((Number) row.get("bucket")).longValue();
-            double val = ((Number) row.get("value")).doubleValue() * scale;
+            double val = ((Number) rawValue).doubleValue() * scale;
             String key = labels.entrySet().stream()
                     .map(e -> e.getKey() + "=" + e.getValue())
                     .collect(Collectors.joining(","));

--- a/datasophon-api/src/test/java/com/datasophon/api/observability/OtelMetricsQueryServiceTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/observability/OtelMetricsQueryServiceTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.datasophon.api.observability.PrometheusMatrixResult.MatrixSeries;
 import com.datasophon.api.observability.PrometheusVectorResult.VectorSample;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -65,10 +66,12 @@ class OtelMetricsQueryServiceTest {
 
     @Test
     void rangeHistogramFieldRate_countAndSum_useHistogramTableAndSeriesKeyPartition() {
-        String countSql = OtelMetricsQueryService.buildRangeHistogramFieldRateSql(
-                "count", false, false, Map.of("vol_name", "prod-fs"), null, List.of("method"));
-        String sumSql = OtelMetricsQueryService.buildRangeHistogramFieldRateSql(
-                "sum", false, false, Map.of("vol_name", "prod-fs"), null, List.of("method"));
+        String countSql = OtelMetricsQueryService.buildRangeFieldRateSql(
+                "count", false, false, Map.of("vol_name", "prod-fs"), null,
+                List.of("method"), "otel_metrics_histogram");
+        String sumSql = OtelMetricsQueryService.buildRangeFieldRateSql(
+                "sum", false, false, Map.of("vol_name", "prod-fs"), null,
+                List.of("method"), "otel_metrics_histogram");
 
         for (String sql : List.of(countSql, sumSql)) {
             assertThat(sql).contains("FROM otel.otel_metrics_histogram");
@@ -92,6 +95,30 @@ class OtelMetricsQueryServiceTest {
         assertThat(sql).contains("attributes['vol_name']");
         assertThat(sql).contains("attributes['mp']");
         assertThat(sql).contains("attributes['method']");
+    }
+
+    @Test
+    void allowedAttrFilterKeys_includeZooKeeperJvmDimensions() {
+        assertThat(OtelMetricsQueryService.ALLOWED_ATTR_FILTER_KEYS)
+                .contains("pool", "gc");
+        String sql = OtelMetricsQueryService.buildRangeGaugeSql(
+                false, false, null, null, List.of("pool"), "otel_metrics_gauge");
+        assertThat(sql).contains("attributes['pool']");
+    }
+
+    @Test
+    void rangeSummaryFieldRate_count_useSummaryTableAndSeriesKeyPartition() {
+        String sql = OtelMetricsQueryService.buildRangeFieldRateSql(
+                "count", false, false, Map.of("gc", "G1 Young Generation"), null,
+                List.of("gc"), "otel_metrics_summary");
+
+        assertThat(sql).contains("FROM otel.otel_metrics_summary");
+        assertThat(sql).contains("CAST(attributes AS STRING) AS series_key");
+        assertThat(sql).contains("PARTITION BY instance, job, gc, series_key");
+        assertThat(sql).contains("reset_count >= prev_reset_count");
+        assertThat(sql).contains("SUM(rate) AS value");
+        assertThat(sql).contains("attributes['gc']");
+        assertThat(sql).contains("count AS value");
     }
 
     // ─── SQL 生成测试 ────────────────────────────────────────────────────────────
@@ -302,10 +329,12 @@ class OtelMetricsQueryServiceTest {
 
         @Test
         void rangeHistogramFieldRate_countAndSum_useHistogramTableAndSeriesKeyPartition() {
-            String countSql = OtelMetricsQueryService.buildRangeHistogramFieldRateSql(
-                    "count", false, false, Map.of("vol_name", "prod-fs"), null, List.of("method"));
-            String sumSql = OtelMetricsQueryService.buildRangeHistogramFieldRateSql(
-                    "sum", false, false, Map.of("vol_name", "prod-fs"), null, List.of("method"));
+            String countSql = OtelMetricsQueryService.buildRangeFieldRateSql(
+                    "count", false, false, Map.of("vol_name", "prod-fs"), null,
+                    List.of("method"), "otel_metrics_histogram");
+            String sumSql = OtelMetricsQueryService.buildRangeFieldRateSql(
+                    "sum", false, false, Map.of("vol_name", "prod-fs"), null,
+                    List.of("method"), "otel_metrics_histogram");
 
             for (String sql : List.of(countSql, sumSql)) {
                 assertThat(sql).contains("FROM otel.otel_metrics_histogram");
@@ -481,6 +510,18 @@ class OtelMetricsQueryServiceTest {
             assertThat(sql).contains("attributes['method']");
         }
 
+        @Test
+        void allowedAttrFilterKeys_includeZooKeeperJvmDimensions() {
+            assertThat(OtelMetricsQueryService.ALLOWED_ATTR_FILTER_KEYS)
+                    .contains("pool", "gc");
+            String memorySql = OtelMetricsQueryService.buildRangeGaugeSql(
+                    false, false, null, null, List.of("pool"), "otel_metrics_gauge");
+            String gcSql = OtelMetricsQueryService.buildRangeRateSql(
+                    false, false, null, null, List.of("gc"), "otel_metrics_sum");
+            assertThat(memorySql).contains("attributes['pool']");
+            assertThat(gcSql).contains("attributes['gc']");
+        }
+
         // ── 安全性测试 ──
 
         @Test
@@ -576,6 +617,28 @@ class OtelMetricsQueryServiceTest {
 
             assertThat(result.result()).hasSize(1);
             assertThat(result.result().get(0).metric()).containsEntry("mode", "idle");
+        }
+
+        @Test
+        void buildVector_nullValue_skipsRowInsteadOfThrowing() {
+            // 无 agg 聚合查询在评估窗口内无匹配行时仍返回一行、value 为 SQL NULL（如 SUM(空集)）；
+            // 复现真实报错：NullPointerException at buildVector 对 row.get("value") 直接拆箱。
+            Map<String, Object> row = new HashMap<>();
+            row.put("ts", 1000L);
+            row.put("value", null);
+            PrometheusVectorResult result = OtelMetricsQueryService.buildVector(List.of(row), 1.0);
+
+            assertThat(result.result()).isEmpty();
+        }
+
+        @Test
+        void buildMatrix_nullValue_skipsRowInsteadOfThrowing() {
+            Map<String, Object> row = new HashMap<>();
+            row.put("bucket", 1000L);
+            row.put("value", null);
+            PrometheusMatrixResult result = OtelMetricsQueryService.buildMatrix(List.of(row), 1.0);
+
+            assertThat(result.result()).isEmpty();
         }
 
         @Test

--- a/datasophon-ui-v2/src/locales/en-US/zookeeperMonitor.test.ts
+++ b/datasophon-ui-v2/src/locales/en-US/zookeeperMonitor.test.ts
@@ -22,14 +22,10 @@ describe('en-US ZooKeeper monitor locale', () => {
       'pages.zookeeperMonitor.panel.packets',
       'pages.zookeeperMonitor.panel.aliveConnectionsTrend',
       'pages.zookeeperMonitor.panel.connectionDataErrors',
-      'pages.zookeeperMonitor.panel.electionTime',
       'pages.zookeeperMonitor.panel.learnersObservers',
       'pages.zookeeperMonitor.panel.quorumCounts',
-      'pages.zookeeperMonitor.panel.fsyncTime',
-      'pages.zookeeperMonitor.panel.snapshotTime',
       'pages.zookeeperMonitor.panel.jvmMemoryPool',
       'pages.zookeeperMonitor.panel.gcCollectionRate',
-      'pages.zookeeperMonitor.panel.jvmGcPauseTime',
     ];
 
     for (const key of requiredKeys) {

--- a/datasophon-ui-v2/src/locales/en-US/zookeeperMonitor.ts
+++ b/datasophon-ui-v2/src/locales/en-US/zookeeperMonitor.ts
@@ -18,16 +18,12 @@ export default {
     'Alive Connections (Trend)',
   'pages.zookeeperMonitor.panel.connectionDataErrors':
     'Connection & Data Errors',
-  'pages.zookeeperMonitor.panel.electionTime': 'Election Time (avg ms)',
   'pages.zookeeperMonitor.panel.learnersObservers':
     'Learners / Synced Observers',
   'pages.zookeeperMonitor.panel.quorumCounts':
     'Commit / Snapshot / Proposal Count',
-  'pages.zookeeperMonitor.panel.fsyncTime': 'Fsync Time (avg ms)',
-  'pages.zookeeperMonitor.panel.snapshotTime': 'Snapshot Time (avg ms)',
   'pages.zookeeperMonitor.panel.jvmMemoryPool': 'JVM Memory Pool Usage',
   'pages.zookeeperMonitor.panel.gcCollectionRate': 'GC Collection Rate',
-  'pages.zookeeperMonitor.panel.jvmGcPauseTime': 'JVM GC Pause Time',
 
   'pages.zookeeperMonitor.toolbar.job': 'Job',
 };

--- a/datasophon-ui-v2/src/locales/zh-CN/zookeeperMonitor.test.ts
+++ b/datasophon-ui-v2/src/locales/zh-CN/zookeeperMonitor.test.ts
@@ -22,14 +22,10 @@ describe('zh-CN ZooKeeper monitor locale', () => {
       'pages.zookeeperMonitor.panel.packets',
       'pages.zookeeperMonitor.panel.aliveConnectionsTrend',
       'pages.zookeeperMonitor.panel.connectionDataErrors',
-      'pages.zookeeperMonitor.panel.electionTime',
       'pages.zookeeperMonitor.panel.learnersObservers',
       'pages.zookeeperMonitor.panel.quorumCounts',
-      'pages.zookeeperMonitor.panel.fsyncTime',
-      'pages.zookeeperMonitor.panel.snapshotTime',
       'pages.zookeeperMonitor.panel.jvmMemoryPool',
       'pages.zookeeperMonitor.panel.gcCollectionRate',
-      'pages.zookeeperMonitor.panel.jvmGcPauseTime',
     ];
 
     for (const key of requiredKeys) {

--- a/datasophon-ui-v2/src/locales/zh-CN/zookeeperMonitor.ts
+++ b/datasophon-ui-v2/src/locales/zh-CN/zookeeperMonitor.ts
@@ -16,14 +16,10 @@ export default {
   'pages.zookeeperMonitor.panel.packets': '数据包（接收 / 发送）',
   'pages.zookeeperMonitor.panel.aliveConnectionsTrend': '活跃连接趋势',
   'pages.zookeeperMonitor.panel.connectionDataErrors': '连接与数据错误',
-  'pages.zookeeperMonitor.panel.electionTime': '选举耗时（平均 ms）',
   'pages.zookeeperMonitor.panel.learnersObservers': 'Learner / 已同步 Observer',
   'pages.zookeeperMonitor.panel.quorumCounts': '提交 / 快照 / Proposal 计数',
-  'pages.zookeeperMonitor.panel.fsyncTime': 'Fsync 耗时（平均 ms）',
-  'pages.zookeeperMonitor.panel.snapshotTime': '快照耗时（平均 ms）',
   'pages.zookeeperMonitor.panel.jvmMemoryPool': 'JVM 内存池使用量',
   'pages.zookeeperMonitor.panel.gcCollectionRate': 'GC 收集速率',
-  'pages.zookeeperMonitor.panel.jvmGcPauseTime': 'JVM GC 暂停时间',
 
   'pages.zookeeperMonitor.toolbar.job': 'Job',
 };

--- a/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/hooks/useZKDashboard.ts
+++ b/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/hooks/useZKDashboard.ts
@@ -1,11 +1,7 @@
-import { useMemo } from 'react';
-import type { PrometheusVector } from '../../_shared/charts/promql';
-import {
-  deriveInstancesAndJobs,
-  replaceVars,
-} from '../../_shared/charts/promql';
+import { useEffect, useState } from 'react';
+import { fetchDorisLabels } from '../../_shared/dorisService';
 import type { TimeSeriesPoint } from '../../_shared/types';
-import { useDashboardData } from '../../_shared/useDashboardData';
+import { useDorisDashboardData } from '../../_shared/useDorisDashboardData';
 import { PANEL_QUERIES, type ZKDashboardVariables } from '../panelQueries';
 
 export interface ZKInstantValues {
@@ -26,14 +22,7 @@ export interface ZKDashboardData {
   error?: string;
 }
 
-const ALL_PANEL_IDS = Array.from(
-  { length: 23 },
-  (_, i) => `Z${String(i + 1).padStart(2, '0')}`,
-);
-
-const EXTRAS = {
-  up: { query: 'up', kind: 'instant' as const },
-};
+const ALL_PANEL_IDS = Object.keys(PANEL_QUERIES);
 
 export interface UseZKDashboardParams {
   variables: ZKDashboardVariables;
@@ -48,23 +37,29 @@ export function useZKDashboard({
   clusterId = 1,
   refreshKey,
 }: UseZKDashboardParams): ZKDashboardData {
-  const data = useDashboardData({
-    panelQueries: PANEL_QUERIES,
-    replaceVars: (promql, vars) =>
-      replaceVars(promql, vars, { instance: '.+', job: '.+' }),
-    variables: variables as unknown as Record<string, string>,
+  const [labels, setLabels] = useState<{ instances: string[]; jobs: string[] }>(
+    { instances: [], jobs: [] },
+  );
+
+  useEffect(() => {
+    fetchDorisLabels('jvm_threads_current', clusterId)
+      .then((res) => {
+        if (res?.data) setLabels(res.data);
+      })
+      .catch(() => {
+        // labels 查询失败不影响面板数据，静默降级
+      });
+  }, [clusterId, refreshKey]);
+
+  const data = useDorisDashboardData({
+    panelDescriptors: PANEL_QUERIES,
     panelIds: ALL_PANEL_IDS,
-    extras: EXTRAS,
+    instance: variables.instance,
+    job: variables.job,
     timeRange,
     clusterId,
     refreshKey,
   });
-
-  const { instances, jobs } = useMemo(() => {
-    const upVector = data.extras.up as PrometheusVector | undefined;
-    if (!upVector) return { instances: [], jobs: [] };
-    return deriveInstancesAndJobs(upVector);
-  }, [data.extras]);
 
   return {
     instant: {
@@ -76,8 +71,8 @@ export function useZKDashboard({
       openFileDescriptors: data.instant.Z06 ?? 0,
     },
     series: data.series,
-    instances,
-    jobs,
+    instances: labels.instances,
+    jobs: labels.jobs,
     loading: data.loading,
     error: data.error,
   };

--- a/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/index.tsx
+++ b/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/index.tsx
@@ -58,9 +58,7 @@ const zkQuorumColors = {
 
 const integerFormatter = (value: number) => value.toFixed(0);
 const millisecondFormatter = (value: number) => `${value.toFixed(1)}ms`;
-const wholeMillisecondFormatter = (value: number) => `${value.toFixed(0)}ms`;
 const opsFormatter = (value: number) => `${value.toFixed(3)}/s`;
-const pauseFormatter = (value: number) => `${value.toFixed(2)}ms/s`;
 
 function formatDuration(ms: number): string {
   const seconds = Math.floor(ms / 1000);
@@ -271,14 +269,7 @@ const ZooKeeperDashboard: FC = () => {
       </Row>
 
       <Row gutter={MONITOR_ROW_GUTTER}>
-        <PanelCol span={8}>
-          <TimeSeriesPanel
-            title={t('pages.zookeeperMonitor.panel.electionTime')}
-            data={series.Z16}
-            yFormatter={wholeMillisecondFormatter}
-          />
-        </PanelCol>
-        <PanelCol span={8}>
+        <PanelCol span={12}>
           <TimeSeriesPanel
             title={t('pages.zookeeperMonitor.panel.learnersObservers')}
             data={series.Z17}
@@ -286,7 +277,7 @@ const ZooKeeperDashboard: FC = () => {
             colorMap={zkLearnerColors}
           />
         </PanelCol>
-        <PanelCol span={8}>
+        <PanelCol span={12}>
           <TimeSeriesPanel
             title={t('pages.zookeeperMonitor.panel.quorumCounts')}
             data={series.Z18}
@@ -298,41 +289,17 @@ const ZooKeeperDashboard: FC = () => {
 
       <Row gutter={MONITOR_ROW_GUTTER}>
         <PanelCol span={12}>
-          <TimeSeriesPanel
-            title={t('pages.zookeeperMonitor.panel.fsyncTime')}
-            data={series.Z19}
-            yFormatter={millisecondFormatter}
-          />
-        </PanelCol>
-        <PanelCol span={12}>
-          <TimeSeriesPanel
-            title={t('pages.zookeeperMonitor.panel.snapshotTime')}
-            data={series.Z20}
-            yFormatter={millisecondFormatter}
-          />
-        </PanelCol>
-      </Row>
-
-      <Row gutter={MONITOR_ROW_GUTTER}>
-        <PanelCol span={8}>
           <AreaPanel
             title={t('pages.zookeeperMonitor.panel.jvmMemoryPool')}
             data={series.Z21}
             yFormatter={formatBytes}
           />
         </PanelCol>
-        <PanelCol span={8}>
+        <PanelCol span={12}>
           <TimeSeriesPanel
             title={t('pages.zookeeperMonitor.panel.gcCollectionRate')}
             data={series.Z22}
             yFormatter={opsFormatter}
-          />
-        </PanelCol>
-        <PanelCol span={8}>
-          <TimeSeriesPanel
-            title={t('pages.zookeeperMonitor.panel.jvmGcPauseTime')}
-            data={series.Z23}
-            yFormatter={pauseFormatter}
           />
         </PanelCol>
       </Row>

--- a/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/mock/zkMockData.test.ts
+++ b/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/mock/zkMockData.test.ts
@@ -13,10 +13,22 @@ describe('ZooKeeperMonitor mock data', () => {
     });
   });
 
-  it('covers every range panel from Z07 through Z23', () => {
-    const expectedIds = Array.from({ length: 17 }, (_, index) =>
-      `Z${String(index + 7).padStart(2, '0')}`,
-    );
+  it('covers every remaining range panel (Z16/Z19/Z20/Z23 移除,见 panelQueries.test.ts)', () => {
+    const expectedIds = [
+      'Z07',
+      'Z08',
+      'Z09',
+      'Z10',
+      'Z11',
+      'Z12',
+      'Z13',
+      'Z14',
+      'Z15',
+      'Z17',
+      'Z18',
+      'Z21',
+      'Z22',
+    ];
 
     expect(Object.keys(zkSeriesData).sort()).toEqual(expectedIds);
     for (const id of expectedIds) {

--- a/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/mock/zkMockData.ts
+++ b/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/mock/zkMockData.ts
@@ -116,9 +116,6 @@ export const zkSeriesData: Record<string, TimeSeriesPoint[]> = {
     ...genSeries('unrecoverable', 0, 0, 92),
     ...genSeries('digest_mismatch', 0, 0, 93),
   ],
-  Z16: genSeries('election_time', 0, 0, 100, {
-    spikes: [{ near: 72, value: 180 }],
-  }),
   Z17: [
     ...genSeries('learners', 2, 0.2, 110, { min: 2, max: 2 }),
     ...genSeries('synced_observers', 0, 0, 111),
@@ -128,19 +125,6 @@ export const zkSeriesData: Record<string, TimeSeriesPoint[]> = {
     ...genCounter('snapshots', 0.01, 121),
     ...genCounter('proposals', 36, 122),
   ],
-  Z19: [
-    ...genSeries('zk-1:7000', 3, 4, 130, {
-      max: 20,
-      spikes: [{ near: 82, value: 20 }],
-    }),
-    ...genSeries('zk-2:7000', 2.5, 3, 131, { max: 8 }),
-    ...genSeries('zk-3:7000', 3.2, 3, 132, { max: 8 }),
-  ],
-  Z20: [
-    ...genSeries('zk-1:7000', 360, 180, 140, { min: 200, max: 500 }),
-    ...genSeries('zk-2:7000', 330, 160, 141, { min: 200, max: 500 }),
-    ...genSeries('zk-3:7000', 380, 170, 142, { min: 200, max: 500 }),
-  ],
   Z21: [
     ...genSeries('G1 Old Gen', 120 * 1024 * 1024, 12 * 1024 * 1024, 150),
     ...genSeries('Metaspace', 60 * 1024 * 1024, 5 * 1024 * 1024, 151),
@@ -149,10 +133,5 @@ export const zkSeriesData: Record<string, TimeSeriesPoint[]> = {
   Z22: [
     ...genSeries('G1 Young Generation', 0.01, 0.006, 160, { max: 0.03 }),
     ...genSeries('G1 Old Generation', 0, 0.001, 161, { max: 0.002 }),
-  ],
-  Z23: [
-    ...genSeries('zk-1:7000', 0.5, 0.25, 170, { max: 1 }),
-    ...genSeries('zk-2:7000', 0.45, 0.25, 171, { max: 1 }),
-    ...genSeries('zk-3:7000', 0.55, 0.25, 172, { max: 1 }),
   ],
 };

--- a/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/panelQueries.test.ts
+++ b/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/panelQueries.test.ts
@@ -1,44 +1,108 @@
 import { describe, expect, it } from 'vitest';
-import { PANEL_QUERIES, replaceZKVars } from './panelQueries';
+import { PANEL_QUERIES } from './panelQueries';
 
 describe('ZooKeeperMonitor panel queries', () => {
-  it('defines every ZooKeeper dashboard panel from Z01 through Z23', () => {
-    const expectedIds = Array.from(
-      { length: 23 },
-      (_, index) => `Z${String(index + 1).padStart(2, '0')}`,
-    );
+  it('defines every remaining ZooKeeper dashboard panel (election_time/fsynctime/snapshottime/jvm_pause_time_ms 因采集侧整体丢弃已移除 Z16/Z19/Z20/Z23,详见 zookeeper-otel-verification.md)', () => {
+    const expectedIds = [
+      'Z01',
+      'Z02',
+      'Z03',
+      'Z04',
+      'Z05',
+      'Z06',
+      'Z07',
+      'Z08',
+      'Z09',
+      'Z10',
+      'Z11',
+      'Z12',
+      'Z13',
+      'Z14',
+      'Z15',
+      'Z17',
+      'Z18',
+      'Z21',
+      'Z22',
+    ];
 
     expect(Object.keys(PANEL_QUERIES).sort()).toEqual(expectedIds);
   });
 
-  it('replaces ZooKeeper variables without requiring an interval variable', () => {
-    expect(
-      replaceZKVars('avg_latency{instance=~"$instance",job=~"$job"}', {
-        instance: 'zk-1:7000',
-        job: 'zookeeper',
-      }),
-    ).toBe('avg_latency{instance=~"zk-1:7000",job=~"zookeeper"}');
-
-    expect(
-      replaceZKVars('watch_count{instance=~"$instance",job=~"$job"}', {}),
-    ).toBe('watch_count{instance=~".+",job=~".+"}');
+  it('Z01-Z06 are instant Doris descriptors', () => {
+    expect(PANEL_QUERIES.Z01).toMatchObject({
+      type: 'instant',
+      metric: 'quorum_size',
+      agg: 'max',
+    });
+    expect(PANEL_QUERIES.Z02).toMatchObject({
+      type: 'instant',
+      metric: 'leader_uptime',
+      agg: 'max',
+    });
+    expect(PANEL_QUERIES.Z03).toMatchObject({
+      type: 'instant',
+      metric: 'jvm_threads_current',
+      agg: 'max',
+    });
+    expect(PANEL_QUERIES.Z04).toMatchObject({
+      type: 'instant',
+      metric: 'jvm_threads_deadlocked',
+      agg: 'max',
+    });
+    expect(PANEL_QUERIES.Z05).toMatchObject({
+      type: 'instant',
+      metric: 'num_alive_connections',
+      agg: 'sum',
+    });
+    expect(PANEL_QUERIES.Z06).toMatchObject({
+      type: 'instant',
+      metric: 'open_file_descriptor_count',
+      agg: 'max',
+    });
   });
 
-  it('keeps the error and JVM panels required by the spec', () => {
-    expect(PANEL_QUERIES.Z15).toMatchObject({
-      type: 'multi-range',
-      queries: [
-        { label: 'conn_rejected' },
-        { label: 'conn_drop' },
-        { label: 'unrecoverable' },
-        { label: 'digest_mismatch' },
-      ],
-    });
+  it('Z15/Z18 use sum table without rate for cumulative counters', () => {
+    for (const id of ['Z15', 'Z18']) {
+      const panel = PANEL_QUERIES[id];
+      expect(panel.type).toBe('multi-range');
+      if (panel.type !== 'multi-range') continue;
+      for (const query of panel.queries) {
+        expect(query.table).toBe('sum');
+        expect(query.rate).toBeUndefined();
+      }
+    }
+  });
 
-    expect(PANEL_QUERIES.Z21).toMatchObject({
-      type: 'range',
-      promql: 'jvm_memory_pool_bytes_used{instance=~"$instance",job=~"$job"}',
-      seriesKey: 'pool',
-    });
+  it('Z13 packets_received/sent 是 gauge 类型(真实沙箱验证:# TYPE packets_sent gauge,非 counter),不带 table/rate', () => {
+    const panel = PANEL_QUERIES.Z13;
+    expect(panel.type).toBe('multi-range');
+    if (panel.type !== 'multi-range') return;
+    for (const query of panel.queries) {
+      expect(query.table).toBeUndefined();
+      expect(query.rate).toBeUndefined();
+    }
+  });
+
+  it('Z21/Z22 carry JVM attribute groupBy and summary count field', () => {
+    const z21 = PANEL_QUERIES.Z21;
+    expect(z21.type).toBe('multi-range');
+    if (z21.type === 'multi-range') {
+      expect(z21.queries[0]).toMatchObject({
+        metric: 'jvm_memory_pool_bytes_used',
+        groupBy: ['pool'],
+      });
+    }
+
+    const z22 = PANEL_QUERIES.Z22;
+    expect(z22.type).toBe('multi-range');
+    if (z22.type === 'multi-range') {
+      expect(z22.queries[0]).toMatchObject({
+        metric: 'jvm_gc_collection_seconds',
+        table: 'summary',
+        field: 'count',
+        rate: '5m',
+        groupBy: ['gc'],
+      });
+    }
   });
 });

--- a/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/panelQueries.ts
+++ b/datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/panelQueries.ts
@@ -1,201 +1,125 @@
-import type { PanelDef } from '../_shared/panelTypes';
+import type { DorisPanelDescriptor } from '../_shared/dorisService';
+
+export type { DorisPanelDescriptor as ZKPanelDescriptor };
 
 export interface ZKDashboardVariables {
   instance: string;
   job: string;
 }
 
-export function replaceZKVars(
-  promql: string,
-  variables: Partial<ZKDashboardVariables>,
-): string {
-  return promql
-    .replace(/\$instance/g, variables.instance || '.+')
-    .replace(/\$job/g, variables.job || '.+');
-}
-
-export const PANEL_QUERIES: Record<string, PanelDef> = {
-  Z01: {
-    type: 'instant',
-    promql: 'max(quorum_size{instance=~"$instance",job=~"$job"})',
-  },
-  Z02: {
-    type: 'instant',
-    promql: 'leader_uptime{instance=~"$instance",job=~"$job"}',
-  },
-  Z03: {
-    type: 'instant',
-    promql: 'max(jvm_threads_current{instance=~"$instance",job=~"$job"})',
-  },
-  Z04: {
-    type: 'instant',
-    promql: 'max(jvm_threads_deadlocked{instance=~"$instance",job=~"$job"})',
-  },
-  Z05: {
-    type: 'instant',
-    promql: 'sum(num_alive_connections{instance=~"$instance",job=~"$job"})',
-  },
+export const PANEL_QUERIES: Record<string, DorisPanelDescriptor> = {
+  Z01: { type: 'instant', metric: 'quorum_size', agg: 'max' },
+  Z02: { type: 'instant', metric: 'leader_uptime', agg: 'max' },
+  Z03: { type: 'instant', metric: 'jvm_threads_current', agg: 'max' },
+  Z04: { type: 'instant', metric: 'jvm_threads_deadlocked', agg: 'max' },
+  Z05: { type: 'instant', metric: 'num_alive_connections', agg: 'sum' },
   Z06: {
     type: 'instant',
-    promql:
-      'max(open_file_descriptor_count{instance=~"$instance",job=~"$job"})',
+    metric: 'open_file_descriptor_count',
+    agg: 'max',
   },
+
   Z07: {
-    type: 'range',
-    promql: 'outstanding_requests{instance=~"$instance",job=~"$job"}',
-    seriesKey: 'instance',
+    type: 'multi-range',
+    queries: [{ label: 'outstanding_requests', metric: 'outstanding_requests' }],
   },
   Z08: {
     type: 'multi-range',
     queries: [
-      {
-        label: 'max',
-        promql: 'max_latency{instance=~"$instance",job=~"$job"}',
-      },
-      {
-        label: 'avg',
-        promql: 'avg_latency{instance=~"$instance",job=~"$job"}',
-      },
-      {
-        label: 'min',
-        promql: 'min_latency{instance=~"$instance",job=~"$job"}',
-      },
+      { label: 'max', metric: 'max_latency' },
+      { label: 'avg', metric: 'avg_latency' },
+      { label: 'min', metric: 'min_latency' },
     ],
   },
   Z09: {
     type: 'multi-range',
     queries: [
-      {
-        label: 'global',
-        promql: 'global_sessions{instance=~"$instance",job=~"$job"}',
-      },
-      {
-        label: 'local',
-        promql: 'local_sessions{instance=~"$instance",job=~"$job"}',
-      },
+      { label: 'global', metric: 'global_sessions' },
+      { label: 'local', metric: 'local_sessions' },
     ],
   },
   Z10: {
     type: 'multi-range',
     queries: [
-      {
-        label: 'znode_count',
-        promql: 'znode_count{instance=~"$instance",job=~"$job"}',
-      },
-      {
-        label: 'ephemerals',
-        promql: 'ephemerals_count{instance=~"$instance",job=~"$job"}',
-      },
+      { label: 'znode_count', metric: 'znode_count' },
+      { label: 'ephemerals', metric: 'ephemerals_count' },
     ],
   },
   Z11: {
-    type: 'range',
-    promql: 'approximate_data_size{instance=~"$instance",job=~"$job"}',
+    type: 'multi-range',
+    queries: [{ label: 'approximate_data_size', metric: 'approximate_data_size' }],
   },
   Z12: {
-    type: 'range',
-    promql: 'watch_count{instance=~"$instance",job=~"$job"}',
-    seriesKey: 'instance',
+    type: 'multi-range',
+    queries: [{ label: 'watch_count', metric: 'watch_count' }],
   },
   Z13: {
     type: 'multi-range',
     queries: [
-      {
-        label: 'received',
-        promql: 'packets_received{instance=~"$instance",job=~"$job"}',
-      },
-      {
-        label: 'sent',
-        promql: 'packets_sent{instance=~"$instance",job=~"$job"}',
-      },
+      { label: 'received', metric: 'packets_received' },
+      { label: 'sent', metric: 'packets_sent' },
     ],
   },
   Z14: {
-    type: 'range',
-    promql: 'num_alive_connections{instance=~"$instance",job=~"$job"}',
-    seriesKey: 'instance',
+    type: 'multi-range',
+    queries: [
+      { label: 'num_alive_connections', metric: 'num_alive_connections' },
+    ],
   },
   Z15: {
     type: 'multi-range',
     queries: [
-      {
-        label: 'conn_rejected',
-        promql: 'connection_rejected{instance=~"$instance",job=~"$job"}',
-      },
-      {
-        label: 'conn_drop',
-        promql: 'connection_drop_count{instance=~"$instance",job=~"$job"}',
-      },
+      { label: 'conn_rejected', metric: 'connection_rejected', table: 'sum' },
+      { label: 'conn_drop', metric: 'connection_drop_count', table: 'sum' },
       {
         label: 'unrecoverable',
-        promql: 'unrecoverable_error_count{instance=~"$instance",job=~"$job"}',
+        metric: 'unrecoverable_error_count',
+        table: 'sum',
       },
       {
         label: 'digest_mismatch',
-        promql: 'digest_mismatches_count{instance=~"$instance",job=~"$job"}',
+        metric: 'digest_mismatches_count',
+        table: 'sum',
       },
     ],
-  },
-  Z16: {
-    type: 'range',
-    promql: 'irate(election_time_sum{instance=~"$instance",job=~"$job"}[1m])',
   },
   Z17: {
     type: 'multi-range',
     queries: [
-      {
-        label: 'learners',
-        promql: 'max(learners{instance=~"$instance",job=~"$job"})',
-      },
-      {
-        label: 'synced_observers',
-        promql: 'max(synced_observers{instance=~"$instance",job=~"$job"})',
-      },
+      { label: 'learners', metric: 'learners' },
+      { label: 'synced_observers', metric: 'synced_observers' },
     ],
   },
   Z18: {
     type: 'multi-range',
     queries: [
+      { label: 'commits', metric: 'commit_count', table: 'sum' },
+      { label: 'snapshots', metric: 'snap_count', table: 'sum' },
+      { label: 'proposals', metric: 'proposal_count', table: 'sum' },
+    ],
+  },
+  Z21: {
+    type: 'multi-range',
+    queries: [
       {
-        label: 'commits',
-        promql: 'commit_count{instance=~"$instance",job=~"$job"}',
-      },
-      {
-        label: 'snapshots',
-        promql: 'snap_count{instance=~"$instance",job=~"$job"}',
-      },
-      {
-        label: 'proposals',
-        promql: 'proposal_count{instance=~"$instance",job=~"$job"}',
+        label: 'pool',
+        metric: 'jvm_memory_pool_bytes_used',
+        groupBy: ['pool'],
       },
     ],
   },
-  Z19: {
-    type: 'range',
-    promql: 'irate(fsynctime_sum{instance=~"$instance",job=~"$job"}[1m])',
-    seriesKey: 'instance',
-  },
-  Z20: {
-    type: 'range',
-    promql: 'rate(snapshottime_sum{instance=~"$instance",job=~"$job"}[5m])',
-    seriesKey: 'instance',
-  },
-  Z21: {
-    type: 'range',
-    promql: 'jvm_memory_pool_bytes_used{instance=~"$instance",job=~"$job"}',
-    seriesKey: 'pool',
-  },
   Z22: {
-    type: 'range',
-    promql:
-      'rate(jvm_gc_collection_seconds_count{instance=~"$instance",job=~"$job"}[5m])',
-    seriesKey: 'gc',
-  },
-  Z23: {
-    type: 'range',
-    promql:
-      'rate(jvm_pause_time_ms_sum{instance=~"$instance",job=~"$job"}[5m])',
-    seriesKey: 'instance',
+    type: 'multi-range',
+    queries: [
+      {
+        label: 'gc',
+        metric: 'jvm_gc_collection_seconds',
+        table: 'summary',
+        field: 'count',
+        rate: '5m',
+        groupBy: ['gc'],
+      },
+    ],
   },
 };
 

--- a/datasophon-worker/src/main/resources/templates/otelcol.ftl
+++ b/datasophon-worker/src/main/resources/templates/otelcol.ftl
@@ -44,6 +44,24 @@ processors:
   memory_limiter:
     check_interval: 5s
     limit_mib: ${memLimitMiB}
+  # Prometheus Summary 类型指标从未被观测到时 quantile 恒为 NaN（count=0），下游 exporter 序列化
+  # NaN 到 JSON 会整批失败并触发 retry 风暴，拖累同一 pipeline 里其它正常指标的导出（沙箱实测确认，
+  # 见 docs/monitoring/zookeeper-otel-verification.md）。丢弃这类空 Summary 数据点不影响其余指标；
+  # 注意：Summary 若历史上被观测过(count>0)之后又因滑动窗口衰减出 NaN 的情况，本处理器无法覆盖
+  # (OTTL 当前版本不支持读写 quantile_values 这一 slice-of-struct 字段)。
+  filter/drop_empty_summary:
+    metrics:
+      datapoint:
+        - 'metric.type == METRIC_DATA_TYPE_SUMMARY and count == 0'
+  # ZooKeeper 的 election_time/fsynctime/snapshottime/jvm_pause_time_ms 即使 count>0 也会因滑动
+  # 时间窗衰减回 NaN(上面 filter/drop_empty_summary 覆盖不到),且当前 OTTL 版本无法读写
+  # quantile_values 字段清空 NaN。直接整体丢弃这 4 个指标,不导入 Doris，避免拖累同一 pipeline
+  # 里其它指标的导出(详见 docs/monitoring/zookeeper-otel-verification.md)。代价:ZooKeeper 看板
+  # Z16/Z19/Z20/Z23 面板将永远无数据。
+  filter/drop_zk_decaying_summary:
+    metrics:
+      metric:
+        - 'name == "election_time" or name == "fsynctime" or name == "snapshottime" or name == "jvm_pause_time_ms"'
   batch:
     send_batch_size: ${batchSize}
     timeout: 5s
@@ -104,7 +122,7 @@ service:
   pipelines:
     metrics:
       receivers: [otlp, prometheus/self<#if (localScrapeJobsYaml!"")?has_content>, prometheus/local</#if>]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, filter/drop_empty_summary, filter/drop_zk_decaying_summary, batch]
       exporters: [<#if (exporterMode!"s3") == "doris">doris<#else>awss3</#if>]
     metrics/host:
       receivers: [host_metrics]

--- a/datasophon-worker/src/test/java/com/datasophon/worker/test/OtelcolTemplateTest.java
+++ b/datasophon-worker/src/test/java/com/datasophon/worker/test/OtelcolTemplateTest.java
@@ -14,7 +14,7 @@ import freemarker.template.Template;
 import freemarker.template.TemplateExceptionHandler;
 
 public class OtelcolTemplateTest {
-    
+
     private Configuration buildCfg() throws Exception {
         Configuration cfg = new Configuration(Configuration.VERSION_2_3_30);
         cfg.setClassForTemplateLoading(OtelcolTemplateTest.class, "/templates");
@@ -22,15 +22,15 @@ public class OtelcolTemplateTest {
         cfg.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
         return cfg;
     }
-    
+
     private String render() throws Exception {
         return render("s3");
     }
-    
+
     private String render(String exporterMode) throws Exception {
         return render(exporterMode, "");
     }
-    
+
     private String render(String exporterMode, String localScrapeJobsYaml) throws Exception {
         Configuration cfg = buildCfg();
         Template tpl = cfg.getTemplate("otelcol.ftl");
@@ -54,7 +54,7 @@ public class OtelcolTemplateTest {
         tpl.process(data, out);
         return out.toString();
     }
-    
+
     @Test
     public void renders_env_file_with_aws_credentials() throws Exception {
         Configuration cfg = buildCfg();
@@ -72,7 +72,7 @@ public class OtelcolTemplateTest {
         assertTrue(env.contains("OTEL_DORIS_USER=otel_collector"));
         assertTrue(env.contains("OTEL_DORIS_PASSWORD=generated-secret"));
     }
-    
+
     @Test
     public void renders_s3_mode_with_persistent_queue() throws Exception {
         String yaml = render();
@@ -99,11 +99,11 @@ public class OtelcolTemplateTest {
         assertTrue(yaml.contains("traces:"));
         assertTrue(yaml.contains("exporters: [awss3]"));
     }
-    
+
     @Test
     public void renders_doris_mode_without_plaintext_password() throws Exception {
         String yaml = render("doris");
-        
+
         assertTrue(yaml.contains("doris:"));
         assertTrue(yaml.contains("endpoint: http://doris-fe:8030"));
         assertTrue(yaml.contains("database: otel"));
@@ -113,41 +113,41 @@ public class OtelcolTemplateTest {
         assertTrue(yaml.contains("exporters: [doris]"));
         assertTrue(!yaml.contains("generated-secret"));
     }
-    
+
     @Test
     public void renders_local_prometheus_receiver_when_local_scrape_jobs_exist() throws Exception {
         String yaml = render("doris", "        - job_name: 'DataNode'\n"
                 + "          static_configs:\n"
                 + "            - targets: ['127.0.0.1:9101']\n");
-        
+
         assertTrue(yaml.contains("prometheus/local:"));
         assertTrue(yaml.contains("job_name: 'DataNode'"));
         assertTrue(yaml.contains("receivers: [otlp, prometheus/self, prometheus/local]"));
     }
-    
+
     @Test
     public void skips_local_prometheus_receiver_when_local_scrape_jobs_are_empty() throws Exception {
         String yaml = render("doris", "");
-        
+
         assertTrue(!yaml.contains("prometheus/local:"));
         assertTrue(yaml.contains("receivers: [otlp, prometheus/self]"));
     }
-    
+
     @Test
     public void local_scrape_jobs_are_independent_from_exporter_mode() throws Exception {
         String yaml = render("s3", "        - job_name: 'DataNode'\n"
                 + "          static_configs:\n"
                 + "            - targets: ['127.0.0.1:9101']\n");
-        
+
         assertTrue(yaml.contains("prometheus/local:"));
         assertTrue(yaml.contains("exporters: [awss3]"));
         assertTrue(yaml.contains("receivers: [otlp, prometheus/self, prometheus/local]"));
     }
-    
+
     @Test
     public void renders_hostmetrics_receiver_with_dedicated_pipeline() throws Exception {
         String yaml = render();
-        
+
         // host_metrics receiver 替代 node_exporter 采集主机 CPU/内存/磁盘/网络
         // （receiver 名用 host_metrics，非 hostmetrics：后者是 v0.154.0 已废弃的 legacy alias）
         assertTrue(yaml.contains("host_metrics:"));
@@ -164,7 +164,32 @@ public class OtelcolTemplateTest {
         // node_exporter 相关端口已彻底退役
         assertTrue(!yaml.contains(":9100"));
     }
-    
+
+    @Test
+    public void renders_filter_processor_dropping_empty_summary_datapoints() throws Exception {
+        String yaml = render("doris");
+
+        // 空 Summary(count=0,quantile 恒为 NaN)会让 dorisexporter 序列化 JSON 时报
+        // "unsupported value: NaN" 导致整批导出失败并拖累同一 pipeline 里其它指标(实测确认，
+        // 见 docs/monitoring/zookeeper-otel-verification.md)
+        assertTrue(yaml.contains("filter/drop_empty_summary:"));
+        assertTrue(yaml.contains("metric.type == METRIC_DATA_TYPE_SUMMARY and count == 0"));
+        assertTrue(yaml.contains(
+                "processors: [memory_limiter, filter/drop_empty_summary, filter/drop_zk_decaying_summary, batch]"));
+    }
+
+    @Test
+    public void renders_filter_processor_dropping_zk_decaying_summary_metrics() throws Exception {
+        String yaml = render("doris");
+
+        // election_time/fsynctime/snapshottime/jvm_pause_time_ms 即使 count>0 也会因滑动时间窗衰减
+        // 回 NaN，filter/drop_empty_summary 覆盖不到；OTTL 当前版本又无法清空 quantile_values，
+        // 因此直接整体丢弃这 4 个指标，不导入 Doris（详见 docs/monitoring/zookeeper-otel-verification.md）
+        assertTrue(yaml.contains("filter/drop_zk_decaying_summary:"));
+        assertTrue(yaml.contains(
+                "name == \"election_time\" or name == \"fsynctime\" or name == \"snapshottime\" or name == \"jvm_pause_time_ms\""));
+    }
+
     @Test
     public void renders_raw_yaml_override_verbatim() throws Exception {
         Configuration cfg = buildCfg();
@@ -173,9 +198,9 @@ public class OtelcolTemplateTest {
         String rawYaml = "receivers:\n  otlp:\nexporters:\n  debug:\n";
         data.put("rawYaml", rawYaml);
         StringWriter out = new StringWriter();
-        
+
         tpl.process(data, out);
-        
+
         assertEquals(rawYaml, out.toString());
     }
 }

--- a/deploy/compose/conf/otelcol-juicefs.yaml
+++ b/deploy/compose/conf/otelcol-juicefs.yaml
@@ -39,6 +39,35 @@ receivers:
               labels:
                 instance: obs-juicefs
 
+  # ZooKeeper 指标端点：PrometheusMetricsProvider 暴露 :7000/metrics。job_name 固定为 "ZkServer"，
+  # 与生产 OtelScrapeConfigBuilder 的角色名一致，验证 docs/monitoring/zookeeper-otel-verification.md。
+  #
+  # metric_relabel_configs 的 keep 白名单仅沙箱验证使用（生产 OtelScrapeConfigBuilder 不做任何过滤，
+  # 抓取整份 /metrics）：ZK 单节点/低负载下有 ~45 个内部 processor 队列类 Summary 指标（如
+  # prep_processor_queue_size、proposal_latency 等，均带 quantile 但从未被观测到）永久输出
+  # `{quantile="0.5"} NaN`，导致 dorisexporter 对 otel_metrics_summary 整批 Stream Load 因
+  # `json: unsupported value: NaN` 失败（已在本沙箱实测确认 summary 表 0 行，即使 gauge/sum 表已有
+  # 数千行）。白名单只保留本次 23 个面板实际用到的指标，绕开这些不相关指标的 NaN 干扰，
+  # 便于验证 Z16/Z19/Z20/Z22/Z23 的 summary 表查询 SQL 本身是否正确。
+  prometheus/zookeeper:
+    config:
+      scrape_configs:
+        - job_name: ZkServer
+          scrape_interval: 15s
+          metrics_path: /metrics
+          static_configs:
+            - targets: ["obs-zookeeper:7000"]
+              labels:
+                instance: obs-zookeeper
+          metric_relabel_configs:
+            - source_labels: [__name__]
+              # 注:election_time/jvm_pause_time_ms 本沙箱下永久 NaN(单节点无选举、无可测量 GC 停顿),
+              # 暂从白名单剔除以隔离验证 fsynctime/snapshottime/jvm_gc_collection_seconds 三个可产生
+              # 真实非 NaN 值的 summary 指标;两者的查询 SQL 逻辑与其余三个完全一致(同一 buildRangeFieldRateSql),
+              # 无法在本沙箱端到端验证不代表实现有问题。
+              regex: '(quorum_size|leader_uptime|jvm_threads_current|jvm_threads_deadlocked|num_alive_connections|open_file_descriptor_count|outstanding_requests|max_latency|avg_latency|min_latency|global_sessions|local_sessions|znode_count|ephemerals_count|approximate_data_size|watch_count|packets_received|packets_sent|connection_rejected|connection_drop_count|unrecoverable_error_count|digest_mismatches_count|learners|synced_observers|commit_count|snap_count|proposal_count|fsynctime(_count|_sum)?|snapshottime(_count|_sum)?|jvm_memory_pool_bytes_used|jvm_gc_collection_seconds(_count|_sum)?)'
+              action: keep
+
   # Doris FE + BE Prometheus 指标采集。
   # obs-doris-fe/be 既充当存储 Doris 又充当被监控 Doris（沙箱一机两用）。
   # static labels 镜像旧 prometheus.ftl configs/doris.json 的 group/job/instance 维度，
@@ -80,6 +109,30 @@ processors:
   memory_limiter:
     check_interval: 5s
     limit_mib: 256
+  # NaN 分位数丢弃：dorisexporter 把 NaN 序列化进 Stream Load JSON 时报
+  # "json: unsupported value: NaN"，导致整批导出失败并触发 retry 风暴，backoff 持续增长直到
+  # sending_queue 被占满、连累 gauge/sum 表的新数据也停止写入（详见
+  # docs/monitoring/zookeeper-otel-verification.md 的采集侧缺陷记录）。
+  # 仅覆盖"Summary 从未被观测到，count=0 且 quantile 恒为 NaN"这一种成因；
+  # ZK 的 election_time/fsynctime/snapshottime/jvm_pause_time_ms 即使 count>0（历史上观测过），
+  # quantile 计算用滑动时间窗口衰减，窗口内无新观测时仍会衰减回 NaN，此类无法用本处理器覆盖——
+  # 已验证 OTTL 在这个 collector 版本里不支持对 quantile_values（slice of struct）做 set() 清空，
+  # 也不支持索引访问 quantile_values[0]（"the keys indexing quantile_values were not used by the
+  # context"），没找到能只处理这一种情况又不影响其它 Summary 消费方（DorisMonitor/NexusMonitor 的
+  # JVM/Jetty timer 面板）的可靠写法，详见验证文档"采集侧发现的真实缺陷"章节。
+  filter/drop_empty_summary:
+    metrics:
+      datapoint:
+        - 'metric.type == METRIC_DATA_TYPE_SUMMARY and count == 0'
+  # ZK 的 election_time/fsynctime/snapshottime/jvm_pause_time_ms 即使 count>0 也会因滑动时间窗衰减
+  # 回 NaN(上面 filter/drop_empty_summary 覆盖不到),且 OTTL 在本 collector 版本不支持读写
+  # quantile_values 字段清空 NaN。用户拍板直接整体丢弃这 4 个指标,不导入 Doris,从根上避免它们
+  # 拖累同一 pipeline 里其它指标的导出(详见 docs/monitoring/zookeeper-otel-verification.md)。
+  # 代价:ZK 看板 Z16/Z19/Z20/Z23 面板将永远无数据。
+  filter/drop_zk_decaying_summary:
+    metrics:
+      metric:
+        - 'name == "election_time" or name == "fsynctime" or name == "snapshottime" or name == "jvm_pause_time_ms"'
   batch:
     timeout: 5s
   # 沙箱身份写死为 sandbox-node；生产 otelcol.ftl 用真实 hostname（见 resource/host_metrics 注释）
@@ -136,8 +189,8 @@ service:
                 port: 8888
   pipelines:
     metrics:
-      receivers: [prometheus/juicefs, prometheus/doris, otlp]
-      processors: [memory_limiter, batch]
+      receivers: [prometheus/juicefs, prometheus/zookeeper, prometheus/doris, otlp]
+      processors: [memory_limiter, filter/drop_empty_summary, filter/drop_zk_decaying_summary, batch]
       exporters: [doris, debug]
     metrics/host:
       receivers: [host_metrics]

--- a/deploy/compose/docker-compose.observability.yml
+++ b/deploy/compose/docker-compose.observability.yml
@@ -197,6 +197,28 @@ services:
         condition: service_completed_successfully
     restart: on-failure
 
+  # ─── ZooKeeper(单节点,PrometheusMetricsProvider 暴露 :7000/metrics,otelcol 抓取) ──
+  # 用于验证 docs/monitoring/zookeeper-otel-migration-tasks.md 的 Task 0/3。
+  # ZOO_CFG_EXTRA 由官方 docker-entrypoint.sh 原样追加进 zoo.cfg,与生产
+  # ZOOKEEPER/service_ddl.json 的 metricsProvider.className/httpPort 参数对齐。
+  obs-zookeeper:
+    image: zookeeper:3.8
+    container_name: obs-zookeeper
+    environment:
+      - ZOO_STANDALONE_ENABLED=true
+      - ZOO_4LW_COMMANDS_WHITELIST=*
+      - ZOO_CFG_EXTRA=metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider metricsProvider.httpPort=7000 metricsProvider.httpHost=0.0.0.0
+    ports:
+      - "2181:2181"
+      - "17000:7000"   # 宿主 7000 被 macOS ControlCenter(AirPlay)占用,改用 17000;容器内网仍是 7000
+    networks:
+      - obs_net
+    healthcheck:
+      test: ["CMD-SHELL", "echo ruok | nc -w 2 localhost 2181 | grep imok"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   # ─── OTel Collector（JuiceFS metrics → dorisexporter → Doris） ───────────────
   obs-otelcol:
     image: otel/opentelemetry-collector-contrib:0.154.0

--- a/docs/monitoring/zookeeper-otel-migration-tasks.md
+++ b/docs/monitoring/zookeeper-otel-migration-tasks.md
@@ -1,0 +1,221 @@
+# ZooKeeper 监控看板迁移任务清单(Prometheus → OTel + Doris)
+
+> 执行者:Codex。产出后由 Claude 检查/审查。
+> 本文件自包含:含背景、已核实事实、逐任务改动点、验收命令与判据。
+
+## 背景
+
+可观测重构 epic(`refactor/observability-otel`)已把 metrics 采集换成 OTel Collector 直写 Doris。
+`datasophon-ui-v2` 的 ZooKeeperMonitor 仍走 `PrometheusProxyV2Controller` 透传 Prometheus,过渡期无数据。
+本任务把它迁到"查 Doris `otel_metrics_*` 表"取数(与 RustFS/JuiceFS/Nexus 看板对齐),恢复数据,**视觉布局不变**。
+
+**分支**:从 `main` 新建 `feat/zookeeper-monitor-otel-doris`。已创建并切换到该分支。
+
+## ⚠️ 2026-07-04 真实沙箱验证结果(已用 docker compose 搭建,详见 `docs/monitoring/zookeeper-otel-verification.md`)
+
+以下"已拍板决策"1-4 中有两处推断被真实数据证伪,代码已按验证结果修正,不要再按最初的决策 2/3 实现:
+
+- **决策 1(Z22 summary count-rate)基本正确**,唯一偏差是 metric_name 多写了 `_count` 后缀——真实
+  metric_name 是 `jvm_gc_collection_seconds`(不带后缀),已修正。
+- **决策 2 完全错误**:`election_time_sum`/`fsynctime_sum`/`snapshottime_sum`/`jvm_pause_time_ms_sum`
+  实测 `/metrics` 端点均为 `# TYPE ... summary`(真 Prometheus Summary,非独立 Counter),真实 metric_name
+  不带 `_sum` 后缀。已改为 `table=summary,field=sum`,metric 去掉 `_sum` 后缀。
+- **决策 3 部分错误**:`packets_received`/`packets_sent` 实测为 `# TYPE ... gauge`(不是 counter),
+  已去掉 Z13 的 `table:'sum'`,恢复默认 gauge。其余 4 个(connection_rejected 等)+ 3 个(commit/snap/
+  proposal_count)确认是真 counter,决策 3 对这 7 个是对的。
+- 额外发现一个**采集侧真实缺陷**(超出本任务范围,未修复):`otel_metrics_summary` 表的 Stream Load 会被
+  同批次任意一个 NaN 分位数值整体拖垮(ZK 大量低频 processor 指标零观测时输出 NaN),生产
+  `otelcol.ftl` 同样没有 NaN 处理,详见验证文档"⚠️ 采集侧发现的真实缺陷"节。
+
+新增沙箱资产(已提交,可复用):`deploy/compose/docker-compose.observability.yml` 的 `obs-zookeeper` 服务 +
+`deploy/compose/conf/otelcol-juicefs.yaml` 的 `prometheus/zookeeper` 抓取任务(含验证专用白名单 relabel)。
+
+## 已拍板决策(本次由 Claude 按现状推断拍板,Codex 实现时按此执行;如与真实环境冲突以 Task 0 验证结果为准并回填此文档)
+
+> **以下 1-4 条为实现前的初始推断,已被上方"真实沙箱验证结果"部分修正/证实,请以验证结果为准。**
+
+1. **Z22(GC Collection Rate)需要新的"summary 表 count-rate"能力**:`jvm_gc_collection_seconds_count`
+   来自 Java simpleclient `hotspot.GarbageCollectorExports`,以 **Prometheus `Summary`** 类型注册
+   (即使不配置分位数,仍会带 `# TYPE jvm_gc_collection_seconds summary`),OTel prometheusreceiver 会把它
+   落进 `otel_metrics_summary` 表而非 `otel_metrics_sum`。该表已有 `count BIGINT`/`sum DOUBLE` 列(与
+   `otel_metrics_histogram` 结构一致),但现有 `buildRangeSummarySql` 只读 `quantile_values`(此指标未配置
+   分位数,该数组为空),读不到 `count`。**需仿照 `buildRangeHistogramFieldRateSql` 新增等价的 summary
+   count-rate 查询路径**(见 Task 1.2)。
+2. **其余 `_sum` 后缀指标按 ZK 自有 Counter 处理,非 Prometheus Summary**:`election_time_sum` /
+   `fsynctime_sum` / `snapshottime_sum` / `jvm_pause_time_ms_sum` 是 ZooKeeper 自身 `SummarySet`/
+   `JvmPauseMonitor` 指标体系导出的**独立 Counter**(与 `avg_latency`/`min_latency`/`max_latency` 是各自
+   独立指标同理),**不是** Prometheus Summary 类型的自动 `_sum` 后缀,因此落 `otel_metrics_sum` 表,直接用
+   现有 `table=sum` + `rateWindow` 能力(`buildRangeRateSql`),**不需要新代码**。
+3. **`packets_received`/`packets_sent`/`connection_rejected`/`connection_drop_count`/
+   `unrecoverable_error_count`/`digest_mismatches_count`/`commit_count`/`snap_count`/`proposal_count`
+   是普通 Counter**,落 `otel_metrics_sum` 表。原 Prometheus 面板(Z13/Z15/Z18)直接读原始累计值(不做
+   rate),迁移后用 `table=sum` **不传 `rateWindow`**(即走 `buildRangeGaugeSql` 对 `otel_metrics_sum` 表原样
+   取值,语义与原面板一致,详见 §9.4 联调注释"cumulative")。
+4. **JVM 基础指标(threads/deadlocked/memory pool/open fd)走 hotspot `DefaultExports`/
+   `MemoryPoolsExports`/`ThreadExports`,均为真 Gauge**,落 `otel_metrics_gauge`,`table` 用默认值,无需改动。
+5. **`fetchDorisLabels` 枚举 instance/job 用 `jvm_threads_current` 作基准指标**(而非 `leader_uptime` 或
+   `quorum_size`):后两者语义上只应由 leader/健康法定节点上报,枚举出的 instance 列表可能不全;
+   `jvm_threads_current` 来自 JVM 进程级 hotspot 指标,每个存活节点必上报,更适合做标签枚举基准
+   (同 RustFS 用 `rustfs_process_uptime_seconds`、Nexus 用 `jvm_vm_uptime` 的先例)。
+6. **验证门禁 = 推导 + 交付 SQL**(当前无运行中的观测沙箱 + ZooKeeper 可核对,§已确认无 docker 容器在跑)。
+   按上述推断实现,产出验证文档待真实环境回填结论。
+
+## 已核实关键事实(实现前必读,避免踩坑)
+
+1. **采集侧零改动**:`ZOOKEEPER/ZkServer` 角色(`package/raw/meta/datacluster-physical/ZOOKEEPER/service_ddl.json`
+   L15)已声明 `jmxPortParam: "metricsProvider.httpPort"`(默认 `7000`),`OtelScrapeConfigBuilder` 自动纳入
+   抓取,`job_name` = 角色名 `ZkServer`。抓取路径用 `DEFAULT_METRICS_PATH = "/metrics"`
+   (`OtelScrapeConfigBuilder.java` 无 ZooKeeper 的 `PATH_OVERRIDES` 条目,与 ZK 原生
+   `PrometheusMetricsProvider` 默认路径一致)。**不改 `OtelScrapeConfigBuilder`。**
+2. **落表/label**:`service_name='ZkServer'`(顶层列,抓取型 job 名);`instance` →
+   `resource_attributes['service']['instance']['id']`(标准 prometheusreceiver 语义,与 JuiceFS/Nexus 一致);
+   `pool`(JVM 内存池名)、`gc`(GC 名)→ 普通 `attributes` VARIANT。
+3. **后端白名单缺口**:`OtelMetricsQueryService.java` L88–96 的 `ALLOWED_ATTR_FILTER_KEYS` 与
+   `INSTANT_SERIES_ATTR_KEYS` **不含 `pool`/`gc`**,必须两处都补(否则 Z21/Z22 的 `groupBy` 被
+   `toValidGroupBy` 静默过滤掉,退化成单一序列)。
+4. **本次唯一新增查询能力 = summary 表 count-rate**(Z22 专用,见"已拍板决策"1)。**没有 histogram 相关工作**
+   ——ZooKeeper 面板中没有任何真正的 Prometheus Histogram 指标,不涉及 `otel_metrics_histogram`。
+5. **`ZKDashboardToolbar.tsx` 是跨看板共享组件,禁止删除/改签名/搬迁**:被 `ApisixMonitor`、`MySQLMonitor`、
+   `NexusMonitor`、`RustfsMonitor` 的 `index.tsx` 直接 `import ... from '../ZooKeeperMonitor/toolbar/ZKDashboardToolbar'`
+   引用。其 props(`instances`/`selectedInstances`/`onInstancesChange`/`jobs`/`selectedJobs`/`onJobsChange`
+   等)与数据源无关,Doris 迁移**不需要改这个文件**,只需保证 `useZKDashboard` 仍然吐出同形状的
+   `instances: string[]` / `jobs: string[]`。
+6. **`replaceZKVars` 整体删除**:Doris 描述符走结构化 `filters`/`groupBy` 参数,不再拼接 PromQL 字符串,
+   该函数与 PromQL 字符串替换机制一起废弃(仿 JuiceFS/RustFS 迁移,不保留 `promql` 字段)。
+7. **共享层能力已就绪**,直接复用:`_shared/dorisService.ts`(`queryDorisInstant`/`queryDorisRange`/
+   `fetchDorisLabels`)、`_shared/useDorisDashboardData.ts`(`instant`/`multi-range` 两种描述符,含并发限流、
+   `mergeNamedSeries` 正确拼接 groupBy 维度到 series 标签、`series_key` 分区已修复历史串线 bug)。
+
+---
+
+## 任务清单
+
+### Task 0 — 验证文档(不阻塞后续)
+
+- [x] 新建 `docs/monitoring/zookeeper-otel-verification.md`,用 docker compose 真实沙箱跑通(非"仿 RustFS 待回填"):
+  - [x] Step1:三张表 COUNT(*) 已确认(gauge/sum 表数千行;summary 表需绕开采集侧 NaN 缺陷才有数据,详见验证文档)。
+  - [x] Step2:枚举三张表 `DISTINCT metric_name` 完成,**发现两处推断错误**(见上方"真实沙箱验证结果")。
+  - [x] Step3:`jvm_memory_pool_bytes_used` 含 `pool`、`jvm_gc_collection_seconds` 含 `gc` 均已确认。
+  - [x] Step4:面板指标存在性逐一核对(quorum_size/leader_uptime/learners/synced_observers 因单节点沙箱
+    无法验证,标注为已知局限,非代码缺陷)。
+- **判据**:文档产出且结论均为真实回填(非占位)。✅达成。
+
+### Task 1 — 后端(datasophon-api)
+
+改文件:`observability/OtelMetricsQueryService.java`、`controller/v2/OtelMetricsQueryController.java`、
+`observability/OtelMetricsQueryServiceTest.java`。
+
+- [x] **1.1 白名单**:`ALLOWED_ATTR_FILTER_KEYS` 与 `INSTANT_SERIES_ATTR_KEYS` **两处**各加 `"pool", "gc"`。
+  真实沙箱确认 `pool`/`gc` 属性键名与实测一致。
+- [x] **1.2 summary 表 count-rate 能力**(Task 0 验证确认"已拍板决策 1"成立,已实现):
+  - 现有 `buildRangeHistogramFieldRateSql(String field, ...)`(L570)硬编码 `FROM otel.otel_metrics_histogram`。
+    **重构为接受表名参数**(如加一个 `otelTable` 形参,仿 `buildRangeGaugeSql`/`buildRangeRateSql` 已有的
+    表参数化写法),使同一份 CTE(`series_key` 分区 + reset 守卫)可同时服务 histogram 和 summary 两张表——
+    两表列结构完全一致(`count BIGINT`/`sum DOUBLE`/`attributes`/`metric_name`/`timestamp`)。
+  - Z22 只需要 `field="count"` 分支,不需要 `field="sum"`,但保持函数签名通用(不为 Z22 单独砍能力)。
+  - 命名建议:重命名为 `buildRangeFieldRateSql(String field, ..., String otelTable)`,调用处传
+    `"otel_metrics_histogram"` 或 `"otel_metrics_summary"`。
+- [x] **1.3 接入 `queryRange` 分发**:`summary`+field-rate 分支已加在 `histogram` 分支之前,`summary`
+  纯分位数分支保持不变。已用真实 Doris 数据手工执行生成的 SQL 验证 rate 计算正确(见验证文档 Step4)。
+- [x] **1.4 Controller**:`field` 参数透传到 `table=summary` 场景无需改动,dispatch 顺序已核对正确。
+- [x] **1.5 测试**:
+  - [x] `rangeSummaryFieldRate_count_useSummaryTableAndSeriesKeyPartition` 已加(顶层+嵌套类各一份)。
+  - [x] `allowedAttrFilterKeys_includeZooKeeperJvmDimensions` 已加,纳入 `pool`/`gc`。
+- **验收**:`JAVA_HOME=$JH21 ./mvnw -pl datasophon-api -am test "-Dtest=OtelMetricsQueryServiceTest,OtelMetricsQueryServiceTest\$*,OtelMetricsQueryControllerTest" -s ~/.m2/setting.xml` 64+8=72 个测试全绿(**注意**:`-Dtest=OtelMetricsQueryServiceTest` 不带 `$*` 通配符时 Surefire 默认不跑 3 个 `@Nested` 内部类,只会显示 7/64,是本项目已知的 Surefire 过滤器坑,不是测试变少);`spotless:check` 通过。
+
+### Task 2 — 前端(datasophon-ui-v2)
+
+目录 `datasophon-ui-v2/src/pages/monitor/ZooKeeperMonitor/`,**照 `RustfsMonitor/` 结构改写**
+(descriptor + 共享 hook,取数走 `_shared/dorisService.ts` + `_shared/useDorisDashboardData.ts`)。
+**`index.tsx` 的 JSX 布局、`toolbar/ZKDashboardToolbar.tsx`、颜色/阈值/formatter 常量一律不动**——
+只改数据来源。
+
+- [x] **2.1 `panelQueries.ts` 重写**(删 `replaceZKVars` 与所有 `promql` 字符串字段,改
+  `Record<string, DorisPanelDescriptor>`,`import type { DorisPanelDescriptor } from '../_shared/dorisService'`)。
+  23 个面板:
+
+  | ID  |            面板             |       类型       |                                                      metric / 关键字段                                                       |
+  |-----|---------------------------|----------------|--------------------------------------------------------------------------------------------------------------------------|
+  | Z01 | Quorum Size               | instant        | `quorum_size`,agg=max                                                                                                    |
+  | Z02 | Leader Uptime             | instant        | `leader_uptime`,agg=max                                                                                                  |
+  | Z03 | JVM Threads Current       | instant        | `jvm_threads_current`,agg=max                                                                                            |
+  | Z04 | JVM Threads Deadlocked    | instant        | `jvm_threads_deadlocked`,agg=max                                                                                         |
+  | Z05 | Alive Connections         | instant        | `num_alive_connections`,agg=sum                                                                                          |
+  | Z06 | Open File Descriptors     | instant        | `open_file_descriptor_count`,agg=max                                                                                     |
+  | Z07 | Outstanding Requests      | multi-range(1) | `outstanding_requests`(gauge,by instance 天然多序列)                                                                          |
+  | Z08 | Latency (max/avg/min)     | multi-range(3) | `max_latency`/`avg_latency`/`min_latency`(gauge)                                                                         |
+  | Z09 | Sessions (global/local)   | multi-range(2) | `global_sessions`/`local_sessions`(gauge)                                                                                |
+  | Z10 | Znodes                    | multi-range(2) | `znode_count`/`ephemerals_count`(gauge)                                                                                  |
+  | Z11 | Approximate Data Size     | multi-range(1) | `approximate_data_size`(gauge)                                                                                           |
+  | Z12 | Watch Count               | multi-range(1) | `watch_count`(gauge,by instance)                                                                                         |
+  | Z13 | Packets (Recv/Sent)       | multi-range(2) | `packets_received`/`packets_sent`,**默认 gauge**(实测 `# TYPE ... gauge`,非 counter,不带 table/rate)                            |
+  | Z14 | Alive Connections (Trend) | multi-range(1) | `num_alive_connections`(gauge,by instance)                                                                               |
+  | Z15 | Connection & Data Errors  | multi-range(4) | `connection_rejected`/`connection_drop_count`/`unrecoverable_error_count`/`digest_mismatches_count`,table=sum,**无 rate** |
+  | Z16 | Election Time             | multi-range(1) | `election_time`,table=summary,field=sum,rate=1m(**实测为 Summary,非 `_sum` 后缀 Counter**)                                     |
+  | Z17 | Learners/Synced Observers | multi-range(2) | `learners`/`synced_observers`(gauge)                                                                                     |
+  | Z18 | Quorum Counts             | multi-range(3) | `commit_count`/`snap_count`/`proposal_count`,table=sum,**无 rate**                                                        |
+  | Z19 | Fsync Time                | multi-range(1) | `fsynctime`,table=summary,field=sum,rate=1m,by instance(**实测为 Summary**)                                                 |
+  | Z20 | Snapshot Time             | multi-range(1) | `snapshottime`,table=summary,field=sum,rate=5m,by instance(**实测为 Summary**)                                              |
+  | Z21 | JVM Memory Pool Usage     | multi-range(1) | `jvm_memory_pool_bytes_used`(gauge),groupBy=['pool']                                                                     |
+  | Z22 | GC Collection Rate        | multi-range(1) | `jvm_gc_collection_seconds`,table=summary,field=count,rate=5m,groupBy=['gc']                                             |
+  | Z23 | JVM GC Pause Time         | multi-range(1) | `jvm_pause_time_ms`,table=summary,field=sum,rate=5m,by instance(**实测为 Summary**)                                         |
+
+  > "由 instance 天然多序列"的面板(Z07/Z12/Z14/Z19/Z20/Z23)**不需要**显式 `groupBy`——后端 SELECT 已含
+  > `instance`/`job` 列,多节点自然产生多条 series,与 RustFS R13/R14/R17 同理。
+  > Z16/`election_time` 在单节点沙箱下 count 恒为 0(standalone 模式不发生选举),真实多节点集群才有非零值,
+  > 且受"采集侧真实缺陷"影响(NaN 拖垮整批 summary 写入),详见验证文档。
+
+- [x] **2.2 `hooks/useZKDashboard.ts` 重写**:
+  - [x] `useDashboardData` → `useDorisDashboardData`(单次拉全部 23 面板)。
+  - [x] instance/job 下拉:`fetchDorisLabels('jvm_threads_current')` 派生(见"已拍板决策 5")。
+  - [x] 保持返回形状不变,`index.tsx` 无需改动解构逻辑。
+- [x] **2.3 `index.tsx`**:确认无需改动,已用 `git diff` 核实未被触碰。
+- [x] **2.4 `panelQueries.test.ts`** 改写:23 个 panelId 全定义;Z15/Z18 `table:'sum'` 不带 rate;
+  Z13 确认默认 gauge(不带 table/rate);Z16/Z19/Z20/Z23 `table:'summary'`+`field:'sum'`+对应 rate;
+  Z21/Z22 `groupBy` 正确,Z22 `table:'summary'`+`field:'count'`。删除 `replaceZKVars` 测试。
+- [x] **2.5 locale**:`src/locales/{zh-CN,en-US}/zookeeperMonitor.ts` 确认未改动,面板标题/数量不变。
+- **验收**:`npm run test`(vitest)149/149 全绿;`npm run lint`(biome+tsc)0 错误。真实结果,非自报。
+
+### Task 3 — 端到端验证(有环境时)
+
+- [x] 用 `deploy/compose/docker-compose.observability.yml`(新增 `obs-zookeeper` + otelcol
+  `prometheus/zookeeper` 抓取任务)搭建真实沙箱,`zkCli.sh` 打真实读写流量。
+- [x] 逐面板确认 Doris 有数据:gauge 表 7000+ 行覆盖 Z01-Z14/Z17/Z21 全部相关指标(quorum_size/
+  leader_uptime/learners/synced_observers 因单节点无 quorum 缺失,标为已知局限);sum 表覆盖 Z15/Z18;
+  summary 表(绕开采集侧 NaN 缺陷后)覆盖 fsynctime/snapshottime/jvm_gc_collection_seconds。
+- [x] Z22 落表推断(otel_metrics_summary)**确认成立**,唯一偏差是 metric_name 多写了 `_count` 后缀,已修正。
+  额外发现 Z16/Z19/Z20/Z23 的"独立 Counter"假设是错的,已按真实类型改为 `table=summary,field=sum`;
+  Z13 的"counter"假设也是错的,已改回默认 gauge。
+- [x] 手工执行 `buildRangeFieldRateSql` 生成的 SQL 模板(summary 表 + groupBy=['gc'])直接对 Doris 跑,
+  验证 rate 计算与 `gc` 维度拆分均正确(见验证文档 Step4)。
+- [x] 回填 Task 0 验证文档结论——已用真实数据全部回填,无"待回填"占位。
+
+> 状态:已完成(2026-07-04)。额外发现并记录一个采集侧真实缺陷(NaN 拖垮 otel_metrics_summary 整批写入),
+> 超出本任务范围,已在验证文档单独标注,未修复,需团队后续决策。
+
+---
+
+## 复用清单(不要重写)
+
+- 后端:`OtelMetricsQueryService`/`OtelMetricsQueryController`(仅加白名单键 + summary field-rate 能力)。
+- 前端取数:`_shared/dorisService.ts`、`_shared/useDorisDashboardData.ts`。
+- 前端 UI:`ZooKeeperMonitor/index.tsx`(布局/颜色/阈值/formatter 全部保留)、
+  `ZooKeeperMonitor/toolbar/ZKDashboardToolbar.tsx`(**禁止修改**,见"已核实关键事实 5")。
+- locale:`src/locales/{zh-CN,en-US}/zookeeperMonitor.ts`(预计免改)。
+- 模板参考:`RustfsMonitor/`(最新纯 Doris 看板,instant+multi-range 组合的最佳范例)。
+
+## 已知局限(不在本任务修)
+
+- Z22 的 summary count-rate 是本次唯一新增后端能力,若真实环境指标落表与推断不符需按 Task 3 回退。
+- 单节点沙箱验证不到多节点场景下 `by instance` 多序列是否正确(与历史 RustFS/JuiceFS 迁移同样局限)。
+
+## Claude 审查要点(实现后)
+
+1. 白名单两处集合都改了(`pool`/`gc` 漏一处则 Z21/Z22 的 `groupBy` 被静默丢弃退化成单一序列)。
+2. Z13/Z15/Z18 **确认没有**误加 `rateWindow`(它们是"显示累计值"语义,不是 rate)。
+3. Z22 的新 summary field-rate 查询是否正确复用了 histogram field-rate 的 `series_key` 分区 + reset 守卫
+   (否则多 GC 收集器名称跨 series 串线)。
+4. Task 0 验证文档的 Step2① 结论是否与"已拍板决策 1"一致;若不一致,确认 Task 3 的回退是否已执行。
+5. `index.tsx`/`ZKDashboardToolbar.tsx` 确实未被改动(除非类型报错才做最小修补)。
+6. 后端 java 测试 + 前端 vitest/lint/tsc 全绿;spotless 通过。
+

--- a/docs/monitoring/zookeeper-otel-verification.md
+++ b/docs/monitoring/zookeeper-otel-verification.md
@@ -92,7 +92,7 @@ obs-zookeeper  ZkServer  G1 Young Generation   1783153620   0.0000
 `pool`/`gc` 白名单生效，`gc` 维度正确拆分成独立 series。GC rate 全为 0 属预期（沙箱运行期内只发生过
 1 次 Young GC，验证窗口内无新增收集事件）。
 
-## ⚠️ 采集侧发现的真实缺陷（超出本任务范围，需团队决策，未修复）
+## ⚠️ 采集侧发现的真实缺陷（已修复，见下方两个 ✅ 章节）
 
 **`otel_metrics_summary` 表的 Stream Load 写入会被同批次里任意一个 `NaN` 值的 datapoint 整体拖垮。**
 
@@ -100,28 +100,122 @@ ZooKeeper 内部有约 45 个 processor 队列类 Summary 指标（`prep_process
 `proposal_latency`、`election_time`、`jvm_pause_time_ms` 等）在从未被观测到时会输出
 `{quantile="0.5",} NaN`（Prometheus Summary 无观测值时的标准行为）。otelcol 的 dorisexporter 把这类
 NaN datapoint 序列化进 Stream Load 的 JSON payload 时报
-`"error": "json: unsupported value: NaN"`，导致**整个 `otel_metrics_summary` 表的这次 Stream Load
-请求失败**（`gauge`/`sum` 表因走独立 Stream Load 请求不受影响，已实测确认）。
+`"error": "json: unsupported value: NaN"`，导致**这次批次导出请求整体失败并重试**。
 
-实测现象：未过滤白名单前，`otel_metrics_summary` 表对 `ZkServer` 长期 0 行，即使
-`jvm_gc_collection_seconds`（本身从不产生 NaN，因为它的 Summary 未配置任何 quantile 分位数）也被
-连带拖累无法落库。加 `metric_relabel_configs` 白名单只保留会产生真实数值的指标后，summary 表才恢复写入。
+**⚠️ 2026-07-04 二次实测更正**：最初观察窗口较短，误判为"gauge/sum 表因走独立 Stream Load 请求不受
+影响"。**实际是同一条 `metrics` pipeline（`prometheus/juicefs`+`prometheus/zookeeper`+`prometheus/doris`+
+`otlp` 四个 receiver 共用一个 `batch` 处理器 + 一个 `doris` exporter）**，NaN 导出失败触发
+`retry_on_failure` 重试，重试 backoff 持续增长（实测从数秒涨到 40+ 秒），`sending_queue`
+（`num_consumers:4, queue_size:500`）逐渐被阻塞的重试请求占满后，**gauge/sum 表的新数据最终也会
+停止写入**——本次调试会话中实测 `num_alive_connections`（纯 gauge,与 summary 无关）数据陈旧到
+980 秒（远超代码 300 秒新鲜度窗口），触发下方 NPE 报错。`docker compose restart obs-otelcol`
+可临时恢复,但因 NaN 源头指标（`election_time`/`jvm_pause_time_ms` 等）持续产生,**重启后几分钟内
+会再次堵塞**,不是一次性修复。
 
 **影响面**：
 1. `election_time`（Z16）在单节点/无选举场景下**几乎不可能有非 NaN 值**——任何长期稳定运行、选举窗口
-已滑出 Summary 统计窗口的 ZK 集群，只要该指标一变回 NaN，整个 summary 表当次批次的写入就会失败，
-包括本该正常写入的 `fsynctime`/`snapshottime`/`jvm_gc_collection_seconds`。
+已滑出 Summary 统计窗口的 ZK 集群，只要该指标一变回 NaN，就会触发上述连锁反应，最终拖累整条 pipeline
+（含 gauge/sum 表）的新数据写入，不只是 summary 表。
 2. `jvm_pause_time_ms`（Z23）同理——只要该 ZK 节点近期没有可观测的 JVM 暂停，也会永久 NaN。
-3. 检查 `datasophon-worker/.../templates/otelcol.ftl`（生产 collector 配置模板）**同样没有任何
+3. Doris 自身指标 `doris_be_tablet_version_num_distribution` 的 `'le' label missing` 接收侧报错是另一个
+独立诱因（Doris histogram 格式问题，与 ZK 无关），同样会拖累同一条共享 pipeline。
+4. 检查 `datasophon-worker/.../templates/otelcol.ftl`（生产 collector 配置模板）**同样没有任何
 NaN 处理逻辑**，说明这不是本沙箱独有问题，是该 dorisexporter 版本（v0.154.0）的通用缺陷，
 **生产环境接入任何"低频 Summary 指标"的服务都可能撞上**（不只是 ZooKeeper）。
 
-**建议（未执行，需团队拍板）**：在 `otelcol.ftl` 的 metrics pipeline 里加一个 `transform` 处理器，
-把 Summary datapoint 里的 NaN quantile 值替换成 0 或直接丢弃该 quantile 点（保留 count/sum 列不受影响，
-因为 count/sum 本身永远是有效数值，只有 quantile 估计值在零观测时才会是 NaN）。这是 collector 配置层面
-的通用修复，不属于本次 ZooKeeper 前后端迁移的范围，本任务的 Java/前端代码改动均按"数据一旦落库、查询
-SQL 正确"验证完毕，**不受此采集侧缺陷影响其正确性**——一旦团队在 collector 层修好 NaN 问题，
-Z16/Z19/Z20/Z22/Z23 无需再改代码即可恢复数据。
+## ✅ 2026-07-04 已部分修复：`filter/drop_empty_summary` 处理器
+
+在 `deploy/compose/conf/otelcol-juicefs.yaml`（沙箱）和
+`datasophon-worker/.../templates/otelcol.ftl`（生产模板，两处均已提交）的 metrics pipeline 里加了：
+
+```yaml
+processors:
+  filter/drop_empty_summary:
+    metrics:
+      datapoint:
+        - 'metric.type == METRIC_DATA_TYPE_SUMMARY and count == 0'
+```
+
+**已用 otelcol 自身暴露的 `otelcol_processor_filter_datapoints_filtered` self-metric 验证生效**
+（沙箱实测持续增长，几分钟内过滤掉 150+ 个空 Summary 数据点）。覆盖"Summary 从未被观测到、
+count=0、quantile 恒为 NaN"这一种成因。
+
+**未能覆盖的第二种成因（尝试过两种方案均失败，已放弃，如实记录）**：`election_time`/
+`fsynctime`/`snapshottime`/`jvm_pause_time_ms` 即使 `count>0`（历史上真实被观测过），quantile
+计算用滑动时间窗口衰减，窗口内长时间无新观测时 quantile 仍会衰减回 NaN——`count==0` 过滤不到
+这种情况（沙箱实测 `fsynctime` count=1579、sum=671 仍输出 NaN）。尝试过：
+
+1. `transform` 处理器 `set(quantile_values, [])`——otelcol 正常启动、无报错，但用 `debug` exporter
+   `verbosity: detailed` 抓包验证发现 quantile_values 并未被清空，`set()` 对这个 slice-of-struct
+   字段静默无效。
+2. `filter` 处理器用索引 `quantile_values[0].value != quantile_values[0].value`（NaN 自比较技巧）
+   在条件里探测——otelcol **直接拒绝启动**，报错 `"the keys indexing quantile_values were not
+   used by the context - this likely means you are trying to index a path that does not support
+   indexing"`，确认这个 collector 版本的 OTTL 不支持对 `quantile_values` 做索引访问。
+
+结论：**当前 OTTL（otelcol-contrib v0.154.0）不支持读写 Summary 的 `quantile_values` 字段**，
+这个衰减性 NaN 无法用"清空/改写 quantile"这类值级别手段可靠解决。
+
+## ✅ 2026-07-04 最终修复：整体丢弃这 4 个指标，不导入 Doris
+
+值级别处理走不通后，改为更简单的指标级别丢弃：`election_time`/`fsynctime`/`snapshottime`/
+`jvm_pause_time_ms` 这 4 个指标本身在 ZK 看板里就只服务 Z16/Z19/Z20/Z23 四个面板，用户拍板直接让
+这 4 个指标不进 Doris，从根上避免它们拖累同一 pipeline 里其它指标的导出。在
+`deploy/compose/conf/otelcol-juicefs.yaml`（沙箱）和 `datasophon-worker/.../templates/otelcol.ftl`
+（生产模板，两处均已提交）新增一个 `metric` 级别（而非 `datapoint` 级别）的 filter 处理器：
+
+```yaml
+processors:
+  filter/drop_zk_decaying_summary:
+    metrics:
+      metric:
+        - 'name == "election_time" or name == "fsynctime" or name == "snapshottime" or name == "jvm_pause_time_ms"'
+```
+
+这个条件只判断 `metric.name`，不涉及 `quantile_values` 字段，因此不受上面提到的 OTTL 限制影响，
+写法也比值级别处理简单得多。
+
+**验证结果（2026-07-04，`docker compose restart obs-otelcol` 后）**：
+- self-metric `otelcol_processor_filter_datapoints_filtered{filter="filter/drop_zk_decaying_summary"}`
+从 0 持续增长（观测到 6+），证明规则确实在拦截数据点。
+- Doris `otel_metrics_summary` 表里 `fsynctime`/`snapshottime` 的最后一条记录时间戳停留在重启前
+（`08:28:05`），重启后再无新记录写入；`election_time`/`jvm_pause_time_ms` 表里本就没有任何历史
+记录（此前一直是 NaN，被 `filter/drop_empty_summary` 挡在门外）。
+- 重启后的 otelcol 日志里不再出现新的 `"unsupported value: NaN"` 报错（重启瞬间那条来自旧进程
+shutdown 时刷已入队数据，与新配置无关）。
+
+**产品侧代价（已知且是本次修复的直接后果）**：`election_time`/`fsynctime`/`snapshottime`/
+`jvm_pause_time_ms` 从采集侧就被丢弃，根本不会落库，对应的 Z16/Z19/Z20/Z23 四个面板**已从
+`datasophon-ui-v2` 的 ZooKeeper 看板里整体移除**（`panelQueries.ts`/`index.tsx`/locale 文件/mock
+数据均已同步删除，详见对应 commit）——不留"看起来能查但永远无数据"的面板，比留着更诚实。这四个
+面板背后的 SQL 查询层代码（`buildRangeFieldRateSql`）逻辑本身没有问题，只是没有数据源；如果未来
+升级 OTel Collector 让 OTTL 支持操作 `quantile_values`，或团队决定换用其它方式处理 NaN，去掉采集侧
+这一条 filter 规则、把面板加回前端即可恢复，Java 查询层代码无需改动。
+`Z01/Z02/Z17`（quorum 专属指标）不受影响，仍需要真实多节点 ensemble 才能验证。
+
+## 附:调试会话中发现并修复的 NPE（与采集侧 NaN 缺陷相关联但独立成因）
+
+**现象**（用户在 IDEA 本地调试 `datasophon-api` 连接本沙箱 Doris 时触发）：
+
+```
+NullPointerException: Cannot invoke "java.lang.Number.doubleValue()" because the return value of
+"java.util.Map.get(Object)" is null
+  at OtelMetricsQueryService.buildVector(OtelMetricsQueryService.java:744)
+  at OtelMetricsQueryService.queryInstant(...)
+```
+
+**根因**：`buildInstantAggSql` 生成 `SELECT SUM(value) AS value, ... FROM (子查询) t`（无 `GROUP BY`），
+这类无分组聚合查询即使子查询命中 0 行，仍会返回**恰好一行**、`value` 列为 SQL `NULL`
+（`SUM(空集) = NULL`，不是 `0`）。触发条件是查询窗口（`evalTime - 300` 秒）内没有该指标的新鲜数据——
+本次是上文"采集侧 NaN 缺陷"导致 otelcol 的 Doris 导出队列被拖慢，`num_alive_connections` 980 秒未更新
+（远超 300 秒新鲜度窗口），并非 ZooKeeper 迁移代码本身的缺陷。
+
+**修复**：`buildVector`/`buildMatrix` 遇到 `row.get("value") == null` 时跳过该行（视同"无数据"，
+与项目既有约定"空结果按 NaN 处理，非真实 0"一致），而不是直接拆箱抛异常。**这是
+`OtelMetricsQueryService` 的通用健壮性修复，影响所有走 instant-agg 查询路径的看板（不限于
+ZooKeeper）**——任何指标在评估窗口内暂时无新鲜数据时都会触发同样的 NPE，此前未被发现是因为此前的
+沙箱验证窗口内数据一直新鲜。已加 `buildVector_nullValue_skipsRowInsteadOfThrowing` +
+`buildMatrix_nullValue_skipsRowInsteadOfThrowing` 两个单测覆盖。
 
 ## 已知局限（沙箱层面，非代码缺陷）
 

--- a/docs/monitoring/zookeeper-otel-verification.md
+++ b/docs/monitoring/zookeeper-otel-verification.md
@@ -1,0 +1,131 @@
+# ZooKeeper 指标接入验证（OTel Collector → Doris）
+
+> 用途：核对 ZooKeeper 监控看板所需指标的落表、维度与存在性。
+> **2026-07-04 已用 `deploy/compose/docker-compose.observability.yml`（新增 `obs-zookeeper` 服务 + otelcol
+> `prometheus/zookeeper` 抓取任务）搭建真实沙箱跑通，本文档记录的是真实观测结果，不是待回填占位。**
+
+## 沙箱环境
+
+- `zookeeper:3.8` 单节点（`ZOO_STANDALONE_ENABLED=true`），`ZOO_CFG_EXTRA` 注入
+  `metricsProvider.className=org.apache.zookeeper.metrics.prometheus.PrometheusMetricsProvider` +
+  `metricsProvider.httpPort=7000`，与生产 `ZOOKEEPER/service_ddl.json` 的
+  `metricsProvider.httpPort` 默认值一致。
+- otelcol `prometheus/zookeeper` 抓取任务 `job_name: ZkServer`，与生产
+  `OtelScrapeConfigBuilder`（`job_name = role.getServiceRoleName()` = `"ZkServer"`）一致。
+- 用 `zkCli.sh create/set/delete` 持续写入 znode，制造真实 fsync/session/packet 流量。
+
+## Step 1 — ZkServer 是否写入 Doris（已确认）
+
+```sql
+SELECT COUNT(*) FROM otel.otel_metrics_gauge WHERE service_name = 'ZkServer';
+SELECT COUNT(*) FROM otel.otel_metrics_sum WHERE service_name = 'ZkServer';
+SELECT COUNT(*) FROM otel.otel_metrics_summary WHERE service_name = 'ZkServer';
+```
+
+**真实结果**：gauge 表 7000+ 行、sum 表 4000+ 行均正常写入；summary 表在未过滤前**长期为 0 行**——
+见下方「⚠️ 采集侧发现的真实缺陷」。加白名单 relabel 隔离掉恒为 `NaN` 的无关指标后，summary 表恢复写入
+（`fsynctime`/`snapshottime`/`jvm_gc_collection_seconds` 三个指标共 4 行）。
+
+## Step 2 — 指标落表与类型核对（已确认，逐条实测 `/metrics` 端点 `# TYPE` 行 + Doris 落表）
+
+**关键结论：本任务清单最初的"已拍板决策"里有两处推断被真实数据证伪，已按下表修正代码：**
+
+|                                                 指标                                                  |  最初假设的落表   |                                **真实落表**                                 |                                    结论                                    |
+|-----------------------------------------------------------------------------------------------------|------------|-------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `jvm_gc_collection_seconds_count`                                                                   | `summary`✅ | `summary`（metric_name 为不带 `_count` 后缀的 **`jvm_gc_collection_seconds`**） | 落表正确，**metric_name 原假设错**（多写了 `_count` 后缀），已修正                           |
+| `election_time_sum`                                                                                 | `sum`❌     | `summary`（metric_name 为 **`election_time`**，非 `_sum` 后缀）                | **假设错**，真实 `# TYPE election_time summary`，已修正为 `table=summary,field=sum` |
+| `fsynctime_sum`                                                                                     | `sum`❌     | `summary`（**`fsynctime`**）                                              | 同上，已修正                                                                   |
+| `snapshottime_sum`                                                                                  | `sum`❌     | `summary`（**`snapshottime`**）                                           | 同上，已修正                                                                   |
+| `jvm_pause_time_ms_sum`                                                                             | `sum`❌     | `summary`（**`jvm_pause_time_ms`**）                                      | 同上，已修正                                                                   |
+| `packets_received`/`packets_sent`                                                                   | `sum`❌     | **`gauge`**（`# TYPE packets_sent gauge`）                                | **假设错**（以为是 counter），已修正为默认 gauge，去掉 `table:'sum'`                       |
+| `connection_rejected`/`connection_drop_count`/`unrecoverable_error_count`/`digest_mismatches_count` | `sum`✅     | `sum`（真实 `# TYPE ... counter`）                                          | 假设正确                                                                     |
+| `commit_count`/`snap_count`/`proposal_count`                                                        | `sum`✅     | `sum`（真实 `# TYPE ... counter`）                                          | 假设正确                                                                     |
+| 其余全部 gauge（`quorum_size`/`jvm_threads_*`/`max_latency` 等）                                           | `gauge`    | `gauge`                                                                 | 假设正确                                                                     |
+
+**已按此表修正** `datasophon-ui-v2/.../ZooKeeperMonitor/panelQueries.ts`：Z13 去掉 `table:'sum'`；
+Z16/Z19/Z20/Z23 的 `metric` 去掉 `_sum` 后缀、`table` 改 `summary`、加 `field:'sum'`；Z22 的 `metric` 去掉
+`_count` 后缀。教训：**"看起来像 Counter 语义" ≠ "真实 Prometheus TYPE 是 counter"**，必须实测
+`/metrics` 端点的 `# TYPE` 行，不能凭指标名字面意思推断。
+
+## Step 3 — 属性维度（已确认）
+
+```sql
+SELECT service_name, metric_name, count, sum, CAST(attributes AS CHAR) AS attrs
+FROM otel.otel_metrics_summary WHERE service_name='ZkServer';
+```
+
+真实结果：
+
+```
+ZkServer  snapshottime                1     5      {}
+ZkServer  jvm_gc_collection_seconds   0     0      {"gc":"G1 Old Generation"}
+ZkServer  jvm_gc_collection_seconds   2     0.021  {"gc":"G1 Young Generation"}
+ZkServer  fsynctime                   1101  431    {}
+```
+
+|                               检查项                                |                                      真实结论                                       |
+|------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| `jvm_memory_pool_bytes_used` 的 `attributes` 含 `pool`             | ✅确认（`pool="G1 Eden Space"` 等）                                                   |
+| `jvm_gc_collection_seconds` 的 `attributes` 含 `gc`                | ✅确认（如上）                                                                         |
+| `instance` 位于 `resource_attributes['service']['instance']['id']` | ✅确认（值为 `obs-zookeeper`）                                                         |
+| `job`/`service_name` 对应 `ZkServer`                               | ✅确认（`resource_attributes['service']['name']` 与顶层 `service_name` 列均为 `ZkServer`） |
+
+## Step 4 — SQL 层端到端验证（已确认，绕过 REST 层直接对 Doris 跑生成的 SQL）
+
+手工拼出 `OtelMetricsQueryService.buildRangeFieldRateSql("sum", ..., "otel_metrics_summary")` 生成的
+SQL 模板（`metric='fsynctime'`），代入真实 start/end/step/rateWindow 直接对 Doris 执行：
+
+```
+instance        job       bucket       value
+obs-zookeeper   ZkServer  1783153620   1.466678892963017
+```
+
+以及 `groupBy=['gc']` 版本（`metric='jvm_gc_collection_seconds', field='count'`）：
+
+```
+instance       job       gc                   bucket       value
+obs-zookeeper  ZkServer  G1 Old Generation     1783153620   0.0000
+obs-zookeeper  ZkServer  G1 Young Generation   1783153620   0.0000
+```
+
+结论：**`buildRangeFieldRateSql` 对 summary 表的 series_key 分区 + reset 守卫 + groupBy 逻辑正确**，
+`pool`/`gc` 白名单生效，`gc` 维度正确拆分成独立 series。GC rate 全为 0 属预期（沙箱运行期内只发生过
+1 次 Young GC，验证窗口内无新增收集事件）。
+
+## ⚠️ 采集侧发现的真实缺陷（超出本任务范围，需团队决策，未修复）
+
+**`otel_metrics_summary` 表的 Stream Load 写入会被同批次里任意一个 `NaN` 值的 datapoint 整体拖垮。**
+
+ZooKeeper 内部有约 45 个 processor 队列类 Summary 指标（`prep_processor_queue_size`、
+`proposal_latency`、`election_time`、`jvm_pause_time_ms` 等）在从未被观测到时会输出
+`{quantile="0.5",} NaN`（Prometheus Summary 无观测值时的标准行为）。otelcol 的 dorisexporter 把这类
+NaN datapoint 序列化进 Stream Load 的 JSON payload 时报
+`"error": "json: unsupported value: NaN"`，导致**整个 `otel_metrics_summary` 表的这次 Stream Load
+请求失败**（`gauge`/`sum` 表因走独立 Stream Load 请求不受影响，已实测确认）。
+
+实测现象：未过滤白名单前，`otel_metrics_summary` 表对 `ZkServer` 长期 0 行，即使
+`jvm_gc_collection_seconds`（本身从不产生 NaN，因为它的 Summary 未配置任何 quantile 分位数）也被
+连带拖累无法落库。加 `metric_relabel_configs` 白名单只保留会产生真实数值的指标后，summary 表才恢复写入。
+
+**影响面**：
+1. `election_time`（Z16）在单节点/无选举场景下**几乎不可能有非 NaN 值**——任何长期稳定运行、选举窗口
+已滑出 Summary 统计窗口的 ZK 集群，只要该指标一变回 NaN，整个 summary 表当次批次的写入就会失败，
+包括本该正常写入的 `fsynctime`/`snapshottime`/`jvm_gc_collection_seconds`。
+2. `jvm_pause_time_ms`（Z23）同理——只要该 ZK 节点近期没有可观测的 JVM 暂停，也会永久 NaN。
+3. 检查 `datasophon-worker/.../templates/otelcol.ftl`（生产 collector 配置模板）**同样没有任何
+NaN 处理逻辑**，说明这不是本沙箱独有问题，是该 dorisexporter 版本（v0.154.0）的通用缺陷，
+**生产环境接入任何"低频 Summary 指标"的服务都可能撞上**（不只是 ZooKeeper）。
+
+**建议（未执行，需团队拍板）**：在 `otelcol.ftl` 的 metrics pipeline 里加一个 `transform` 处理器，
+把 Summary datapoint 里的 NaN quantile 值替换成 0 或直接丢弃该 quantile 点（保留 count/sum 列不受影响，
+因为 count/sum 本身永远是有效数值，只有 quantile 估计值在零观测时才会是 NaN）。这是 collector 配置层面
+的通用修复，不属于本次 ZooKeeper 前后端迁移的范围，本任务的 Java/前端代码改动均按"数据一旦落库、查询
+SQL 正确"验证完毕，**不受此采集侧缺陷影响其正确性**——一旦团队在 collector 层修好 NaN 问题，
+Z16/Z19/Z20/Z22/Z23 无需再改代码即可恢复数据。
+
+## 已知局限（沙箱层面，非代码缺陷）
+
+- `quorum_size`（Z01）、`leader_uptime`（Z02）、`learners`/`synced_observers`（Z17）在
+  `ZOO_STANDALONE_ENABLED=true` 单节点模式下**完全不存在**（这些是仅复制/quorum 模式才有的指标，
+  standalone 模式跳过 Leader 选举）。真实多节点集群应有数据，本沙箱无法验证，需要真实 3+ 节点 ensemble。
+


### PR DESCRIPTION
## Summary

- 将 ZooKeeperMonitor 看板从 `PrometheusProxyV2Controller` 取数迁移到查询 Doris `otel_metrics_*` 表,与已完成的 RustFS/JuiceFS/Nexus 看板取数方式对齐。
- 后端 `OtelMetricsQueryService` 把原本只服务 histogram 表的 `buildRangeHistogramFieldRateSql` 泛化为 `buildRangeFieldRateSql(...,otelTable)`,histogram/summary 两表复用同一份 series_key 分区 + reset 守卫逻辑,支持 summary 表的 count/sum 列 counter-rate 查询。
- 真实 docker compose 沙箱验证过程中发现并修正两处最初凭指标名推断错的假设(election_time 等 4 个指标实为 Summary 类型而非独立 Counter;packets_received/sent 实为 gauge 而非 counter),顺带修复了 `buildVector`/`buildMatrix` 在聚合查询无匹配行时的一个真实 NPE(不限 ZooKeeper,所有 instant-agg 查询都受益)。
- 沙箱验证还发现一个采集侧缺陷:ZooKeeper 大量从未被观测的 Summary 指标输出 NaN 分位数,会拖垮 dorisexporter 的 Stream Load 导出并连累同一 pipeline 里其它指标停止写入。已加 `filter/drop_empty_summary`(丢弃 count=0 空 Summary)和 `filter/drop_zk_decaying_summary`(整体丢弃 4 个即使 count>0 也会衰减回 NaN、OTTL 当前版本无法值级别清理的指标)两个处理器,沙箱配置和生产 `otelcol.ftl` 模板均已同步。
- 因为 election_time/fsynctime/snapshottime/jvm_pause_time_ms 这 4 个指标不再导入 Doris,对应的 Z16/Z19/Z20/Z23 四个前端面板已从看板整体移除,而不是保留永远无数据的空面板。

## 已知权衡(Known tradeoffs)

> 以下两点是本 PR 在 OTTL 当前版本约束下的有意取舍,合并前请知悉。

1. **永久失去 4 项 ZooKeeper 延迟可见性。** 移除的 Z16/Z19/Z20/Z23 分别对应选举耗时(election_time)、fsync 耗时(fsynctime)、快照耗时(snapshottime)、JVM GC 暂停(jvm_pause_time_ms)。这些指标为 Summary 类型,quantile 用滑动时间窗计算,窗口内无新观测时会衰减回 NaN;而当前 collector 版本的 OTTL 不支持读写 `quantile_values`(slice-of-struct)做值级别清理,`filter/drop_empty_summary` 也只能覆盖 count=0 的空 Summary。因此只能整体丢弃这 4 个指标不入 Doris,**代价是这几项延迟指标在新看板下永久不可见**,直到 OTTL 支持相应能力后再恢复。

2. **`filter/drop_zk_decaying_summary` 是全局按指标名丢弃的 processor。** 它挂在生产 `otelcol.ftl` 的 metrics pipeline 上,按 metric name 生效于**所有节点/服务**,而非仅 ZooKeeper 节点。当前 4 个名字(election_time/fsynctime/snapshottime/jvm_pause_time_ms)均为 ZooKeeper 专有,无碰撞风险;但若未来任何其它服务出现同名(尤其较通用的 `jvm_pause_time_ms`),会被此 processor 静默丢弃、不入 Doris。新增服务时需留意此全局丢弃清单。(同 pipeline 上的 `filter/drop_empty_summary` 也是全局生效,但空 Summary 的 quantile 本就是 NaN、无信息,丢弃属普适改进,对 Doris/Nexus 看板的 JVM/Jetty timer 面板无损。)

## Test plan

- [x] `./mvnw -pl datasophon-api,datasophon-worker -am test` — 后端 84 个测试全绿(`OtelMetricsQueryServiceTest`/`OtelMetricsQueryControllerTest`/`OtelcolTemplateTest`)
- [x] `./mvnw spotless:apply` / `spotless:check` 通过
- [x] `pnpm test`(datasophon-ui-v2)— 148 个测试全绿
- [x] `pnpm tsc` / `pnpm lint` 通过
- [x] 用 `deploy/compose/docker-compose.observability.yml` 真实 docker compose 沙箱(新增 `obs-zookeeper` 服务)端到端验证:三张表落库、维度正确、`buildRangeFieldRateSql` 生成的 SQL 手工执行验证 rate 计算正确、`filter/drop_zk_decaying_summary` 用 otelcol 自身 self-metric 验证真实生效(而非仅凭进程正常启动),详见 `docs/monitoring/zookeeper-otel-verification.md`
