### PR TITLE
feat(apisix): 网关配置 Tab（图形化+代码化双视图）

### DIFF
--- a/datasophon-api/src/main/java/com/datasophon/api/controller/v2/ApisixGatewayV2Controller.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/controller/v2/ApisixGatewayV2Controller.java
@@ -1,0 +1,74 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.controller.v2;
+
+import com.datasophon.api.controller.ApiController;
+import com.datasophon.api.dto.ApiResponse;
+import com.datasophon.api.dto.v2.ApisixGatewayPushResult;
+import com.datasophon.api.dto.v2.ApisixGatewayResponse;
+import com.datasophon.api.dto.v2.SaveApisixGatewayRequest;
+import com.datasophon.api.service.ApisixGatewayConfigService;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+/**
+ * APISIX(standalone) 网关配置 Tab 的读写接口。
+ *
+ * <p>真相源是隐藏参数 {@code apisixGatewayYaml}，图形化视图只是其 {@code js-yaml.load()}
+ * 后的结构化投影；全部业务逻辑委托给 {@link ApisixGatewayConfigService}。
+ */
+@RestController
+@RequestMapping("/v2/cluster/{clusterId}/service/instance/{instanceId}/apisix/gateway")
+public class ApisixGatewayV2Controller extends ApiController {
+
+    private final ApisixGatewayConfigService gatewayConfigService;
+
+    public ApisixGatewayV2Controller(ApisixGatewayConfigService gatewayConfigService) {
+        this.gatewayConfigService = gatewayConfigService;
+    }
+
+    @GetMapping
+    public ApiResponse<ApisixGatewayResponse> get(@PathVariable Integer clusterId,
+                                                  @PathVariable Integer instanceId) {
+        return ApiResponse.ok(gatewayConfigService.getGatewayConfig(clusterId, instanceId));
+    }
+
+    /**
+     * 保存网关配置：校验 YAML → 复用 saveServiceConfig 落库 → 只对 apisix.yaml 下发（不重启）。
+     */
+    @PostMapping
+    public ApiResponse<List<ApisixGatewayPushResult>> save(@PathVariable Integer clusterId,
+                                                           @PathVariable Integer instanceId,
+                                                           @Valid @RequestBody SaveApisixGatewayRequest req) {
+        return ApiResponse.ok(gatewayConfigService.saveGatewayConfig(clusterId, instanceId, req.getGatewayYaml()));
+    }
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/ApisixGatewayPushResult.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/ApisixGatewayPushResult.java
@@ -1,0 +1,38 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.dto.v2;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/** 单个 Apisix 角色实例的「只 configure 不重启」下发结果。 */
+@Data
+@AllArgsConstructor
+public class ApisixGatewayPushResult {
+
+    private String hostname;
+
+    private boolean success;
+
+    private String message;
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/ApisixGatewayResponse.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/ApisixGatewayResponse.java
@@ -1,0 +1,42 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.dto.v2;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/** GET /v2/.../apisix/gateway 响应体：网关配置 YAML + 托管段预览 + 节点列表。 */
+@Data
+@AllArgsConstructor
+public class ApisixGatewayResponse {
+
+    /** 用户可编辑段（upstreams/routes/global_rules），非空时为持久化值，空时为向导参数拼出的初始值。 */
+    private String gatewayYaml;
+
+    /** 模板固定输出的托管段（plugin_metadata + #END），供前端拼出「最终 apisix.yaml」只读预览。 */
+    private String managedSuffix;
+
+    private List<ApisixGatewayRole> roles;
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/ApisixGatewayRole.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/ApisixGatewayRole.java
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.dto.v2;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/** APISIX 角色实例的节点视图（供网关配置 Tab 展示节点列表）。 */
+@Data
+@AllArgsConstructor
+public class ApisixGatewayRole {
+
+    private String hostname;
+
+    private String state;
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/SaveApisixGatewayRequest.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/SaveApisixGatewayRequest.java
@@ -1,0 +1,34 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.dto.v2;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+/** v2 保存 APISIX 网关配置请求体（JSON）。 */
+@Data
+public class SaveApisixGatewayRequest {
+
+    @NotNull(message = "网关配置不能为空")
+    private String gatewayYaml;
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/service/ApisixGatewayConfigService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/ApisixGatewayConfigService.java
@@ -44,9 +44,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -98,19 +103,22 @@ public class ApisixGatewayConfigService {
     private final ClusterServiceRoleGroupConfigService roleGroupConfigService;
     private final ClusterServiceRoleInstanceService roleInstanceService;
     private final ServiceInstallService serviceInstallService;
+    private final Executor masterExecutor;
 
     public ApisixGatewayConfigService(ClusterInfoService clusterInfoService,
                                       ClusterServiceInstanceService serviceInstanceService,
                                       ClusterServiceInstanceRoleGroupService roleGroupService,
                                       ClusterServiceRoleGroupConfigService roleGroupConfigService,
                                       ClusterServiceRoleInstanceService roleInstanceService,
-                                      ServiceInstallService serviceInstallService) {
+                                      ServiceInstallService serviceInstallService,
+                                      @Qualifier("masterExecutor") Executor masterExecutor) {
         this.clusterInfoService = clusterInfoService;
         this.serviceInstanceService = serviceInstanceService;
         this.roleGroupService = roleGroupService;
         this.roleGroupConfigService = roleGroupConfigService;
         this.roleInstanceService = roleInstanceService;
         this.serviceInstallService = serviceInstallService;
+        this.masterExecutor = masterExecutor;
     }
 
     public ApisixGatewayResponse getGatewayConfig(Integer clusterId, Integer instanceId) {
@@ -167,14 +175,8 @@ public class ApisixGatewayConfigService {
      */
     private List<ServiceConfig> loadEffectiveConfigs(Integer clusterId) {
         List<ServiceConfig> configs = new ArrayList<>(serviceInstallService.getServiceConfigOption(clusterId, SERVICE_NAME));
-        boolean hasGatewayYamlParam = configs.stream().anyMatch(c -> GATEWAY_YAML_PARAM.equals(c.getName()));
-        if (!hasGatewayYamlParam) {
-            serviceInstallService.getServiceConfigFromDdl(clusterId, SERVICE_NAME).stream()
-                    .filter(c -> GATEWAY_YAML_PARAM.equals(c.getName()))
-                    .findFirst()
-                    .ifPresent(configs::add);
-        }
-        return configs;
+        List<ServiceConfig> ddlConfigs = serviceInstallService.getServiceConfigFromDdl(clusterId, SERVICE_NAME);
+        return ServiceConfigUtils.addAll(configs, ddlConfigs);
     }
 
     private List<ApisixGatewayPushResult> pushToRunningRoles(Integer clusterId, Integer roleGroupId) {
@@ -197,18 +199,32 @@ public class ApisixGatewayConfigService {
                 .filter(e -> e.getServiceRoleState() == ServiceRoleState.RUNNING)
                 .toList();
 
-        List<ApisixGatewayPushResult> results = new ArrayList<>();
+        // 每台网关节点的下发是独立、阻塞的 gRPC 调用（最长 180s 超时），按主机 fan-out 到
+        // masterExecutor，避免多台网关节点时总耗时随节点数线性叠加（同款写法见 HostCheckService）。
+        List<CompletableFuture<ApisixGatewayPushResult>> futures = new ArrayList<>(runningRoles.size());
         for (ClusterServiceRoleInstanceEntity role : runningRoles) {
+            Supplier<ApisixGatewayPushResult> task = () -> pushToRole(clusterInfo, apisixYamlOnly, role);
             try {
-                ExecResult result = ServiceLifecycleUtils.configServiceRoleInstance(clusterInfo, apisixYamlOnly, role);
-                results.add(new ApisixGatewayPushResult(role.getHostname(), result != null && result.isSuccess(),
-                        result != null ? result.getExecOut() : "下发结果为空"));
-            } catch (Exception e) {
-                log.error("push apisix gateway config to {} failed", role.getHostname(), e);
-                results.add(new ApisixGatewayPushResult(role.getHostname(), false, e.getMessage()));
+                futures.add(CompletableFuture.supplyAsync(task, masterExecutor));
+            } catch (RejectedExecutionException e) {
+                // 池满时退化为调用线程串行执行，等价旧行为
+                futures.add(CompletableFuture.completedFuture(task.get()));
             }
         }
-        return results;
+        return futures.stream().map(CompletableFuture::join).toList();
+    }
+
+    private ApisixGatewayPushResult pushToRole(ClusterInfoEntity clusterInfo,
+                                               Map<Generators, List<ServiceConfig>> configFileMap,
+                                               ClusterServiceRoleInstanceEntity role) {
+        try {
+            ExecResult result = ServiceLifecycleUtils.configServiceRoleInstance(clusterInfo, configFileMap, role);
+            return new ApisixGatewayPushResult(role.getHostname(), result != null && result.isSuccess(),
+                    result != null ? result.getExecOut() : "下发结果为空");
+        } catch (Exception e) {
+            log.error("push apisix gateway config to {} failed", role.getHostname(), e);
+            return new ApisixGatewayPushResult(role.getHostname(), false, e.getMessage());
+        }
     }
 
     private void resetNeedRestart(Integer instanceId, Integer roleGroupId) {

--- a/datasophon-api/src/main/java/com/datasophon/api/service/ApisixGatewayConfigService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/ApisixGatewayConfigService.java
@@ -1,0 +1,315 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.service;
+
+import com.datasophon.api.dto.v2.ApisixGatewayPushResult;
+import com.datasophon.api.dto.v2.ApisixGatewayResponse;
+import com.datasophon.api.dto.v2.ApisixGatewayRole;
+import com.datasophon.api.exceptions.BusinessHintException;
+import com.datasophon.api.utils.ServiceConfigUtils;
+import com.datasophon.api.utils.ServiceLifecycleUtils;
+import com.datasophon.common.Constants;
+import com.datasophon.common.model.Generators;
+import com.datasophon.common.model.ServiceConfig;
+import com.datasophon.common.utils.ExecResult;
+import com.datasophon.dao.entity.ClusterInfoEntity;
+import com.datasophon.dao.entity.ClusterServiceInstanceEntity;
+import com.datasophon.dao.entity.ClusterServiceInstanceRoleGroup;
+import com.datasophon.dao.entity.ClusterServiceRoleGroupConfig;
+import com.datasophon.dao.entity.ClusterServiceRoleInstanceEntity;
+import com.datasophon.dao.enums.NeedRestart;
+import com.datasophon.dao.enums.ServiceRoleState;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+
+/**
+ * APISIX(standalone) 网关配置 Tab 的读写主干：真相源是隐藏参数 {@code apisixGatewayYaml}，
+ * 保存时复用 {@link ServiceInstallService#saveServiceConfig} 落库，再只对 {@code apisix.yaml}
+ * 这一个 generator 调 {@link ServiceLifecycleUtils#configServiceRoleInstance} 下发（不重启）。
+ */
+@Service
+public class ApisixGatewayConfigService {
+
+    private static final Logger log = LoggerFactory.getLogger(ApisixGatewayConfigService.class);
+
+    static final String SERVICE_NAME = "APISIX";
+    static final String ROLE_NAME = "Apisix";
+    static final String GATEWAY_YAML_PARAM = "apisixGatewayYaml";
+    static final String ROUTE_URI_PARAM = "apisixRouteUri";
+    static final String UPSTREAM_HOST_PARAM = "apisixUpstreamHost";
+    static final String UPSTREAM_PORT_PARAM = "apisixUpstreamPort";
+    static final String APISIX_YAML_FILENAME = "apisix.yaml";
+
+    /**
+     * plugin_metadata + #END 由 apisix-routes.ftl 模板固定输出（不交给 UI 编辑），
+     * 这里必须与该模板的固定段保持一致，模板改动时需同步更新此常量。
+     */
+    static final String MANAGED_SUFFIX = "\n"
+            + "# opentelemetry 插件运行时读取的是 plugin_metadata，不是 config.yaml 的 plugin_attr——\n"
+            + "# 缺失时插件会静默跳过（access.log 报 \"plugin_metadata is required\"），不生成任何 span。\n"
+            + "plugin_metadata:\n"
+            + "  - id: opentelemetry\n"
+            + "    resource:\n"
+            + "      service.name: apisix\n"
+            + "    collector:\n"
+            + "      address: 127.0.0.1:4318\n"
+            + "      request_timeout: 3\n"
+            + "    batch_span_processor:\n"
+            + "      drop_on_queue_full: false\n"
+            + "      max_queue_size: 1024\n"
+            + "      batch_timeout: 2\n"
+            + "#END\n";
+
+    private final ClusterInfoService clusterInfoService;
+    private final ClusterServiceInstanceService serviceInstanceService;
+    private final ClusterServiceInstanceRoleGroupService roleGroupService;
+    private final ClusterServiceRoleGroupConfigService roleGroupConfigService;
+    private final ClusterServiceRoleInstanceService roleInstanceService;
+    private final ServiceInstallService serviceInstallService;
+
+    public ApisixGatewayConfigService(ClusterInfoService clusterInfoService,
+                                      ClusterServiceInstanceService serviceInstanceService,
+                                      ClusterServiceInstanceRoleGroupService roleGroupService,
+                                      ClusterServiceRoleGroupConfigService roleGroupConfigService,
+                                      ClusterServiceRoleInstanceService roleInstanceService,
+                                      ServiceInstallService serviceInstallService) {
+        this.clusterInfoService = clusterInfoService;
+        this.serviceInstanceService = serviceInstanceService;
+        this.roleGroupService = roleGroupService;
+        this.roleGroupConfigService = roleGroupConfigService;
+        this.roleInstanceService = roleInstanceService;
+        this.serviceInstallService = serviceInstallService;
+    }
+
+    public ApisixGatewayResponse getGatewayConfig(Integer clusterId, Integer instanceId) {
+        requireApisixInstance(instanceId);
+
+        Map<String, ServiceConfig> currentConfigs = toConfigMap(loadEffectiveConfigs(clusterId));
+
+        String gatewayYaml = stringValue(currentConfigs.get(GATEWAY_YAML_PARAM));
+        if (gatewayYaml == null || gatewayYaml.isBlank()) {
+            gatewayYaml = buildInitialGatewayYaml(
+                    stringValue(currentConfigs.get(ROUTE_URI_PARAM)),
+                    stringValue(currentConfigs.get(UPSTREAM_HOST_PARAM)),
+                    stringValue(currentConfigs.get(UPSTREAM_PORT_PARAM)));
+        }
+
+        List<ApisixGatewayRole> roles = roleInstanceService
+                .getServiceRoleInstanceListByClusterIdAndRoleName(clusterId, ROLE_NAME)
+                .stream()
+                .map(e -> new ApisixGatewayRole(e.getHostname(), e.getServiceRoleState().getDesc()))
+                .toList();
+
+        return new ApisixGatewayResponse(gatewayYaml, MANAGED_SUFFIX, roles);
+    }
+
+    public List<ApisixGatewayPushResult> saveGatewayConfig(Integer clusterId, Integer instanceId, String gatewayYaml) {
+        ClusterServiceInstanceEntity serviceInstance = requireApisixInstance(instanceId);
+        validateGatewayYaml(gatewayYaml);
+
+        NeedRestart beforeNeedRestart = serviceInstance.getNeedRestart();
+        ClusterServiceInstanceRoleGroup defaultGroup =
+                roleGroupService.getDefaultRoleGroupByServiceInstanceId(instanceId);
+
+        List<ServiceConfig> configs = loadEffectiveConfigs(clusterId);
+        for (ServiceConfig config : configs) {
+            if (GATEWAY_YAML_PARAM.equals(config.getName())) {
+                config.setValue(gatewayYaml);
+            }
+        }
+
+        // roleGroupId=-1：saveServiceConfig 内部据此取默认角色组（Apisix 只有一个角色，无需前端选组）
+        serviceInstallService.saveServiceConfig(clusterId, SERVICE_NAME, configs, -1);
+
+        if (beforeNeedRestart == NeedRestart.NO) {
+            resetNeedRestart(instanceId, defaultGroup.getId());
+        }
+
+        return pushToRunningRoles(clusterId, defaultGroup.getId());
+    }
+
+    /**
+     * {@link ServiceInstallService#getServiceConfigOption} 对已安装实例只回放上次持久化的
+     * configJson，不会带上 DDL 新增但从未保存过的参数。已安装的 APISIX 实例可能早于
+     * {@code apisixGatewayYaml} 这个参数存在，这里补一次兜底合并，否则该实例永远无法写入网关配置。
+     */
+    private List<ServiceConfig> loadEffectiveConfigs(Integer clusterId) {
+        List<ServiceConfig> configs = new ArrayList<>(serviceInstallService.getServiceConfigOption(clusterId, SERVICE_NAME));
+        boolean hasGatewayYamlParam = configs.stream().anyMatch(c -> GATEWAY_YAML_PARAM.equals(c.getName()));
+        if (!hasGatewayYamlParam) {
+            serviceInstallService.getServiceConfigFromDdl(clusterId, SERVICE_NAME).stream()
+                    .filter(c -> GATEWAY_YAML_PARAM.equals(c.getName()))
+                    .findFirst()
+                    .ifPresent(configs::add);
+        }
+        return configs;
+    }
+
+    private List<ApisixGatewayPushResult> pushToRunningRoles(Integer clusterId, Integer roleGroupId) {
+        ClusterInfoEntity clusterInfo = clusterInfoService.getById(clusterId);
+        ClusterServiceRoleGroupConfig savedConfig = roleGroupConfigService.getConfigByRoleGroupId(roleGroupId);
+
+        Map<Generators, List<ServiceConfig>> fullConfigFileMap = new HashMap<>();
+        ServiceConfigUtils.generateConfigFileMap(fullConfigFileMap, savedConfig, clusterId);
+
+        Map<Generators, List<ServiceConfig>> apisixYamlOnly = new HashMap<>();
+        fullConfigFileMap.forEach((generator, configs) -> {
+            if (APISIX_YAML_FILENAME.equals(generator.getFilename())) {
+                apisixYamlOnly.put(generator, configs);
+            }
+        });
+
+        List<ClusterServiceRoleInstanceEntity> runningRoles = roleInstanceService
+                .getServiceRoleInstanceListByClusterIdAndRoleName(clusterId, ROLE_NAME)
+                .stream()
+                .filter(e -> e.getServiceRoleState() == ServiceRoleState.RUNNING)
+                .toList();
+
+        List<ApisixGatewayPushResult> results = new ArrayList<>();
+        for (ClusterServiceRoleInstanceEntity role : runningRoles) {
+            try {
+                ExecResult result = ServiceLifecycleUtils.configServiceRoleInstance(clusterInfo, apisixYamlOnly, role);
+                results.add(new ApisixGatewayPushResult(role.getHostname(), result != null && result.isSuccess(),
+                        result != null ? result.getExecOut() : "下发结果为空"));
+            } catch (Exception e) {
+                log.error("push apisix gateway config to {} failed", role.getHostname(), e);
+                results.add(new ApisixGatewayPushResult(role.getHostname(), false, e.getMessage()));
+            }
+        }
+        return results;
+    }
+
+    private void resetNeedRestart(Integer instanceId, Integer roleGroupId) {
+        ClusterServiceInstanceEntity serviceInstance = serviceInstanceService.getById(instanceId);
+        serviceInstance.setNeedRestart(NeedRestart.NO);
+        serviceInstanceService.updateById(serviceInstance);
+
+        ClusterServiceInstanceRoleGroup roleGroup = roleGroupService.getById(roleGroupId);
+        roleGroup.setNeedRestart(NeedRestart.NO);
+        roleGroupService.updateById(roleGroup);
+
+        List<ClusterServiceRoleInstanceEntity> roleInstances = roleInstanceService.list(
+                new QueryWrapper<ClusterServiceRoleInstanceEntity>().eq(Constants.ROLE_GROUP_ID, roleGroupId));
+        roleInstances.forEach(e -> e.setNeedRestart(NeedRestart.NO));
+        roleInstanceService.updateBatchById(roleInstances);
+    }
+
+    private ClusterServiceInstanceEntity requireApisixInstance(Integer instanceId) {
+        ClusterServiceInstanceEntity serviceInstance = serviceInstanceService.getById(instanceId);
+        if (serviceInstance == null || !SERVICE_NAME.equals(serviceInstance.getServiceName())) {
+            throw new BusinessHintException("服务实例不是 APISIX");
+        }
+        return serviceInstance;
+    }
+
+    private void validateGatewayYaml(String gatewayYaml) {
+        if (gatewayYaml.contains("#END")) {
+            throw new BusinessHintException("网关配置中不能包含 #END（由平台模板统一追加）");
+        }
+        Object parsed;
+        try {
+            parsed = new Yaml(new SafeConstructor(new LoaderOptions())).load(gatewayYaml);
+        } catch (Exception e) {
+            throw new BusinessHintException("YAML 解析失败：" + e.getMessage());
+        }
+        if (!(parsed instanceof Map)) {
+            throw new BusinessHintException("网关配置顶层必须是一个 map");
+        }
+        @SuppressWarnings("unchecked")
+        Map<String, Object> doc = (Map<String, Object>) parsed;
+        if (doc.containsKey("plugin_metadata")) {
+            throw new BusinessHintException("plugin_metadata 由平台模板托管，不能出现在网关配置中");
+        }
+        if (!hasGlobalRulePlugin(doc, "prometheus") || !hasGlobalRulePlugin(doc, "opentelemetry")) {
+            throw new BusinessHintException("global_rules 必须同时包含 prometheus 与 opentelemetry 两条规则");
+        }
+    }
+
+    private boolean hasGlobalRulePlugin(Map<String, Object> doc, String pluginName) {
+        if (!(doc.get("global_rules") instanceof List<?> rules)) {
+            return false;
+        }
+        for (Object rule : rules) {
+            if (rule instanceof Map<?, ?> ruleMap && ruleMap.get("plugins") instanceof Map<?, ?> plugins
+                    && plugins.containsKey(pluginName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Map<String, ServiceConfig> toConfigMap(List<ServiceConfig> configs) {
+        Map<String, ServiceConfig> map = new HashMap<>();
+        for (ServiceConfig config : configs) {
+            map.put(config.getName(), config);
+        }
+        return map;
+    }
+
+    private static String stringValue(ServiceConfig config) {
+        if (config == null || config.getValue() == null) {
+            return null;
+        }
+        return String.valueOf(config.getValue());
+    }
+
+    private static String buildInitialGatewayYaml(String uri, String host, String port) {
+        return "upstreams:\n"
+                + "  - id: 1\n"
+                + "    type: roundrobin\n"
+                + "    nodes:\n"
+                + "      '" + escapeSingleQuote(host) + ":" + port + "': 1\n"
+                + "\n"
+                + "routes:\n"
+                + "  - id: 1\n"
+                + "    uri: '" + escapeSingleQuote(uri) + "'\n"
+                + "    upstream_id: 1\n"
+                + "\n"
+                + "global_rules:\n"
+                + "  - id: 1\n"
+                + "    plugins:\n"
+                + "      prometheus:\n"
+                + "        prefer_name: true\n"
+                + "  - id: 2\n"
+                + "    plugins:\n"
+                + "      opentelemetry:\n"
+                + "        sampler:\n"
+                + "          name: always_on\n";
+    }
+
+    private static String escapeSingleQuote(String s) {
+        return s == null ? "" : s.replace("'", "''");
+    }
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/utils/ServiceLifecycleUtils.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/utils/ServiceLifecycleUtils.java
@@ -28,22 +28,24 @@ import com.datasophon.api.master.handler.service.ServiceInstallHandler;
 import com.datasophon.api.master.handler.service.ServiceStartHandler;
 import com.datasophon.api.master.handler.service.ServiceStopHandler;
 import com.datasophon.api.master.handler.service.ServiceUpgradeHandler;
+import com.datasophon.api.service.FrameServiceService;
 import com.datasophon.common.model.Generators;
 import com.datasophon.common.model.ServiceConfig;
 import com.datasophon.common.model.ServiceRoleInfo;
 import com.datasophon.common.utils.ExecResult;
 import com.datasophon.dao.entity.ClusterInfoEntity;
 import com.datasophon.dao.entity.ClusterServiceRoleInstanceEntity;
+import com.datasophon.dao.entity.FrameServiceEntity;
 
 import java.util.List;
 import java.util.Map;
 
 /** 服务启停/安装/升级 Handler 链装配(原 ProcessUtils 拆出)。 */
 public class ServiceLifecycleUtils {
-    
+
     private ServiceLifecycleUtils() {
     }
-    
+
     public static ExecResult restartService(ServiceRoleInfo serviceRoleInfo, boolean needReConfig) throws Exception {
         ServiceHandler serviceStartHandler = new ServiceStartHandler();
         ServiceHandler serviceStopHandler = new ServiceStopHandler();
@@ -56,7 +58,7 @@ public class ServiceLifecycleUtils {
         }
         return serviceStopHandler.handlerRequest(serviceRoleInfo);
     }
-    
+
     public static ExecResult startService(ServiceRoleInfo serviceRoleInfo, boolean needReConfig) throws Exception {
         ExecResult execResult;
         if (needReConfig) {
@@ -70,26 +72,26 @@ public class ServiceLifecycleUtils {
         }
         return execResult;
     }
-    
+
     public static ExecResult stopService(ServiceRoleInfo serviceRoleInfo) throws Exception {
         ServiceHandler serviceStopHandler = new ServiceStopHandler();
         return serviceStopHandler.handlerRequest(serviceRoleInfo);
     }
-    
+
     public static ExecResult startInstallService(ServiceRoleInfo serviceRoleInfo) throws Exception {
         ServiceHandler serviceInstallHandler = new ServiceInstallHandler();
         ServiceHandler serviceConfigureHandler = new ServiceConfigureHandler();
-        
+
         // 安装时，不见是否启动成功(部分软件，需要全部节点启动成功后，状态才能成功)
         ServiceStartHandler serviceStartHandler = new ServiceStartHandler();
         serviceStartHandler.setCheckStatus(false);
-        
+
         serviceInstallHandler.setNext(serviceConfigureHandler);
         serviceConfigureHandler.setNext(serviceStartHandler);
         ExecResult execResult = serviceInstallHandler.handlerRequest(serviceRoleInfo);
         return execResult;
     }
-    
+
     /**
      * 升级角色服务，操作链
      * 1. 停止服务
@@ -99,16 +101,16 @@ public class ServiceLifecycleUtils {
      */
     public static ExecResult upgradeService(ServiceRoleInfo serviceRoleInfo) throws Exception {
         ServiceHandler handler = new ServiceStopHandler();
-        
+
         handler
                 .thenNext(new ServiceUpgradeHandler())
                 .thenNext(new ServiceConfigureHandler())
                 .thenNext(new ServiceStartHandler());
-        
+
         ExecResult execResult = handler.handlerRequest(serviceRoleInfo);
         return execResult;
     }
-    
+
     public static ExecResult configServiceRoleInstance(ClusterInfoEntity clusterInfo,
                                                        Map<Generators, List<ServiceConfig>> configFileMap,
                                                        ClusterServiceRoleInstanceEntity roleInstanceEntity) throws Exception {
@@ -118,6 +120,12 @@ public class ServiceLifecycleUtils {
         serviceRoleInfo.setFrameCode(clusterInfo.getClusterFrame());
         serviceRoleInfo.setConfigFileMap(configFileMap);
         serviceRoleInfo.setHostname(roleInstanceEntity.getHostname());
+        // ServiceConfigureHandler.resolvePackageName 依赖 archInfoMap 按主机架构解析安装包名，
+        // 不填充会在任何主机上都报"未找到匹配 CPU 架构的安装包"（ServicePkgNameUtils.getArchInfo 直接返回 null）。
+        FrameServiceService frameServiceService = SpringTool.getApplicationContext().getBean(FrameServiceService.class);
+        FrameServiceEntity frameServiceEntity = frameServiceService.getServiceByFrameCodeAndServiceName(
+                clusterInfo.getClusterFrame(), roleInstanceEntity.getServiceName());
+        serviceRoleInfo.setArchInfoMap(ServicePkgNameUtils.getArchInfo(frameServiceEntity));
         ServiceConfigureHandler configureHandler = new ServiceConfigureHandler();
         return configureHandler.handlerRequest(serviceRoleInfo);
     }

--- a/datasophon-api/src/test/java/com/datasophon/api/service/ApisixGatewayConfigServiceTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/ApisixGatewayConfigServiceTest.java
@@ -1,0 +1,347 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datasophon.api.dto.v2.ApisixGatewayResponse;
+import com.datasophon.api.exceptions.BusinessHintException;
+import com.datasophon.common.model.ServiceConfig;
+import com.datasophon.dao.entity.ClusterServiceInstanceEntity;
+import com.datasophon.dao.entity.ClusterServiceInstanceRoleGroup;
+import com.datasophon.dao.entity.ClusterServiceRoleGroupConfig;
+import com.datasophon.dao.entity.ClusterServiceRoleInstanceEntity;
+import com.datasophon.dao.enums.NeedRestart;
+import com.datasophon.dao.enums.ServiceRoleState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.baomidou.mybatisplus.core.conditions.Wrapper;
+
+class ApisixGatewayConfigServiceTest {
+
+    private static final Integer CLUSTER_ID = 1;
+    private static final Integer INSTANCE_ID = 10;
+    private static final Integer ROLE_GROUP_ID = 100;
+
+    private final ClusterInfoService clusterInfoService = mock(ClusterInfoService.class);
+    private final ClusterServiceInstanceService serviceInstanceService = mock(ClusterServiceInstanceService.class);
+    private final ClusterServiceInstanceRoleGroupService roleGroupService =
+            mock(ClusterServiceInstanceRoleGroupService.class);
+    private final ClusterServiceRoleGroupConfigService roleGroupConfigService =
+            mock(ClusterServiceRoleGroupConfigService.class);
+    private final ClusterServiceRoleInstanceService roleInstanceService =
+            mock(ClusterServiceRoleInstanceService.class);
+    private final ServiceInstallService serviceInstallService = mock(ServiceInstallService.class);
+
+    private final ApisixGatewayConfigService service = new ApisixGatewayConfigService(
+            clusterInfoService, serviceInstanceService, roleGroupService, roleGroupConfigService,
+            roleInstanceService, serviceInstallService);
+
+    private static ClusterServiceInstanceEntity apisixInstance() {
+        ClusterServiceInstanceEntity entity = new ClusterServiceInstanceEntity();
+        entity.setId(INSTANCE_ID);
+        entity.setServiceName("APISIX");
+        entity.setNeedRestart(NeedRestart.NO);
+        return entity;
+    }
+
+    private static ServiceConfig config(String name, Object value) {
+        ServiceConfig config = new ServiceConfig();
+        config.setName(name);
+        config.setValue(value);
+        return config;
+    }
+
+    private void stubEffectiveConfigs(List<ServiceConfig> configs) {
+        when(serviceInstallService.getServiceConfigOption(eq(CLUSTER_ID), eq("APISIX")))
+                .thenReturn(new ArrayList<>(configs));
+    }
+
+    private void stubDefaultRoleGroupAndEmptyPush() {
+        ClusterServiceInstanceRoleGroup group = new ClusterServiceInstanceRoleGroup();
+        group.setId(ROLE_GROUP_ID);
+        when(roleGroupService.getDefaultRoleGroupByServiceInstanceId(INSTANCE_ID)).thenReturn(group);
+        when(roleGroupService.getById(ROLE_GROUP_ID)).thenReturn(group);
+
+        ClusterServiceRoleGroupConfig savedConfig = new ClusterServiceRoleGroupConfig();
+        savedConfig.setConfigFileJson("[]");
+        when(roleGroupConfigService.getConfigByRoleGroupId(ROLE_GROUP_ID)).thenReturn(savedConfig);
+
+        when(roleInstanceService.getServiceRoleInstanceListByClusterIdAndRoleName(CLUSTER_ID, "Apisix"))
+                .thenReturn(List.of());
+    }
+
+    // ------------------------------------------------------------------
+    // T3: GET /apisix/gateway
+    // ------------------------------------------------------------------
+
+    @Test
+    void getGatewayConfig_buildsWizardYaml_whenGatewayYamlParamEmpty() {
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+        stubEffectiveConfigs(List.of(
+                config("apisixGatewayYaml", ""),
+                config("apisixRouteUri", "/get"),
+                config("apisixUpstreamHost", "192.168.10.135"),
+                config("apisixUpstreamPort", 8080)));
+        when(roleInstanceService.getServiceRoleInstanceListByClusterIdAndRoleName(CLUSTER_ID, "Apisix"))
+                .thenReturn(List.of());
+
+        ApisixGatewayResponse response = service.getGatewayConfig(CLUSTER_ID, INSTANCE_ID);
+
+        assertTrue(response.getGatewayYaml().contains("uri: '/get'"), "应由向导参数拼出初始路由");
+        assertTrue(response.getGatewayYaml().contains("'192.168.10.135:8080': 1"));
+        assertTrue(response.getManagedSuffix().contains("#END"), "托管段须含 #END");
+        assertFalse(response.getGatewayYaml().contains("#END"), "托管段不应混入用户可编辑段");
+    }
+
+    @Test
+    void getGatewayConfig_returnsPersistedYaml_whenGatewayYamlParamNonEmpty() {
+        String persisted = "upstreams:\n  - id: 1\nroutes:\n  - id: 1\n    uri: '/custom'\n";
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+        stubEffectiveConfigs(List.of(
+                config("apisixGatewayYaml", persisted),
+                config("apisixRouteUri", "/get"),
+                config("apisixUpstreamHost", "127.0.0.1"),
+                config("apisixUpstreamPort", 8080)));
+        when(roleInstanceService.getServiceRoleInstanceListByClusterIdAndRoleName(CLUSTER_ID, "Apisix"))
+                .thenReturn(List.of());
+
+        ApisixGatewayResponse response = service.getGatewayConfig(CLUSTER_ID, INSTANCE_ID);
+
+        assertEquals(persisted, response.getGatewayYaml(), "已保存过则原样返回，不重新拼向导 YAML");
+    }
+
+    @Test
+    void getGatewayConfig_backfillsMissingParam_forLegacyInstance() {
+        // 已安装实例的持久化 configJson 早于 apisixGatewayYaml 这个 DDL 参数存在
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+        stubEffectiveConfigs(List.of(
+                config("apisixRouteUri", "/legacy"),
+                config("apisixUpstreamHost", "10.0.0.1"),
+                config("apisixUpstreamPort", 9999)));
+        when(serviceInstallService.getServiceConfigFromDdl(eq(CLUSTER_ID), eq("APISIX")))
+                .thenReturn(List.of(config("apisixGatewayYaml", "")));
+        when(roleInstanceService.getServiceRoleInstanceListByClusterIdAndRoleName(CLUSTER_ID, "Apisix"))
+                .thenReturn(List.of());
+
+        ApisixGatewayResponse response = service.getGatewayConfig(CLUSTER_ID, INSTANCE_ID);
+
+        assertTrue(response.getGatewayYaml().contains("uri: '/legacy'"));
+        assertTrue(response.getGatewayYaml().contains("'10.0.0.1:9999': 1"));
+    }
+
+    @Test
+    void getGatewayConfig_mapsRoleInstancesToRoles() {
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+        stubEffectiveConfigs(List.of(
+                config("apisixGatewayYaml", "routes: []\n"),
+                config("apisixRouteUri", "/get"),
+                config("apisixUpstreamHost", "127.0.0.1"),
+                config("apisixUpstreamPort", 8080)));
+        ClusterServiceRoleInstanceEntity role = new ClusterServiceRoleInstanceEntity();
+        role.setHostname("ddh-01");
+        role.setServiceRoleState(ServiceRoleState.RUNNING);
+        when(roleInstanceService.getServiceRoleInstanceListByClusterIdAndRoleName(CLUSTER_ID, "Apisix"))
+                .thenReturn(List.of(role));
+
+        ApisixGatewayResponse response = service.getGatewayConfig(CLUSTER_ID, INSTANCE_ID);
+
+        assertEquals(1, response.getRoles().size());
+        assertEquals("ddh-01", response.getRoles().get(0).getHostname());
+    }
+
+    // ------------------------------------------------------------------
+    // T4: POST /apisix/gateway —— YAML 校验四条规则
+    // ------------------------------------------------------------------
+
+    private static final String VALID_YAML = "upstreams:\n"
+            + "  - id: 1\n"
+            + "    type: roundrobin\n"
+            + "    nodes:\n"
+            + "      '127.0.0.1:8080': 1\n"
+            + "routes:\n"
+            + "  - id: 1\n"
+            + "    uri: '/get'\n"
+            + "    upstream_id: 1\n"
+            + "global_rules:\n"
+            + "  - id: 1\n"
+            + "    plugins:\n"
+            + "      prometheus:\n"
+            + "        prefer_name: true\n"
+            + "  - id: 2\n"
+            + "    plugins:\n"
+            + "      opentelemetry:\n"
+            + "        sampler:\n"
+            + "          name: always_on\n";
+
+    @Test
+    void saveGatewayConfig_rejectsNonApisixInstance() {
+        ClusterServiceInstanceEntity other = new ClusterServiceInstanceEntity();
+        other.setId(INSTANCE_ID);
+        other.setServiceName("KAFKA");
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(other);
+
+        assertThrows(BusinessHintException.class,
+                () -> service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, VALID_YAML));
+        verify(serviceInstallService, never()).saveServiceConfig(any(), any(), any(), any());
+    }
+
+    @Test
+    void saveGatewayConfig_rejectsYamlContainingEndMarker() {
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+
+        String withEnd = VALID_YAML + "#END\n";
+        assertThrows(BusinessHintException.class,
+                () -> service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, withEnd));
+    }
+
+    @Test
+    void saveGatewayConfig_rejectsPluginMetadataKey() {
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+
+        String withPluginMetadata = VALID_YAML + "plugin_metadata:\n  - id: opentelemetry\n";
+        assertThrows(BusinessHintException.class,
+                () -> service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, withPluginMetadata));
+    }
+
+    @Test
+    void saveGatewayConfig_rejectsMissingPrometheusRule() {
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+
+        String missingPrometheus = "routes: []\n"
+                + "global_rules:\n"
+                + "  - id: 2\n"
+                + "    plugins:\n"
+                + "      opentelemetry:\n"
+                + "        sampler:\n"
+                + "          name: always_on\n";
+        assertThrows(BusinessHintException.class,
+                () -> service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, missingPrometheus));
+    }
+
+    @Test
+    void saveGatewayConfig_rejectsMissingOpentelemetryRule() {
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+
+        String missingOtel = "routes: []\n"
+                + "global_rules:\n"
+                + "  - id: 1\n"
+                + "    plugins:\n"
+                + "      prometheus:\n"
+                + "        prefer_name: true\n";
+        assertThrows(BusinessHintException.class,
+                () -> service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, missingOtel));
+    }
+
+    @Test
+    void saveGatewayConfig_rejectsUnparsableYaml() {
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+
+        assertThrows(BusinessHintException.class,
+                () -> service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, "not: [valid"));
+    }
+
+    @Test
+    void saveGatewayConfig_acceptsValidYaml_andSavesWithDefaultRoleGroupSentinel() {
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
+        stubEffectiveConfigs(List.of(
+                config("apisixGatewayYaml", ""),
+                config("apisixRouteUri", "/get"),
+                config("apisixUpstreamHost", "127.0.0.1"),
+                config("apisixUpstreamPort", 8080)));
+        stubDefaultRoleGroupAndEmptyPush();
+
+        service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, VALID_YAML);
+
+        verify(serviceInstallService).saveServiceConfig(eq(CLUSTER_ID), eq("APISIX"), any(), eq(-1));
+    }
+
+    // ------------------------------------------------------------------
+    // T4: needRestart 有条件复位
+    // ------------------------------------------------------------------
+
+    @Test
+    void saveGatewayConfig_resetsNeedRestart_whenPreviouslyNo() {
+        ClusterServiceInstanceEntity instance = apisixInstance();
+        instance.setNeedRestart(NeedRestart.NO);
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(instance);
+        stubEffectiveConfigs(List.of(
+                config("apisixGatewayYaml", ""),
+                config("apisixRouteUri", "/get"),
+                config("apisixUpstreamHost", "127.0.0.1"),
+                config("apisixUpstreamPort", 8080)));
+        stubDefaultRoleGroupAndEmptyPush();
+        ClusterServiceRoleInstanceEntity roleInstance = new ClusterServiceRoleInstanceEntity();
+        roleInstance.setNeedRestart(NeedRestart.YES);
+        when(roleInstanceService.list(any(Wrapper.class))).thenReturn(new ArrayList<>(List.of(roleInstance)));
+
+        service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, VALID_YAML);
+
+        verify(serviceInstanceService).updateById(argThatNeedRestartIsNo());
+        verify(roleGroupService).updateById(argThatRoleGroupNeedRestartIsNo());
+        verify(roleInstanceService).updateBatchById(any());
+        assertEquals(NeedRestart.NO, roleInstance.getNeedRestart(), "角色实例应被复位回 NO");
+    }
+
+    @Test
+    void saveGatewayConfig_keepsNeedRestart_whenPreviouslyYes() {
+        ClusterServiceInstanceEntity instance = apisixInstance();
+        instance.setNeedRestart(NeedRestart.YES);
+        when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(instance);
+        stubEffectiveConfigs(List.of(
+                config("apisixGatewayYaml", ""),
+                config("apisixRouteUri", "/get"),
+                config("apisixUpstreamHost", "127.0.0.1"),
+                config("apisixUpstreamPort", 8080)));
+        stubDefaultRoleGroupAndEmptyPush();
+
+        service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, VALID_YAML);
+
+        // 调用前已是 YES：说明用户另改过需重启项（如端口），不能被网关保存悄悄清掉
+        verify(serviceInstanceService, never()).updateById(any());
+        verify(roleGroupService, never()).updateById(any());
+        verify(roleInstanceService, never()).updateBatchById(any());
+    }
+
+    private static ClusterServiceInstanceEntity argThatNeedRestartIsNo() {
+        return argThat(e -> e.getNeedRestart() == NeedRestart.NO);
+    }
+
+    private static ClusterServiceInstanceRoleGroup argThatRoleGroupNeedRestartIsNo() {
+        return argThat(g -> g.getNeedRestart() == NeedRestart.NO);
+    }
+}

--- a/datasophon-api/src/test/java/com/datasophon/api/service/ApisixGatewayConfigServiceTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/ApisixGatewayConfigServiceTest.java
@@ -46,6 +46,7 @@ import com.datasophon.dao.enums.ServiceRoleState;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 import org.junit.jupiter.api.Test;
 
@@ -66,10 +67,11 @@ class ApisixGatewayConfigServiceTest {
     private final ClusterServiceRoleInstanceService roleInstanceService =
             mock(ClusterServiceRoleInstanceService.class);
     private final ServiceInstallService serviceInstallService = mock(ServiceInstallService.class);
+    private final Executor synchronousExecutor = Runnable::run;
 
     private final ApisixGatewayConfigService service = new ApisixGatewayConfigService(
             clusterInfoService, serviceInstanceService, roleGroupService, roleGroupConfigService,
-            roleInstanceService, serviceInstallService);
+            roleInstanceService, serviceInstallService, synchronousExecutor);
 
     private static ClusterServiceInstanceEntity apisixInstance() {
         ClusterServiceInstanceEntity entity = new ClusterServiceInstanceEntity();
@@ -89,6 +91,15 @@ class ApisixGatewayConfigServiceTest {
     private void stubEffectiveConfigs(List<ServiceConfig> configs) {
         when(serviceInstallService.getServiceConfigOption(eq(CLUSTER_ID), eq("APISIX")))
                 .thenReturn(new ArrayList<>(configs));
+    }
+
+    /** T4 各用例保存前的默认已持久化配置（apisixGatewayYaml 已存在，路由/上游走向导默认值）。 */
+    private static List<ServiceConfig> defaultSaveConfigs() {
+        return List.of(
+                config("apisixGatewayYaml", ""),
+                config("apisixRouteUri", "/get"),
+                config("apisixUpstreamHost", "127.0.0.1"),
+                config("apisixUpstreamPort", 8080));
     }
 
     private void stubDefaultRoleGroupAndEmptyPush() {
@@ -278,11 +289,7 @@ class ApisixGatewayConfigServiceTest {
     @Test
     void saveGatewayConfig_acceptsValidYaml_andSavesWithDefaultRoleGroupSentinel() {
         when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(apisixInstance());
-        stubEffectiveConfigs(List.of(
-                config("apisixGatewayYaml", ""),
-                config("apisixRouteUri", "/get"),
-                config("apisixUpstreamHost", "127.0.0.1"),
-                config("apisixUpstreamPort", 8080)));
+        stubEffectiveConfigs(defaultSaveConfigs());
         stubDefaultRoleGroupAndEmptyPush();
 
         service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, VALID_YAML);
@@ -299,11 +306,7 @@ class ApisixGatewayConfigServiceTest {
         ClusterServiceInstanceEntity instance = apisixInstance();
         instance.setNeedRestart(NeedRestart.NO);
         when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(instance);
-        stubEffectiveConfigs(List.of(
-                config("apisixGatewayYaml", ""),
-                config("apisixRouteUri", "/get"),
-                config("apisixUpstreamHost", "127.0.0.1"),
-                config("apisixUpstreamPort", 8080)));
+        stubEffectiveConfigs(defaultSaveConfigs());
         stubDefaultRoleGroupAndEmptyPush();
         ClusterServiceRoleInstanceEntity roleInstance = new ClusterServiceRoleInstanceEntity();
         roleInstance.setNeedRestart(NeedRestart.YES);
@@ -322,11 +325,7 @@ class ApisixGatewayConfigServiceTest {
         ClusterServiceInstanceEntity instance = apisixInstance();
         instance.setNeedRestart(NeedRestart.YES);
         when(serviceInstanceService.getById(INSTANCE_ID)).thenReturn(instance);
-        stubEffectiveConfigs(List.of(
-                config("apisixGatewayYaml", ""),
-                config("apisixRouteUri", "/get"),
-                config("apisixUpstreamHost", "127.0.0.1"),
-                config("apisixUpstreamPort", 8080)));
+        stubEffectiveConfigs(defaultSaveConfigs());
         stubDefaultRoleGroupAndEmptyPush();
 
         service.saveGatewayConfig(CLUSTER_ID, INSTANCE_ID, VALID_YAML);

--- a/datasophon-ui-v2/src/locales/en-US.ts
+++ b/datasophon-ui-v2/src/locales/en-US.ts
@@ -1,3 +1,4 @@
+import apisixGateway from './en-US/apisixGateway';
 import apisixMonitor from './en-US/apisixMonitor';
 import clusterDashboard from './en-US/clusterDashboard';
 import component from './en-US/component';
@@ -45,4 +46,5 @@ export default {
   ...additionalMonitor,
   ...clusterDashboard,
   ...lineage,
+  ...apisixGateway,
 };

--- a/datasophon-ui-v2/src/locales/en-US/apisixGateway.test.ts
+++ b/datasophon-ui-v2/src/locales/en-US/apisixGateway.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import messages from './apisixGateway';
+import zhMessages from '../zh-CN/apisixGateway';
+
+describe('en-US Apisix gateway locale', () => {
+  it('all keys exist and are non-empty', () => {
+    const localeMessages: Record<string, string> = messages;
+    for (const key of Object.keys(localeMessages)) {
+      expect(key.startsWith('pages.apisixGateway.')).toBe(true);
+      expect(localeMessages[key]).toBeTypeOf('string');
+      expect(localeMessages[key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keys are fully aligned with zh-CN', () => {
+    const enKeys = Object.keys(messages).sort();
+    const zhKeys = Object.keys(zhMessages).sort();
+    expect(enKeys).toEqual(zhKeys);
+  });
+});

--- a/datasophon-ui-v2/src/locales/en-US/apisixGateway.ts
+++ b/datasophon-ui-v2/src/locales/en-US/apisixGateway.ts
@@ -1,0 +1,22 @@
+export default {
+  'pages.apisixGateway.tab': 'Gateway Config',
+  'pages.apisixGateway.view.graphic': 'Graphic',
+  'pages.apisixGateway.view.code': 'Code',
+  'pages.apisixGateway.save': 'Save',
+  'pages.apisixGateway.saveSuccess': 'Gateway config saved and pushed',
+  'pages.apisixGateway.saveFailed': 'Save failed',
+  'pages.apisixGateway.banner.managedHint':
+    'plugin_metadata (tracing) and the trailing #END marker are managed by the platform and cannot be edited here',
+  'pages.apisixGateway.preview.button': 'Preview final apisix.yaml',
+  'pages.apisixGateway.preview.title': 'Final apisix.yaml preview (read-only)',
+  'pages.apisixGateway.resource.routes': 'Routes',
+  'pages.apisixGateway.resource.upstreams': 'Upstreams',
+  'pages.apisixGateway.resource.globalRules': 'Global Rules',
+  'pages.apisixGateway.globalRule.builtin': 'Built-in',
+  'pages.apisixGateway.confirm.commentsLostTitle': 'Comments will be lost',
+  'pages.apisixGateway.confirm.commentsLostContent':
+    'The current code has comments. They cannot be preserved once you switch to the graphic view and back. Continue?',
+  'pages.apisixGateway.parseError': 'Failed to parse YAML, please fix the errors in the code view first',
+  'pages.apisixGateway.unknownSegmentsHint':
+    'The current config also has {count} section(s) editable only in the code view (e.g. consumers)',
+};

--- a/datasophon-ui-v2/src/locales/zh-CN.ts
+++ b/datasophon-ui-v2/src/locales/zh-CN.ts
@@ -1,3 +1,4 @@
+import apisixGateway from './zh-CN/apisixGateway';
 import apisixMonitor from './zh-CN/apisixMonitor';
 import clusterDashboard from './zh-CN/clusterDashboard';
 import component from './zh-CN/component';
@@ -45,4 +46,5 @@ export default {
   ...additionalMonitor,
   ...clusterDashboard,
   ...lineage,
+  ...apisixGateway,
 };

--- a/datasophon-ui-v2/src/locales/zh-CN/apisixGateway.test.ts
+++ b/datasophon-ui-v2/src/locales/zh-CN/apisixGateway.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import messages from './apisixGateway';
+import enMessages from '../en-US/apisixGateway';
+
+describe('zh-CN Apisix gateway locale', () => {
+  it('all keys exist and are non-empty', () => {
+    const localeMessages: Record<string, string> = messages;
+    for (const key of Object.keys(localeMessages)) {
+      expect(key.startsWith('pages.apisixGateway.')).toBe(true);
+      expect(localeMessages[key]).toBeTypeOf('string');
+      expect(localeMessages[key].length).toBeGreaterThan(0);
+    }
+  });
+
+  it('keys are fully aligned with en-US', () => {
+    const zhKeys = Object.keys(messages).sort();
+    const enKeys = Object.keys(enMessages).sort();
+    expect(zhKeys).toEqual(enKeys);
+  });
+});

--- a/datasophon-ui-v2/src/locales/zh-CN/apisixGateway.ts
+++ b/datasophon-ui-v2/src/locales/zh-CN/apisixGateway.ts
@@ -1,0 +1,22 @@
+export default {
+  'pages.apisixGateway.tab': '网关配置',
+  'pages.apisixGateway.view.graphic': '图形化',
+  'pages.apisixGateway.view.code': '代码化',
+  'pages.apisixGateway.save': '保存',
+  'pages.apisixGateway.saveSuccess': '网关配置已保存并下发',
+  'pages.apisixGateway.saveFailed': '保存失败',
+  'pages.apisixGateway.banner.managedHint':
+    'plugin_metadata（链路追踪）与文件末尾的 #END 终止符由平台统一管理，不在此处编辑',
+  'pages.apisixGateway.preview.button': '预览最终 apisix.yaml',
+  'pages.apisixGateway.preview.title': '最终 apisix.yaml 预览（只读）',
+  'pages.apisixGateway.resource.routes': 'Routes',
+  'pages.apisixGateway.resource.upstreams': 'Upstreams',
+  'pages.apisixGateway.resource.globalRules': 'Global Rules',
+  'pages.apisixGateway.globalRule.builtin': '系统内置',
+  'pages.apisixGateway.confirm.commentsLostTitle': '切换视图将丢失注释',
+  'pages.apisixGateway.confirm.commentsLostContent':
+    '当前代码含有注释，切换到图形化视图再切回时注释将无法保留，是否继续？',
+  'pages.apisixGateway.parseError': 'YAML 解析失败，请先修正代码视图中的错误',
+  'pages.apisixGateway.unknownSegmentsHint':
+    '当前配置还含有 {count} 个仅可在代码视图编辑的段（如 consumers）',
+};

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/CodeView.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/CodeView.tsx
@@ -6,9 +6,9 @@
  */
 
 import Editor from '@monaco-editor/react';
+import { useIntl } from '@umijs/max';
 import { Alert, Button, Drawer } from 'antd';
 import React, { useState } from 'react';
-import { useIntl } from '@umijs/max';
 
 interface CodeViewProps {
   text: string;
@@ -16,7 +16,17 @@ interface CodeViewProps {
   managedSuffix: string;
 }
 
-const CodeView: React.FC<CodeViewProps> = ({ text, onChange, managedSuffix }) => {
+const MONACO_YAML_OPTIONS = {
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  fontSize: 13,
+};
+
+const CodeView: React.FC<CodeViewProps> = ({
+  text,
+  onChange,
+  managedSuffix,
+}) => {
   const intl = useIntl();
   const [previewOpen, setPreviewOpen] = useState(false);
 
@@ -30,22 +40,26 @@ const CodeView: React.FC<CodeViewProps> = ({ text, onChange, managedSuffix }) =>
           id: 'pages.apisixGateway.banner.managedHint',
         })}
       />
-      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+      <div
+        style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}
+      >
         <Button onClick={() => setPreviewOpen(true)}>
           {intl.formatMessage({ id: 'pages.apisixGateway.preview.button' })}
         </Button>
       </div>
-      <div style={{ border: '1px solid #e8e8e8', borderRadius: 4, overflow: 'hidden' }}>
+      <div
+        style={{
+          border: '1px solid #e8e8e8',
+          borderRadius: 4,
+          overflow: 'hidden',
+        }}
+      >
         <Editor
           height="60vh"
           language="yaml"
           value={text}
           onChange={(v) => onChange(v ?? '')}
-          options={{
-            minimap: { enabled: false },
-            scrollBeyondLastLine: false,
-            fontSize: 13,
-          }}
+          options={MONACO_YAML_OPTIONS}
         />
       </div>
       <Drawer
@@ -58,12 +72,7 @@ const CodeView: React.FC<CodeViewProps> = ({ text, onChange, managedSuffix }) =>
           height="80vh"
           language="yaml"
           value={text + managedSuffix}
-          options={{
-            readOnly: true,
-            minimap: { enabled: false },
-            scrollBeyondLastLine: false,
-            fontSize: 13,
-          }}
+          options={{ ...MONACO_YAML_OPTIONS, readOnly: true }}
         />
       </Drawer>
     </div>

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/CodeView.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/CodeView.tsx
@@ -1,0 +1,73 @@
+/**
+ * 网关配置代码视图：Monaco 编辑 apisixGatewayYaml 用户可编辑段。
+ *
+ * plugin_metadata 与 #END 由模板固定输出、不在此编辑，故提供只读的
+ * 「预览最终 apisix.yaml」抽屉：拼接 text + managedSuffix 展示真实落盘效果。
+ */
+
+import Editor from '@monaco-editor/react';
+import { Alert, Button, Drawer } from 'antd';
+import React, { useState } from 'react';
+import { useIntl } from '@umijs/max';
+
+interface CodeViewProps {
+  text: string;
+  onChange: (text: string) => void;
+  managedSuffix: string;
+}
+
+const CodeView: React.FC<CodeViewProps> = ({ text, onChange, managedSuffix }) => {
+  const intl = useIntl();
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  return (
+    <div>
+      <Alert
+        type="info"
+        showIcon
+        style={{ marginBottom: 8 }}
+        message={intl.formatMessage({
+          id: 'pages.apisixGateway.banner.managedHint',
+        })}
+      />
+      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 8 }}>
+        <Button onClick={() => setPreviewOpen(true)}>
+          {intl.formatMessage({ id: 'pages.apisixGateway.preview.button' })}
+        </Button>
+      </div>
+      <div style={{ border: '1px solid #e8e8e8', borderRadius: 4, overflow: 'hidden' }}>
+        <Editor
+          height="60vh"
+          language="yaml"
+          value={text}
+          onChange={(v) => onChange(v ?? '')}
+          options={{
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            fontSize: 13,
+          }}
+        />
+      </div>
+      <Drawer
+        title={intl.formatMessage({ id: 'pages.apisixGateway.preview.title' })}
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        width={720}
+      >
+        <Editor
+          height="80vh"
+          language="yaml"
+          value={text + managedSuffix}
+          options={{
+            readOnly: true,
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            fontSize: 13,
+          }}
+        />
+      </Drawer>
+    </div>
+  );
+};
+
+export default CodeView;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/GlobalRuleTable.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/GlobalRuleTable.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import GlobalRuleTable from './GlobalRuleTable';
+import type { ApisixGatewayDoc } from './gatewayYaml';
+
+vi.mock('@umijs/max', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+// @ant-design/pro-components 在这个 vitest(happy-dom + ESM) 组合下直接 import 会报
+// "exports is not defined in ES module scope"（仓库既有测试如 History.test.tsx 也是这么绕过的），
+// 这里给一个足够真实的 ProTable mock：按 columns 对 dataSource 逐行渲染，
+// 保证「操作」列里的 <a> 链接是真实可点击的 DOM 节点。
+vi.mock('@ant-design/pro-components', () => ({
+  ProTable: ({
+    columns,
+    dataSource,
+    toolBarRender,
+  }: {
+    columns: Array<{ dataIndex?: string; render?: (v: unknown, r: any) => ReactNode }>;
+    dataSource: any[];
+    toolBarRender?: () => ReactNode;
+  }) => (
+    <div>
+      {toolBarRender?.()}
+      <table>
+        <tbody>
+          {dataSource.map((record, i) => (
+            <tr key={record.id ?? i}>
+              {columns.map((col, j) => (
+                <td key={col.dataIndex ?? j}>
+                  {col.render
+                    ? col.render(col.dataIndex ? record[col.dataIndex] : undefined, record)
+                    : String(record[col.dataIndex ?? ''] ?? '')}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ),
+  ModalForm: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  ProFormDigit: () => null,
+  ProFormText: () => null,
+  ProFormTextArea: () => null,
+  ProFormSelect: () => null,
+}));
+
+const DOC: ApisixGatewayDoc = {
+  global_rules: [
+    { id: 1, plugins: { prometheus: { prefer_name: true } } },
+    { id: 2, plugins: { opentelemetry: {} } },
+    { id: 3, plugins: { 'limit-count': {} } },
+  ],
+};
+
+describe('GlobalRuleTable builtin rule protection', () => {
+  it('marks id 1/2 as builtin and hides edit/delete actions for them', () => {
+    render(<GlobalRuleTable doc={DOC} onChange={vi.fn()} />);
+
+    const builtinTags = screen.getAllByText('pages.apisixGateway.globalRule.builtin');
+    expect(builtinTags).toHaveLength(2);
+
+    // 非内置规则(id 3)仍有编辑/删除入口
+    expect(screen.getAllByText('删除')).toHaveLength(1);
+    expect(screen.getAllByText('编辑')).toHaveLength(1);
+  });
+
+  it('deleting the non-builtin rule keeps both builtin rules intact', () => {
+    const onChange = vi.fn();
+    render(<GlobalRuleTable doc={DOC} onChange={onChange} />);
+
+    fireEvent.click(screen.getByText('删除'));
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...DOC,
+      global_rules: [
+        { id: 1, plugins: { prometheus: { prefer_name: true } } },
+        { id: 2, plugins: { opentelemetry: {} } },
+      ],
+    });
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/GlobalRuleTable.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/GlobalRuleTable.tsx
@@ -1,22 +1,14 @@
-import { PlusOutlined } from '@ant-design/icons';
-import {
-  ModalForm,
-  ProFormDigit,
-  ProFormTextArea,
-  type ProColumns,
-  ProTable,
-} from '@ant-design/pro-components';
-import { App, Button, Tag } from 'antd';
-import React, { useState } from 'react';
+import { type ProColumns, ProFormTextArea } from '@ant-design/pro-components';
 import { useIntl } from '@umijs/max';
+import { Tag } from 'antd';
+import React from 'react';
 import {
-  findDuplicateIds,
-  isBuiltinGlobalRule,
-  removeGlobalRule,
-  upsertById,
   type ApisixGatewayDoc,
   type ApisixGlobalRule,
+  isBuiltinGlobalRule,
+  removeGlobalRule,
 } from './gatewayYaml';
+import { ResourceCrudTable } from './ResourceCrudTable';
 
 interface GlobalRuleTableProps {
   doc: ApisixGatewayDoc;
@@ -25,36 +17,9 @@ interface GlobalRuleTableProps {
 
 const GlobalRuleTable: React.FC<GlobalRuleTableProps> = ({ doc, onChange }) => {
   const intl = useIntl();
-  const { message } = App.useApp();
   const rules = doc.global_rules ?? [];
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editRecord, setEditRecord] = useState<ApisixGlobalRule | null>(null);
-
-  const handleDelete = (record: ApisixGlobalRule) => {
-    onChange({ ...doc, global_rules: removeGlobalRule(rules, record.id) });
-  };
-
-  const onFinish = async (values: Record<string, any>) => {
-    let plugins: Record<string, unknown>;
-    try {
-      plugins = JSON.parse(values.pluginsJson || '{}');
-    } catch {
-      message.error('plugins 不是合法的 JSON');
-      return false;
-    }
-    const updated: ApisixGlobalRule = { ...(editRecord ?? {}), id: values.id, plugins };
-    const next = upsertById(rules, updated);
-    if (findDuplicateIds(next).length > 0) {
-      message.error('id 已存在，请使用唯一 id');
-      return false;
-    }
-    onChange({ ...doc, global_rules: next });
-    setModalOpen(false);
-    return true;
-  };
 
   const columns: ProColumns<ApisixGlobalRule>[] = [
-    { title: 'id', dataIndex: 'id', width: 80 },
     {
       title: 'plugins',
       dataIndex: 'plugins',
@@ -68,91 +33,48 @@ const GlobalRuleTable: React.FC<GlobalRuleTableProps> = ({ doc, onChange }) => {
       render: (_, record) =>
         isBuiltinGlobalRule(record) ? (
           <Tag color="blue">
-            {intl.formatMessage({ id: 'pages.apisixGateway.globalRule.builtin' })}
+            {intl.formatMessage({
+              id: 'pages.apisixGateway.globalRule.builtin',
+            })}
           </Tag>
         ) : null,
-    },
-    {
-      title: '操作',
-      valueType: 'option',
-      width: 120,
-      render: (_, record) =>
-        isBuiltinGlobalRule(record)
-          ? []
-          : [
-              <a
-                key="edit"
-                onClick={() => {
-                  setEditRecord(record);
-                  setModalOpen(true);
-                }}
-              >
-                编辑
-              </a>,
-              <a
-                key="delete"
-                style={{ color: 'red' }}
-                onClick={() => handleDelete(record)}
-              >
-                删除
-              </a>,
-            ],
     },
   ];
 
   return (
-    <>
-      <ProTable<ApisixGlobalRule>
-        rowKey="id"
-        columns={columns}
-        dataSource={rules}
-        search={false}
-        options={false}
-        pagination={false}
-        toolBarRender={() => [
-          <Button
-            key="add"
-            type="primary"
-            icon={<PlusOutlined />}
-            onClick={() => {
-              setEditRecord(null);
-              setModalOpen(true);
-            }}
-          >
-            新建 Global Rule
-          </Button>,
-        ]}
-      />
-      <ModalForm
-        title={editRecord ? '编辑 Global Rule' : '新建 Global Rule'}
-        open={modalOpen}
-        onOpenChange={setModalOpen}
-        onFinish={onFinish}
-        initialValues={
-          editRecord
-            ? {
-                id: editRecord.id,
-                pluginsJson: JSON.stringify(editRecord.plugins ?? {}, null, 2),
-              }
-            : { pluginsJson: '{\n\n}' }
+    <ResourceCrudTable<ApisixGlobalRule>
+      resourceLabel="Global Rule"
+      items={rules}
+      onChange={(next) => onChange({ ...doc, global_rules: next })}
+      columns={columns}
+      canModify={(record) => !isBuiltinGlobalRule(record)}
+      deleteItem={(items, record) => removeGlobalRule(items, record.id)}
+      getInitialValues={(editRecord) =>
+        editRecord
+          ? {
+              id: editRecord.id,
+              pluginsJson: JSON.stringify(editRecord.plugins ?? {}, null, 2),
+            }
+          : { pluginsJson: '{\n\n}' }
+      }
+      parseValues={(values, editRecord) => {
+        let plugins: Record<string, unknown>;
+        try {
+          plugins = JSON.parse(values.pluginsJson || '{}');
+        } catch {
+          return 'plugins 不是合法的 JSON';
         }
-        width={480}
-        modalProps={{ destroyOnHidden: true }}
-      >
-        <ProFormDigit
-          name="id"
-          label="id"
-          disabled={!!editRecord}
-          rules={[{ required: true, message: '请输入 id' }]}
-        />
+        return { ...(editRecord ?? {}), id: values.id, plugins };
+      }}
+      formFields={
         <ProFormTextArea
           name="pluginsJson"
           label="plugins（JSON）"
           fieldProps={{ rows: 6 }}
           rules={[{ required: true, message: '请输入 plugins' }]}
         />
-      </ModalForm>
-    </>
+      }
+    />
   );
 };
 

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/GlobalRuleTable.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/GlobalRuleTable.tsx
@@ -1,0 +1,159 @@
+import { PlusOutlined } from '@ant-design/icons';
+import {
+  ModalForm,
+  ProFormDigit,
+  ProFormTextArea,
+  type ProColumns,
+  ProTable,
+} from '@ant-design/pro-components';
+import { App, Button, Tag } from 'antd';
+import React, { useState } from 'react';
+import { useIntl } from '@umijs/max';
+import {
+  findDuplicateIds,
+  isBuiltinGlobalRule,
+  removeGlobalRule,
+  upsertById,
+  type ApisixGatewayDoc,
+  type ApisixGlobalRule,
+} from './gatewayYaml';
+
+interface GlobalRuleTableProps {
+  doc: ApisixGatewayDoc;
+  onChange: (next: ApisixGatewayDoc) => void;
+}
+
+const GlobalRuleTable: React.FC<GlobalRuleTableProps> = ({ doc, onChange }) => {
+  const intl = useIntl();
+  const { message } = App.useApp();
+  const rules = doc.global_rules ?? [];
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editRecord, setEditRecord] = useState<ApisixGlobalRule | null>(null);
+
+  const handleDelete = (record: ApisixGlobalRule) => {
+    onChange({ ...doc, global_rules: removeGlobalRule(rules, record.id) });
+  };
+
+  const onFinish = async (values: Record<string, any>) => {
+    let plugins: Record<string, unknown>;
+    try {
+      plugins = JSON.parse(values.pluginsJson || '{}');
+    } catch {
+      message.error('plugins 不是合法的 JSON');
+      return false;
+    }
+    const updated: ApisixGlobalRule = { ...(editRecord ?? {}), id: values.id, plugins };
+    const next = upsertById(rules, updated);
+    if (findDuplicateIds(next).length > 0) {
+      message.error('id 已存在，请使用唯一 id');
+      return false;
+    }
+    onChange({ ...doc, global_rules: next });
+    setModalOpen(false);
+    return true;
+  };
+
+  const columns: ProColumns<ApisixGlobalRule>[] = [
+    { title: 'id', dataIndex: 'id', width: 80 },
+    {
+      title: 'plugins',
+      dataIndex: 'plugins',
+      render: (_, record) =>
+        record.plugins ? Object.keys(record.plugins).join(', ') : '-',
+    },
+    {
+      title: '',
+      dataIndex: 'builtin',
+      width: 100,
+      render: (_, record) =>
+        isBuiltinGlobalRule(record) ? (
+          <Tag color="blue">
+            {intl.formatMessage({ id: 'pages.apisixGateway.globalRule.builtin' })}
+          </Tag>
+        ) : null,
+    },
+    {
+      title: '操作',
+      valueType: 'option',
+      width: 120,
+      render: (_, record) =>
+        isBuiltinGlobalRule(record)
+          ? []
+          : [
+              <a
+                key="edit"
+                onClick={() => {
+                  setEditRecord(record);
+                  setModalOpen(true);
+                }}
+              >
+                编辑
+              </a>,
+              <a
+                key="delete"
+                style={{ color: 'red' }}
+                onClick={() => handleDelete(record)}
+              >
+                删除
+              </a>,
+            ],
+    },
+  ];
+
+  return (
+    <>
+      <ProTable<ApisixGlobalRule>
+        rowKey="id"
+        columns={columns}
+        dataSource={rules}
+        search={false}
+        options={false}
+        pagination={false}
+        toolBarRender={() => [
+          <Button
+            key="add"
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              setEditRecord(null);
+              setModalOpen(true);
+            }}
+          >
+            新建 Global Rule
+          </Button>,
+        ]}
+      />
+      <ModalForm
+        title={editRecord ? '编辑 Global Rule' : '新建 Global Rule'}
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        onFinish={onFinish}
+        initialValues={
+          editRecord
+            ? {
+                id: editRecord.id,
+                pluginsJson: JSON.stringify(editRecord.plugins ?? {}, null, 2),
+              }
+            : { pluginsJson: '{\n\n}' }
+        }
+        width={480}
+        modalProps={{ destroyOnHidden: true }}
+      >
+        <ProFormDigit
+          name="id"
+          label="id"
+          disabled={!!editRecord}
+          rules={[{ required: true, message: '请输入 id' }]}
+        />
+        <ProFormTextArea
+          name="pluginsJson"
+          label="plugins（JSON）"
+          fieldProps={{ rows: 6 }}
+          rules={[{ required: true, message: '请输入 plugins' }]}
+        />
+      </ModalForm>
+    </>
+  );
+};
+
+export default GlobalRuleTable;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/GraphicView.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/GraphicView.tsx
@@ -1,0 +1,75 @@
+import { Alert, Menu } from 'antd';
+import React, { useMemo, useState } from 'react';
+import { useIntl } from '@umijs/max';
+import GlobalRuleTable from './GlobalRuleTable';
+import RouteTable from './RouteTable';
+import UpstreamTable from './UpstreamTable';
+import type { ApisixGatewayDoc } from './gatewayYaml';
+
+const KNOWN_TOP_LEVEL_KEYS = ['upstreams', 'routes', 'global_rules'];
+
+type ResourceType = 'routes' | 'upstreams' | 'globalRules';
+
+interface GraphicViewProps {
+  doc: ApisixGatewayDoc;
+  onChange: (next: ApisixGatewayDoc) => void;
+}
+
+const GraphicView: React.FC<GraphicViewProps> = ({ doc, onChange }) => {
+  const intl = useIntl();
+  const [resource, setResource] = useState<ResourceType>('routes');
+
+  const unknownSegmentCount = useMemo(
+    () => Object.keys(doc).filter((key) => !KNOWN_TOP_LEVEL_KEYS.includes(key)).length,
+    [doc],
+  );
+
+  const menuItems = [
+    {
+      key: 'routes',
+      label: intl.formatMessage({ id: 'pages.apisixGateway.resource.routes' }),
+    },
+    {
+      key: 'upstreams',
+      label: intl.formatMessage({ id: 'pages.apisixGateway.resource.upstreams' }),
+    },
+    {
+      key: 'globalRules',
+      label: intl.formatMessage({ id: 'pages.apisixGateway.resource.globalRules' }),
+    },
+  ];
+
+  return (
+    <div>
+      {unknownSegmentCount > 0 && (
+        <Alert
+          type="warning"
+          showIcon
+          style={{ marginBottom: 8 }}
+          message={intl.formatMessage(
+            { id: 'pages.apisixGateway.unknownSegmentsHint' },
+            { count: unknownSegmentCount },
+          )}
+        />
+      )}
+      <div style={{ display: 'flex', gap: 16 }}>
+        <Menu
+          mode="vertical"
+          selectedKeys={[resource]}
+          items={menuItems}
+          onClick={({ key }) => setResource(key as ResourceType)}
+          style={{ width: 160, flexShrink: 0 }}
+        />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {resource === 'routes' && <RouteTable doc={doc} onChange={onChange} />}
+          {resource === 'upstreams' && <UpstreamTable doc={doc} onChange={onChange} />}
+          {resource === 'globalRules' && (
+            <GlobalRuleTable doc={doc} onChange={onChange} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default GraphicView;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/ResourceCrudTable.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/ResourceCrudTable.tsx
@@ -1,0 +1,156 @@
+/**
+ * upstreams/routes/global_rules 三张表共用的增删改脚手架：id 列、操作列、
+ * 新建/编辑弹窗、id 唯一性校验、保存回调都在这里统一实现，调用方只需提供
+ * 资源特有的列、表单字段与"表单值 -> 记录"的解析函数。
+ */
+
+import { PlusOutlined } from '@ant-design/icons';
+import {
+  ModalForm,
+  type ProColumns,
+  ProFormDigit,
+  ProTable,
+} from '@ant-design/pro-components';
+import { App, Button } from 'antd';
+import React, { useState } from 'react';
+import { findDuplicateIds, upsertById } from './gatewayYaml';
+
+export interface ResourceCrudTableProps<T extends { id: number | string }> {
+  /** 用于按钮/弹窗标题，如「Upstream」「Route」「Global Rule」 */
+  resourceLabel: string;
+  items: T[];
+  onChange: (next: T[]) => void;
+  /** 资源特有列（id 列、操作列由本组件统一渲染，这里不用再传） */
+  columns: ProColumns<T>[];
+  /** 资源特有表单字段（id 字段由本组件统一渲染） */
+  formFields: React.ReactNode;
+  getInitialValues: (editRecord: T | null) => Record<string, any>;
+  /** 把表单值解析为完整记录；返回字符串表示校验失败，字符串内容即错误提示 */
+  parseValues: (
+    values: Record<string, any>,
+    editRecord: T | null,
+  ) => T | string;
+  /** 删除单条记录后的新列表，默认按 id 过滤 */
+  deleteItem?: (items: T[], record: T) => T[];
+  /** 某条记录是否允许编辑/删除，默认恒为 true */
+  canModify?: (record: T) => boolean;
+}
+
+function defaultDeleteItem<T extends { id: number | string }>(
+  items: T[],
+  record: T,
+): T[] {
+  return items.filter((item) => String(item.id) !== String(record.id));
+}
+
+export function ResourceCrudTable<T extends { id: number | string }>({
+  resourceLabel,
+  items,
+  onChange,
+  columns,
+  formFields,
+  getInitialValues,
+  parseValues,
+  deleteItem = defaultDeleteItem,
+  canModify = () => true,
+}: ResourceCrudTableProps<T>) {
+  const { message } = App.useApp();
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editRecord, setEditRecord] = useState<T | null>(null);
+
+  const handleDelete = (record: T) => {
+    onChange(deleteItem(items, record));
+  };
+
+  const onFinish = async (values: Record<string, any>) => {
+    const parsed = parseValues(values, editRecord);
+    if (typeof parsed === 'string') {
+      message.error(parsed);
+      return false;
+    }
+    const next = upsertById(items, parsed);
+    if (findDuplicateIds(next).length > 0) {
+      message.error('id 已存在，请使用唯一 id');
+      return false;
+    }
+    onChange(next);
+    setModalOpen(false);
+    return true;
+  };
+
+  const allColumns: ProColumns<T>[] = [
+    { title: 'id', dataIndex: 'id', width: 80 },
+    ...columns,
+    {
+      title: '操作',
+      valueType: 'option',
+      width: 120,
+      render: (_, record) =>
+        canModify(record)
+          ? [
+              <a
+                key="edit"
+                onClick={() => {
+                  setEditRecord(record);
+                  setModalOpen(true);
+                }}
+              >
+                编辑
+              </a>,
+              <a
+                key="delete"
+                style={{ color: 'red' }}
+                onClick={() => handleDelete(record)}
+              >
+                删除
+              </a>,
+            ]
+          : [],
+    },
+  ];
+
+  return (
+    <>
+      <ProTable<T>
+        rowKey="id"
+        columns={allColumns}
+        dataSource={items}
+        search={false}
+        options={false}
+        pagination={false}
+        toolBarRender={() => [
+          <Button
+            key="add"
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              setEditRecord(null);
+              setModalOpen(true);
+            }}
+          >
+            新建 {resourceLabel}
+          </Button>,
+        ]}
+      />
+      <ModalForm
+        title={editRecord ? `编辑 ${resourceLabel}` : `新建 ${resourceLabel}`}
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        onFinish={onFinish}
+        initialValues={getInitialValues(editRecord)}
+        width={480}
+        modalProps={{ destroyOnHidden: true }}
+      >
+        <ProFormDigit
+          name="id"
+          label="id"
+          disabled={!!editRecord}
+          rules={[{ required: true, message: '请输入 id' }]}
+        />
+        {formFields}
+      </ModalForm>
+    </>
+  );
+}
+
+export default ResourceCrudTable;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/RouteTable.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/RouteTable.tsx
@@ -1,0 +1,162 @@
+import { PlusOutlined } from '@ant-design/icons';
+import {
+  ModalForm,
+  ProFormDigit,
+  ProFormSelect,
+  ProFormText,
+  ProFormTextArea,
+  type ProColumns,
+  ProTable,
+} from '@ant-design/pro-components';
+import { App, Button } from 'antd';
+import React, { useState } from 'react';
+import type { ApisixGatewayDoc, ApisixRoute } from './gatewayYaml';
+import { findDuplicateIds, upsertById } from './gatewayYaml';
+
+interface RouteTableProps {
+  doc: ApisixGatewayDoc;
+  onChange: (next: ApisixGatewayDoc) => void;
+}
+
+const RouteTable: React.FC<RouteTableProps> = ({ doc, onChange }) => {
+  const { message } = App.useApp();
+  const routes = doc.routes ?? [];
+  const upstreamOptions = (doc.upstreams ?? []).map((u) => ({
+    label: String(u.id),
+    value: u.id,
+  }));
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editRecord, setEditRecord] = useState<ApisixRoute | null>(null);
+
+  const handleDelete = (record: ApisixRoute) => {
+    onChange({
+      ...doc,
+      routes: routes.filter((r) => String(r.id) !== String(record.id)),
+    });
+  };
+
+  const onFinish = async (values: Record<string, any>) => {
+    let plugins: Record<string, unknown> | undefined;
+    if (values.pluginsJson?.trim()) {
+      try {
+        plugins = JSON.parse(values.pluginsJson);
+      } catch {
+        message.error('plugins 不是合法的 JSON');
+        return false;
+      }
+    }
+    const updated: ApisixRoute = {
+      ...(editRecord ?? {}),
+      id: values.id,
+      uri: values.uri,
+      upstream_id: values.upstream_id,
+      plugins,
+    };
+    const next = upsertById(routes, updated);
+    if (findDuplicateIds(next).length > 0) {
+      message.error('id 已存在，请使用唯一 id');
+      return false;
+    }
+    onChange({ ...doc, routes: next });
+    setModalOpen(false);
+    return true;
+  };
+
+  const columns: ProColumns<ApisixRoute>[] = [
+    { title: 'id', dataIndex: 'id', width: 80 },
+    { title: 'uri', dataIndex: 'uri' },
+    { title: 'upstream_id', dataIndex: 'upstream_id', width: 120 },
+    {
+      title: 'plugins',
+      dataIndex: 'plugins',
+      render: (_, record) =>
+        record.plugins ? Object.keys(record.plugins).join(', ') : '-',
+    },
+    {
+      title: '操作',
+      valueType: 'option',
+      width: 120,
+      render: (_, record) => [
+        <a
+          key="edit"
+          onClick={() => {
+            setEditRecord(record);
+            setModalOpen(true);
+          }}
+        >
+          编辑
+        </a>,
+        <a key="delete" style={{ color: 'red' }} onClick={() => handleDelete(record)}>
+          删除
+        </a>,
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <ProTable<ApisixRoute>
+        rowKey="id"
+        columns={columns}
+        dataSource={routes}
+        search={false}
+        options={false}
+        pagination={false}
+        toolBarRender={() => [
+          <Button
+            key="add"
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              setEditRecord(null);
+              setModalOpen(true);
+            }}
+          >
+            新建 Route
+          </Button>,
+        ]}
+      />
+      <ModalForm
+        title={editRecord ? '编辑 Route' : '新建 Route'}
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        onFinish={onFinish}
+        initialValues={
+          editRecord
+            ? {
+                id: editRecord.id,
+                uri: editRecord.uri,
+                upstream_id: editRecord.upstream_id,
+                pluginsJson: editRecord.plugins
+                  ? JSON.stringify(editRecord.plugins, null, 2)
+                  : '',
+              }
+            : {}
+        }
+        width={480}
+        modalProps={{ destroyOnHidden: true }}
+      >
+        <ProFormDigit
+          name="id"
+          label="id"
+          disabled={!!editRecord}
+          rules={[{ required: true, message: '请输入 id' }]}
+        />
+        <ProFormText name="uri" label="uri" rules={[{ required: true }]} />
+        <ProFormSelect
+          name="upstream_id"
+          label="upstream_id"
+          options={upstreamOptions}
+          rules={[{ required: true, message: '请选择 upstream' }]}
+        />
+        <ProFormTextArea
+          name="pluginsJson"
+          label="plugins（JSON，可留空）"
+          fieldProps={{ rows: 6 }}
+        />
+      </ModalForm>
+    </>
+  );
+};
+
+export default RouteTable;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/RouteTable.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/RouteTable.tsx
@@ -1,161 +1,88 @@
-import { PlusOutlined } from '@ant-design/icons';
 import {
-  ModalForm,
-  ProFormDigit,
+  type ProColumns,
   ProFormSelect,
   ProFormText,
   ProFormTextArea,
-  type ProColumns,
-  ProTable,
 } from '@ant-design/pro-components';
-import { App, Button } from 'antd';
-import React, { useState } from 'react';
+import React from 'react';
 import type { ApisixGatewayDoc, ApisixRoute } from './gatewayYaml';
-import { findDuplicateIds, upsertById } from './gatewayYaml';
+import { ResourceCrudTable } from './ResourceCrudTable';
 
 interface RouteTableProps {
   doc: ApisixGatewayDoc;
   onChange: (next: ApisixGatewayDoc) => void;
 }
 
+const columns: ProColumns<ApisixRoute>[] = [
+  { title: 'uri', dataIndex: 'uri' },
+  { title: 'upstream_id', dataIndex: 'upstream_id', width: 120 },
+  {
+    title: 'plugins',
+    dataIndex: 'plugins',
+    render: (_, record) =>
+      record.plugins ? Object.keys(record.plugins).join(', ') : '-',
+  },
+];
+
 const RouteTable: React.FC<RouteTableProps> = ({ doc, onChange }) => {
-  const { message } = App.useApp();
   const routes = doc.routes ?? [];
   const upstreamOptions = (doc.upstreams ?? []).map((u) => ({
     label: String(u.id),
     value: u.id,
   }));
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editRecord, setEditRecord] = useState<ApisixRoute | null>(null);
-
-  const handleDelete = (record: ApisixRoute) => {
-    onChange({
-      ...doc,
-      routes: routes.filter((r) => String(r.id) !== String(record.id)),
-    });
-  };
-
-  const onFinish = async (values: Record<string, any>) => {
-    let plugins: Record<string, unknown> | undefined;
-    if (values.pluginsJson?.trim()) {
-      try {
-        plugins = JSON.parse(values.pluginsJson);
-      } catch {
-        message.error('plugins 不是合法的 JSON');
-        return false;
-      }
-    }
-    const updated: ApisixRoute = {
-      ...(editRecord ?? {}),
-      id: values.id,
-      uri: values.uri,
-      upstream_id: values.upstream_id,
-      plugins,
-    };
-    const next = upsertById(routes, updated);
-    if (findDuplicateIds(next).length > 0) {
-      message.error('id 已存在，请使用唯一 id');
-      return false;
-    }
-    onChange({ ...doc, routes: next });
-    setModalOpen(false);
-    return true;
-  };
-
-  const columns: ProColumns<ApisixRoute>[] = [
-    { title: 'id', dataIndex: 'id', width: 80 },
-    { title: 'uri', dataIndex: 'uri' },
-    { title: 'upstream_id', dataIndex: 'upstream_id', width: 120 },
-    {
-      title: 'plugins',
-      dataIndex: 'plugins',
-      render: (_, record) =>
-        record.plugins ? Object.keys(record.plugins).join(', ') : '-',
-    },
-    {
-      title: '操作',
-      valueType: 'option',
-      width: 120,
-      render: (_, record) => [
-        <a
-          key="edit"
-          onClick={() => {
-            setEditRecord(record);
-            setModalOpen(true);
-          }}
-        >
-          编辑
-        </a>,
-        <a key="delete" style={{ color: 'red' }} onClick={() => handleDelete(record)}>
-          删除
-        </a>,
-      ],
-    },
-  ];
 
   return (
-    <>
-      <ProTable<ApisixRoute>
-        rowKey="id"
-        columns={columns}
-        dataSource={routes}
-        search={false}
-        options={false}
-        pagination={false}
-        toolBarRender={() => [
-          <Button
-            key="add"
-            type="primary"
-            icon={<PlusOutlined />}
-            onClick={() => {
-              setEditRecord(null);
-              setModalOpen(true);
-            }}
-          >
-            新建 Route
-          </Button>,
-        ]}
-      />
-      <ModalForm
-        title={editRecord ? '编辑 Route' : '新建 Route'}
-        open={modalOpen}
-        onOpenChange={setModalOpen}
-        onFinish={onFinish}
-        initialValues={
-          editRecord
-            ? {
-                id: editRecord.id,
-                uri: editRecord.uri,
-                upstream_id: editRecord.upstream_id,
-                pluginsJson: editRecord.plugins
-                  ? JSON.stringify(editRecord.plugins, null, 2)
-                  : '',
-              }
-            : {}
+    <ResourceCrudTable<ApisixRoute>
+      resourceLabel="Route"
+      items={routes}
+      onChange={(next) => onChange({ ...doc, routes: next })}
+      columns={columns}
+      getInitialValues={(editRecord) =>
+        editRecord
+          ? {
+              id: editRecord.id,
+              uri: editRecord.uri,
+              upstream_id: editRecord.upstream_id,
+              pluginsJson: editRecord.plugins
+                ? JSON.stringify(editRecord.plugins, null, 2)
+                : '',
+            }
+          : {}
+      }
+      parseValues={(values, editRecord) => {
+        let plugins: Record<string, unknown> | undefined;
+        if (values.pluginsJson?.trim()) {
+          try {
+            plugins = JSON.parse(values.pluginsJson);
+          } catch {
+            return 'plugins 不是合法的 JSON';
+          }
         }
-        width={480}
-        modalProps={{ destroyOnHidden: true }}
-      >
-        <ProFormDigit
-          name="id"
-          label="id"
-          disabled={!!editRecord}
-          rules={[{ required: true, message: '请输入 id' }]}
-        />
-        <ProFormText name="uri" label="uri" rules={[{ required: true }]} />
-        <ProFormSelect
-          name="upstream_id"
-          label="upstream_id"
-          options={upstreamOptions}
-          rules={[{ required: true, message: '请选择 upstream' }]}
-        />
-        <ProFormTextArea
-          name="pluginsJson"
-          label="plugins（JSON，可留空）"
-          fieldProps={{ rows: 6 }}
-        />
-      </ModalForm>
-    </>
+        return {
+          ...(editRecord ?? {}),
+          id: values.id,
+          uri: values.uri,
+          upstream_id: values.upstream_id,
+          plugins,
+        };
+      }}
+      formFields={
+        <>
+          <ProFormText name="uri" label="uri" rules={[{ required: true }]} />
+          <ProFormSelect
+            name="upstream_id"
+            label="upstream_id"
+            options={upstreamOptions}
+            rules={[{ required: true, message: '请选择 upstream' }]}
+          />
+          <ProFormTextArea
+            name="pluginsJson"
+            label="plugins（JSON，可留空）"
+            fieldProps={{ rows: 6 }}
+          />
+        </>
+      }
+    />
   );
 };
 

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/UpstreamTable.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/UpstreamTable.tsx
@@ -1,0 +1,144 @@
+import { PlusOutlined } from '@ant-design/icons';
+import {
+  ModalForm,
+  ProFormDigit,
+  ProFormText,
+  ProFormTextArea,
+  type ProColumns,
+  ProTable,
+} from '@ant-design/pro-components';
+import { App, Button } from 'antd';
+import React, { useState } from 'react';
+import type { ApisixGatewayDoc, ApisixUpstream } from './gatewayYaml';
+import { findDuplicateIds, upsertById } from './gatewayYaml';
+
+interface UpstreamTableProps {
+  doc: ApisixGatewayDoc;
+  onChange: (next: ApisixGatewayDoc) => void;
+}
+
+const UpstreamTable: React.FC<UpstreamTableProps> = ({ doc, onChange }) => {
+  const { message } = App.useApp();
+  const upstreams = doc.upstreams ?? [];
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editRecord, setEditRecord] = useState<ApisixUpstream | null>(null);
+
+  const handleDelete = (record: ApisixUpstream) => {
+    onChange({
+      ...doc,
+      upstreams: upstreams.filter((u) => String(u.id) !== String(record.id)),
+    });
+  };
+
+  const onFinish = async (values: Record<string, any>) => {
+    let nodes: Record<string, number>;
+    try {
+      nodes = JSON.parse(values.nodesJson || '{}');
+    } catch {
+      message.error('nodes 不是合法的 JSON');
+      return false;
+    }
+    const updated: ApisixUpstream = {
+      ...(editRecord ?? {}),
+      id: values.id,
+      type: values.type,
+      nodes,
+    };
+    const next = upsertById(upstreams, updated);
+    if (findDuplicateIds(next).length > 0) {
+      message.error('id 已存在，请使用唯一 id');
+      return false;
+    }
+    onChange({ ...doc, upstreams: next });
+    setModalOpen(false);
+    return true;
+  };
+
+  const columns: ProColumns<ApisixUpstream>[] = [
+    { title: 'id', dataIndex: 'id', width: 80 },
+    { title: 'type', dataIndex: 'type', width: 120 },
+    {
+      title: 'nodes',
+      dataIndex: 'nodes',
+      render: (_, record) => JSON.stringify(record.nodes ?? {}),
+    },
+    {
+      title: '操作',
+      valueType: 'option',
+      width: 120,
+      render: (_, record) => [
+        <a
+          key="edit"
+          onClick={() => {
+            setEditRecord(record);
+            setModalOpen(true);
+          }}
+        >
+          编辑
+        </a>,
+        <a key="delete" style={{ color: 'red' }} onClick={() => handleDelete(record)}>
+          删除
+        </a>,
+      ],
+    },
+  ];
+
+  return (
+    <>
+      <ProTable<ApisixUpstream>
+        rowKey="id"
+        columns={columns}
+        dataSource={upstreams}
+        search={false}
+        options={false}
+        pagination={false}
+        toolBarRender={() => [
+          <Button
+            key="add"
+            type="primary"
+            icon={<PlusOutlined />}
+            onClick={() => {
+              setEditRecord(null);
+              setModalOpen(true);
+            }}
+          >
+            新建 Upstream
+          </Button>,
+        ]}
+      />
+      <ModalForm
+        title={editRecord ? '编辑 Upstream' : '新建 Upstream'}
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        onFinish={onFinish}
+        initialValues={
+          editRecord
+            ? {
+                id: editRecord.id,
+                type: editRecord.type ?? 'roundrobin',
+                nodesJson: JSON.stringify(editRecord.nodes ?? {}, null, 2),
+              }
+            : { type: 'roundrobin', nodesJson: '{\n  "127.0.0.1:8080": 1\n}' }
+        }
+        width={480}
+        modalProps={{ destroyOnHidden: true }}
+      >
+        <ProFormDigit
+          name="id"
+          label="id"
+          disabled={!!editRecord}
+          rules={[{ required: true, message: '请输入 id' }]}
+        />
+        <ProFormText name="type" label="type" rules={[{ required: true }]} />
+        <ProFormTextArea
+          name="nodesJson"
+          label="nodes（JSON，host:port -> 权重）"
+          fieldProps={{ rows: 6 }}
+          rules={[{ required: true, message: '请输入 nodes' }]}
+        />
+      </ModalForm>
+    </>
+  );
+};
+
+export default UpstreamTable;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/UpstreamTable.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/UpstreamTable.tsx
@@ -1,143 +1,70 @@
-import { PlusOutlined } from '@ant-design/icons';
 import {
-  ModalForm,
-  ProFormDigit,
+  type ProColumns,
   ProFormText,
   ProFormTextArea,
-  type ProColumns,
-  ProTable,
 } from '@ant-design/pro-components';
-import { App, Button } from 'antd';
-import React, { useState } from 'react';
+import React from 'react';
 import type { ApisixGatewayDoc, ApisixUpstream } from './gatewayYaml';
-import { findDuplicateIds, upsertById } from './gatewayYaml';
+import { ResourceCrudTable } from './ResourceCrudTable';
 
 interface UpstreamTableProps {
   doc: ApisixGatewayDoc;
   onChange: (next: ApisixGatewayDoc) => void;
 }
 
+const columns: ProColumns<ApisixUpstream>[] = [
+  { title: 'type', dataIndex: 'type', width: 120 },
+  {
+    title: 'nodes',
+    dataIndex: 'nodes',
+    render: (_, record) => JSON.stringify(record.nodes ?? {}),
+  },
+];
+
 const UpstreamTable: React.FC<UpstreamTableProps> = ({ doc, onChange }) => {
-  const { message } = App.useApp();
   const upstreams = doc.upstreams ?? [];
-  const [modalOpen, setModalOpen] = useState(false);
-  const [editRecord, setEditRecord] = useState<ApisixUpstream | null>(null);
-
-  const handleDelete = (record: ApisixUpstream) => {
-    onChange({
-      ...doc,
-      upstreams: upstreams.filter((u) => String(u.id) !== String(record.id)),
-    });
-  };
-
-  const onFinish = async (values: Record<string, any>) => {
-    let nodes: Record<string, number>;
-    try {
-      nodes = JSON.parse(values.nodesJson || '{}');
-    } catch {
-      message.error('nodes 不是合法的 JSON');
-      return false;
-    }
-    const updated: ApisixUpstream = {
-      ...(editRecord ?? {}),
-      id: values.id,
-      type: values.type,
-      nodes,
-    };
-    const next = upsertById(upstreams, updated);
-    if (findDuplicateIds(next).length > 0) {
-      message.error('id 已存在，请使用唯一 id');
-      return false;
-    }
-    onChange({ ...doc, upstreams: next });
-    setModalOpen(false);
-    return true;
-  };
-
-  const columns: ProColumns<ApisixUpstream>[] = [
-    { title: 'id', dataIndex: 'id', width: 80 },
-    { title: 'type', dataIndex: 'type', width: 120 },
-    {
-      title: 'nodes',
-      dataIndex: 'nodes',
-      render: (_, record) => JSON.stringify(record.nodes ?? {}),
-    },
-    {
-      title: '操作',
-      valueType: 'option',
-      width: 120,
-      render: (_, record) => [
-        <a
-          key="edit"
-          onClick={() => {
-            setEditRecord(record);
-            setModalOpen(true);
-          }}
-        >
-          编辑
-        </a>,
-        <a key="delete" style={{ color: 'red' }} onClick={() => handleDelete(record)}>
-          删除
-        </a>,
-      ],
-    },
-  ];
 
   return (
-    <>
-      <ProTable<ApisixUpstream>
-        rowKey="id"
-        columns={columns}
-        dataSource={upstreams}
-        search={false}
-        options={false}
-        pagination={false}
-        toolBarRender={() => [
-          <Button
-            key="add"
-            type="primary"
-            icon={<PlusOutlined />}
-            onClick={() => {
-              setEditRecord(null);
-              setModalOpen(true);
-            }}
-          >
-            新建 Upstream
-          </Button>,
-        ]}
-      />
-      <ModalForm
-        title={editRecord ? '编辑 Upstream' : '新建 Upstream'}
-        open={modalOpen}
-        onOpenChange={setModalOpen}
-        onFinish={onFinish}
-        initialValues={
-          editRecord
-            ? {
-                id: editRecord.id,
-                type: editRecord.type ?? 'roundrobin',
-                nodesJson: JSON.stringify(editRecord.nodes ?? {}, null, 2),
-              }
-            : { type: 'roundrobin', nodesJson: '{\n  "127.0.0.1:8080": 1\n}' }
+    <ResourceCrudTable<ApisixUpstream>
+      resourceLabel="Upstream"
+      items={upstreams}
+      onChange={(next) => onChange({ ...doc, upstreams: next })}
+      columns={columns}
+      getInitialValues={(editRecord) =>
+        editRecord
+          ? {
+              id: editRecord.id,
+              type: editRecord.type ?? 'roundrobin',
+              nodesJson: JSON.stringify(editRecord.nodes ?? {}, null, 2),
+            }
+          : { type: 'roundrobin', nodesJson: '{\n  "127.0.0.1:8080": 1\n}' }
+      }
+      parseValues={(values, editRecord) => {
+        let nodes: Record<string, number>;
+        try {
+          nodes = JSON.parse(values.nodesJson || '{}');
+        } catch {
+          return 'nodes 不是合法的 JSON';
         }
-        width={480}
-        modalProps={{ destroyOnHidden: true }}
-      >
-        <ProFormDigit
-          name="id"
-          label="id"
-          disabled={!!editRecord}
-          rules={[{ required: true, message: '请输入 id' }]}
-        />
-        <ProFormText name="type" label="type" rules={[{ required: true }]} />
-        <ProFormTextArea
-          name="nodesJson"
-          label="nodes（JSON，host:port -> 权重）"
-          fieldProps={{ rows: 6 }}
-          rules={[{ required: true, message: '请输入 nodes' }]}
-        />
-      </ModalForm>
-    </>
+        return {
+          ...(editRecord ?? {}),
+          id: values.id,
+          type: values.type,
+          nodes,
+        };
+      }}
+      formFields={
+        <>
+          <ProFormText name="type" label="type" rules={[{ required: true }]} />
+          <ProFormTextArea
+            name="nodesJson"
+            label="nodes（JSON，host:port -> 权重）"
+            fieldProps={{ rows: 6 }}
+            rules={[{ required: true, message: '请输入 nodes' }]}
+          />
+        </>
+      }
+    />
   );
 };
 

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/gatewayYaml.test.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/gatewayYaml.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dumpGatewayYaml,
+  findDanglingUpstreamRefs,
+  findDuplicateIds,
+  hasComments,
+  isBuiltinGlobalRule,
+  loadGatewayYaml,
+  removeGlobalRule,
+  upsertById,
+} from './gatewayYaml';
+
+describe('loadGatewayYaml / dumpGatewayYaml', () => {
+  it('round-trips a typical doc', () => {
+    const text = 'routes:\n  - id: 1\n    uri: /get\n';
+    const doc = loadGatewayYaml(text);
+    expect(doc.routes).toEqual([{ id: 1, uri: '/get' }]);
+    expect(dumpGatewayYaml(doc)).toContain('uri: /get');
+  });
+
+  it('returns empty map for empty text', () => {
+    expect(loadGatewayYaml('')).toEqual({});
+  });
+
+  it('throws when top level is not a map', () => {
+    expect(() => loadGatewayYaml('- a\n- b\n')).toThrow();
+    expect(() => loadGatewayYaml('just a string')).toThrow();
+  });
+
+  it('preserves unknown top-level sections and unknown fields on round trip', () => {
+    const text =
+      'routes:\n  - id: 1\n    uri: /get\n    custom_field: kept\nconsumers:\n  - username: alice\n';
+    const doc = loadGatewayYaml(text);
+    const dumped = dumpGatewayYaml(doc);
+    const reloaded = loadGatewayYaml(dumped);
+    expect(reloaded.consumers).toEqual([{ username: 'alice' }]);
+    expect((reloaded.routes as any[])[0].custom_field).toBe('kept');
+  });
+});
+
+describe('isBuiltinGlobalRule / removeGlobalRule', () => {
+  it('treats id 1 and 2 as builtin (prometheus / opentelemetry)', () => {
+    expect(isBuiltinGlobalRule({ id: 1 })).toBe(true);
+    expect(isBuiltinGlobalRule({ id: '2' })).toBe(true);
+    expect(isBuiltinGlobalRule({ id: 3 })).toBe(false);
+  });
+
+  it('removeGlobalRule keeps builtin rules even when asked to remove them', () => {
+    const rules = [
+      { id: 1, plugins: { prometheus: {} } },
+      { id: 2, plugins: { opentelemetry: {} } },
+      { id: 3, plugins: { 'limit-count': {} } },
+    ];
+    expect(removeGlobalRule(rules, 1).map((r) => r.id)).toEqual([1, 2, 3]);
+    expect(removeGlobalRule(rules, 3).map((r) => r.id)).toEqual([1, 2]);
+  });
+});
+
+describe('upsertById', () => {
+  it('merges instead of replacing, keeping fields the form does not know about', () => {
+    const list = [{ id: 1, uri: '/get', unknownField: 'kept' }];
+    const next = upsertById(list, { id: 1, uri: '/post' } as any);
+    expect(next[0]).toEqual({ id: 1, uri: '/post', unknownField: 'kept' });
+  });
+
+  it('appends when id not found', () => {
+    const next = upsertById([{ id: 1 }], { id: 2 });
+    expect(next.map((i) => i.id)).toEqual([1, 2]);
+  });
+});
+
+describe('findDuplicateIds', () => {
+  it('detects duplicate ids', () => {
+    expect(findDuplicateIds([{ id: 1 }, { id: 2 }, { id: 1 }])).toEqual(['1']);
+    expect(findDuplicateIds([{ id: 1 }, { id: 2 }])).toEqual([]);
+  });
+});
+
+describe('findDanglingUpstreamRefs', () => {
+  it('flags routes referencing a missing upstream', () => {
+    const doc = {
+      upstreams: [{ id: 1 }],
+      routes: [
+        { id: 1, uri: '/ok', upstream_id: 1 },
+        { id: 2, uri: '/broken', upstream_id: 99 },
+      ],
+    };
+    expect(findDanglingUpstreamRefs(doc)).toEqual(['/broken']);
+  });
+
+  it('returns empty when all references resolve', () => {
+    const doc = {
+      upstreams: [{ id: 1 }],
+      routes: [{ id: 1, uri: '/ok', upstream_id: 1 }],
+    };
+    expect(findDanglingUpstreamRefs(doc)).toEqual([]);
+  });
+});
+
+describe('hasComments', () => {
+  it('detects a real comment line', () => {
+    expect(hasComments('routes: []\n# a comment\n')).toBe(true);
+  });
+
+  it('ignores # inside quoted strings', () => {
+    expect(hasComments("uri: '/a#b'\n")).toBe(false);
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/gatewayYaml.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/gatewayYaml.ts
@@ -1,0 +1,120 @@
+import yaml from 'js-yaml';
+
+/**
+ * `apisixGatewayYaml` 真相源的结构化投影。图形化视图只读写 routes/upstreams/global_rules，
+ * 其余顶层段（如用户在代码视图写的 consumers/ssls）与单条记录上的未知字段原样保留，
+ * dump 时自然带出——这是约束 1（图形化只投影它认识的部分）。
+ */
+export interface ApisixRoute {
+  id: number | string;
+  uri?: string;
+  upstream_id?: number | string;
+  plugins?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ApisixUpstream {
+  id: number | string;
+  type?: string;
+  nodes?: Record<string, number>;
+  [key: string]: unknown;
+}
+
+export interface ApisixGlobalRule {
+  id: number | string;
+  plugins?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface ApisixGatewayDoc {
+  upstreams?: ApisixUpstream[];
+  routes?: ApisixRoute[];
+  global_rules?: ApisixGlobalRule[];
+  [key: string]: unknown;
+}
+
+/** 内置 global_rules：id 1 = prometheus，id 2 = opentelemetry，后端 POST 校验强制要求两者都在 */
+export const BUILTIN_GLOBAL_RULE_IDS = ['1', '2'];
+
+export function isBuiltinGlobalRule(rule: { id: number | string }): boolean {
+  return BUILTIN_GLOBAL_RULE_IDS.includes(String(rule.id));
+}
+
+/** 顶层非 map（如空文档、纯数组、纯标量）时返回空 map，不当作解析失败 */
+export function loadGatewayYaml(text: string): ApisixGatewayDoc {
+  const doc = yaml.load(text);
+  if (doc == null) {
+    return {};
+  }
+  if (typeof doc !== 'object' || Array.isArray(doc)) {
+    throw new Error('YAML 顶层必须是一个 map');
+  }
+  return doc as ApisixGatewayDoc;
+}
+
+export function dumpGatewayYaml(doc: ApisixGatewayDoc): string {
+  return yaml.dump(doc, { indent: 2, lineWidth: -1, noRefs: true });
+}
+
+/**
+ * 内置规则不可删——被删除的调用方应先用此函数过滤，而不是直接对 global_rules 数组 splice。
+ */
+export function removeGlobalRule(
+  rules: ApisixGlobalRule[],
+  id: number | string,
+): ApisixGlobalRule[] {
+  return rules.filter(
+    (rule) => isBuiltinGlobalRule(rule) || String(rule.id) !== String(id),
+  );
+}
+
+/** 表单提交合并语义：{...originalItem, ...formValues}，保留表单不认识的字段（约束 1） */
+export function upsertById<T extends { id: number | string }>(
+  list: T[],
+  updated: T,
+): T[] {
+  const idx = list.findIndex((item) => String(item.id) === String(updated.id));
+  if (idx === -1) {
+    return [...list, updated];
+  }
+  const next = [...list];
+  next[idx] = { ...list[idx], ...updated };
+  return next;
+}
+
+/** id 唯一性校验：返回重复出现的 id 列表（去重） */
+export function findDuplicateIds(items: { id: number | string }[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const item of items) {
+    const key = String(item.id);
+    if (seen.has(key)) {
+      duplicates.add(key);
+    }
+    seen.add(key);
+  }
+  return [...duplicates];
+}
+
+/** upstream 引用完整性校验：返回引用了不存在 upstream 的 route 的 uri/id 列表 */
+export function findDanglingUpstreamRefs(doc: ApisixGatewayDoc): string[] {
+  const upstreamIds = new Set((doc.upstreams ?? []).map((u) => String(u.id)));
+  return (doc.routes ?? [])
+    .filter(
+      (route) =>
+        route.upstream_id != null && !upstreamIds.has(String(route.upstream_id)),
+    )
+    .map((route) => String(route.uri ?? route.id));
+}
+
+/**
+ * 注释检测（约束 2）：非严格 YAML 词法分析，逐行剥离引号内容后看是否还含 `#`。
+ * 用途仅是决定要不要弹「切换将丢失注释」的二次确认，误判的代价很低，
+ * 不值得为此引入完整的 YAML tokenizer。
+ */
+export function hasComments(text: string): boolean {
+  return text.split('\n').some((line) => {
+    const withoutStrings = line.replace(/'[^']*'|"[^"]*"/g, '');
+    return withoutStrings.includes('#');
+  });
+}

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/index.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/index.test.tsx
@@ -1,0 +1,208 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getApisixGateway, saveApisixGateway } from '@/services/service';
+import ApisixGatewayPanel from './index';
+
+vi.mock('@umijs/max', () => ({
+  useIntl: () => ({
+    formatMessage: ({ id }: { id: string }) => id,
+  }),
+}));
+
+// @ant-design/pro-components 直接 import 在这套 vitest(happy-dom + ESM) 组合下会报
+// "exports is not defined in ES module scope"，仓库既有测试（如 History.test.tsx）也用 mock 绕过。
+// index.tsx 只用到 ProCard 做外层容器，透传 children 即可。
+vi.mock('@ant-design/pro-components', () => ({
+  ProCard: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@monaco-editor/react', () => ({
+  default: ({
+    value,
+    onChange,
+    options,
+  }: {
+    value: string;
+    onChange?: (v: string) => void;
+    options?: { readOnly?: boolean };
+  }) => (
+    <textarea
+      data-testid={options?.readOnly ? 'editor-readonly' : 'editor'}
+      value={value}
+      readOnly={!!options?.readOnly}
+      onChange={(e) => onChange?.(e.target.value)}
+    />
+  ),
+}));
+
+vi.mock('./GraphicView', () => ({
+  default: ({
+    doc,
+    onChange,
+  }: {
+    doc: Record<string, unknown>;
+    onChange: (next: Record<string, unknown>) => void;
+  }) => (
+    <div>
+      <div data-testid="graphic-view" />
+      <button
+        type="button"
+        onClick={() =>
+          onChange({
+            ...doc,
+            routes: [
+              ...((doc.routes as unknown[]) ?? []),
+              { id: 999, uri: '/added' },
+            ],
+          })
+        }
+      >
+        mutate-doc
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/services/service', () => ({
+  getApisixGateway: vi.fn(),
+  saveApisixGateway: vi.fn(),
+}));
+
+const CLUSTER_ID = 1;
+const INSTANCE_ID = 10;
+
+const WITH_COMMENTS_TEXT =
+  'routes:\n  - id: 1\n    uri: /get\n# a real comment\nconsumers:\n  - username: alice\n';
+
+function mockGetResponse(text: string) {
+  vi.mocked(getApisixGateway).mockResolvedValue({
+    data: { gatewayYaml: text, managedSuffix: '#END\n', roles: [] },
+  } as never);
+}
+
+describe('ApisixGatewayPanel view switch state machine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(saveApisixGateway).mockResolvedValue({ data: [] } as never);
+  });
+
+  it('code view is usable standalone: loads text and saves it verbatim', async () => {
+    mockGetResponse('routes:\n  - id: 1\n    uri: /get\n');
+    render(<ApisixGatewayPanel clusterId={CLUSTER_ID} instanceId={INSTANCE_ID} />);
+
+    const editor = await screen.findByTestId('editor');
+    expect(editor).toHaveValue('routes:\n  - id: 1\n    uri: /get\n');
+
+    fireEvent.change(editor, { target: { value: 'routes:\n  - id: 1\n    uri: /new\n' } });
+    fireEvent.click(screen.getByText('pages.apisixGateway.save'));
+
+    await waitFor(() =>
+      expect(saveApisixGateway).toHaveBeenCalledWith(
+        CLUSTER_ID,
+        INSTANCE_ID,
+        'routes:\n  - id: 1\n    uri: /new\n',
+      ),
+    );
+  });
+
+  it('code -> graphic: unparsable YAML stays on code view and does not crash', async () => {
+    mockGetResponse('not: [valid');
+    render(<ApisixGatewayPanel clusterId={CLUSTER_ID} instanceId={INSTANCE_ID} />);
+    await screen.findByTestId('editor');
+
+    fireEvent.mouseDown(screen.getByText('pages.apisixGateway.view.graphic'));
+    fireEvent.click(screen.getByText('pages.apisixGateway.view.graphic'));
+
+    expect(screen.queryByTestId('graphic-view')).not.toBeInTheDocument();
+    expect(screen.getByTestId('editor')).toBeInTheDocument();
+  });
+
+  it('code -> graphic: valid YAML switches successfully', async () => {
+    mockGetResponse('routes:\n  - id: 1\n    uri: /get\n');
+    render(<ApisixGatewayPanel clusterId={CLUSTER_ID} instanceId={INSTANCE_ID} />);
+    await screen.findByTestId('editor');
+
+    fireEvent.click(screen.getByText('pages.apisixGateway.view.graphic'));
+
+    await screen.findByTestId('graphic-view');
+    expect(screen.queryByTestId('editor')).not.toBeInTheDocument();
+  });
+
+  it('graphic -> code (unchanged): reuses the original text verbatim, preserving comments/formatting', async () => {
+    mockGetResponse(WITH_COMMENTS_TEXT);
+    render(<ApisixGatewayPanel clusterId={CLUSTER_ID} instanceId={INSTANCE_ID} />);
+    await screen.findByTestId('editor');
+
+    fireEvent.click(screen.getByText('pages.apisixGateway.view.graphic'));
+    await screen.findByTestId('graphic-view');
+
+    fireEvent.click(screen.getByText('pages.apisixGateway.view.code'));
+
+    const editor = await screen.findByTestId('editor');
+    expect(editor).toHaveValue(WITH_COMMENTS_TEXT);
+  });
+
+  it('graphic -> code (changed, no comments): dumps doc without confirmation', async () => {
+    mockGetResponse('routes:\n  - id: 1\n    uri: /get\n');
+    render(<ApisixGatewayPanel clusterId={CLUSTER_ID} instanceId={INSTANCE_ID} />);
+    await screen.findByTestId('editor');
+
+    fireEvent.click(screen.getByText('pages.apisixGateway.view.graphic'));
+    await screen.findByTestId('graphic-view');
+    fireEvent.click(screen.getByText('mutate-doc'));
+
+    fireEvent.click(screen.getByText('pages.apisixGateway.view.code'));
+
+    const editor = await screen.findByTestId('editor');
+    expect((editor as HTMLTextAreaElement).value).toContain('/added');
+    expect(
+      screen.queryByText('pages.apisixGateway.confirm.commentsLostTitle'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('graphic -> code (changed, has comments): asks for confirmation before dumping', async () => {
+    mockGetResponse(WITH_COMMENTS_TEXT);
+    render(<ApisixGatewayPanel clusterId={CLUSTER_ID} instanceId={INSTANCE_ID} />);
+    await screen.findByTestId('editor');
+
+    fireEvent.click(screen.getByText('pages.apisixGateway.view.graphic'));
+    await screen.findByTestId('graphic-view');
+    fireEvent.click(screen.getByText('mutate-doc'));
+
+    fireEvent.click(screen.getByText('pages.apisixGateway.view.code'));
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByText('pages.apisixGateway.confirm.commentsLostTitle').length,
+      ).toBeGreaterThan(0),
+    );
+    // 确认前仍停在图形化视图，代码尚未被覆盖
+    expect(screen.getByTestId('graphic-view')).toBeInTheDocument();
+
+    const okButton = screen
+      .getAllByRole('button')
+      .find((btn) => btn.textContent === 'OK') as HTMLElement;
+    fireEvent.click(okButton);
+
+    const editor = await screen.findByTestId('editor');
+    expect((editor as HTMLTextAreaElement).value).toContain('/added');
+    expect((editor as HTMLTextAreaElement).value).not.toContain('a real comment');
+  });
+
+  it('saves dump(doc) when currently on the graphic view', async () => {
+    mockGetResponse('routes:\n  - id: 1\n    uri: /get\n');
+    render(<ApisixGatewayPanel clusterId={CLUSTER_ID} instanceId={INSTANCE_ID} />);
+    await screen.findByTestId('editor');
+
+    fireEvent.click(screen.getByText('pages.apisixGateway.view.graphic'));
+    await screen.findByTestId('graphic-view');
+    fireEvent.click(screen.getByText('mutate-doc'));
+
+    fireEvent.click(screen.getByText('pages.apisixGateway.save'));
+
+    await waitFor(() => expect(saveApisixGateway).toHaveBeenCalled());
+    const payload = vi.mocked(saveApisixGateway).mock.calls[0][2];
+    expect(payload).toContain('/added');
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/index.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/ApisixGateway/index.tsx
@@ -1,0 +1,166 @@
+/**
+ * APISIX(standalone) 网关配置 Tab —— 图形化 + 代码化双视图管理 upstreams/routes/global_rules。
+ *
+ * 真相源是隐藏参数 apisixGatewayYaml；图形化视图是它 load() 后的结构化投影，
+ * 切换视图 = load/dump，不是两套数据（见 docs/apisix-gateway-tab-实施任务清单）。
+ * 状态机语义（约束 2/3）：
+ *  - 代码 → 图形化：先 load(text) 试解析，失败留在代码视图并报错，不静默降级。
+ *  - 图形化 → 代码（未改动）：直接复用原始 text，不重新 dump，保住注释与排版。
+ *  - 图形化 → 代码（已改动）：dump(doc)；若原 text 含注释，先二次确认告知注释将丢失。
+ *  - 保存以当前所在视图为准：代码视图交 text，图形化视图交 dump(doc)。
+ */
+
+import { ProCard } from '@ant-design/pro-components';
+import { Button, Modal, Segmented, message } from 'antd';
+import React, { useEffect, useRef, useState } from 'react';
+import { useIntl } from '@umijs/max';
+import { getApisixGateway, saveApisixGateway } from '@/services/service';
+import CodeView from './CodeView';
+import GraphicView from './GraphicView';
+import {
+  type ApisixGatewayDoc,
+  dumpGatewayYaml,
+  hasComments,
+  loadGatewayYaml,
+} from './gatewayYaml';
+
+interface ApisixGatewayPanelProps {
+  clusterId: number;
+  instanceId: number;
+}
+
+type ViewMode = 'code' | 'graphic';
+
+const ApisixGatewayPanel: React.FC<ApisixGatewayPanelProps> = ({
+  clusterId,
+  instanceId,
+}) => {
+  const intl = useIntl();
+  const mountedRef = useRef(true);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [view, setView] = useState<ViewMode>('code');
+
+  const [text, setText] = useState('');
+  const [doc, setDoc] = useState<ApisixGatewayDoc>({});
+  const [graphicDirty, setGraphicDirty] = useState(false);
+  const [managedSuffix, setManagedSuffix] = useState('');
+
+  useEffect(() => {
+    mountedRef.current = true;
+    setLoading(true);
+    getApisixGateway(clusterId, instanceId)
+      .then((res: any) => {
+        if (!mountedRef.current) return;
+        const data: DATASOPHON.ApisixGatewayResponse | undefined = res?.data;
+        setText(data?.gatewayYaml ?? '');
+        setManagedSuffix(data?.managedSuffix ?? '');
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (mountedRef.current) setLoading(false);
+      });
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [clusterId, instanceId]);
+
+  const switchToGraphic = () => {
+    try {
+      setDoc(loadGatewayYaml(text));
+      setGraphicDirty(false);
+      setView('graphic');
+    } catch (e: any) {
+      message.error(
+        `${intl.formatMessage({ id: 'pages.apisixGateway.parseError' })}${
+          e?.message ? `：${e.message}` : ''
+        }`,
+      );
+    }
+  };
+
+  const applyGraphicToText = () => {
+    setText(dumpGatewayYaml(doc));
+    setGraphicDirty(false);
+    setView('code');
+  };
+
+  const switchToCode = () => {
+    if (!graphicDirty) {
+      setView('code');
+      return;
+    }
+    if (hasComments(text)) {
+      Modal.confirm({
+        title: intl.formatMessage({
+          id: 'pages.apisixGateway.confirm.commentsLostTitle',
+        }),
+        content: intl.formatMessage({
+          id: 'pages.apisixGateway.confirm.commentsLostContent',
+        }),
+        onOk: applyGraphicToText,
+      });
+      return;
+    }
+    applyGraphicToText();
+  };
+
+  const onSave = async () => {
+    const payload = view === 'code' ? text : dumpGatewayYaml(doc);
+    setSaving(true);
+    try {
+      await saveApisixGateway(clusterId, instanceId, payload);
+      message.success(intl.formatMessage({ id: 'pages.apisixGateway.saveSuccess' }));
+      setText(payload);
+      setGraphicDirty(false);
+    } catch {
+      // 全局错误处理器已提示，这里不重复
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <ProCard loading={loading}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          marginBottom: 12,
+        }}
+      >
+        <Segmented
+          value={view}
+          onChange={(v) => (v === 'graphic' ? switchToGraphic() : switchToCode())}
+          options={[
+            {
+              label: intl.formatMessage({ id: 'pages.apisixGateway.view.graphic' }),
+              value: 'graphic',
+            },
+            {
+              label: intl.formatMessage({ id: 'pages.apisixGateway.view.code' }),
+              value: 'code',
+            },
+          ]}
+        />
+        <Button type="primary" loading={saving} onClick={onSave}>
+          {intl.formatMessage({ id: 'pages.apisixGateway.save' })}
+        </Button>
+      </div>
+      {view === 'code' ? (
+        <CodeView text={text} onChange={setText} managedSuffix={managedSuffix} />
+      ) : (
+        <GraphicView
+          doc={doc}
+          onChange={(next) => {
+            setDoc(next);
+            setGraphicDirty(true);
+          }}
+        />
+      )}
+    </ProCard>
+  );
+};
+
+export default ApisixGatewayPanel;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ClusterContext from '@/context/ClusterContext';
@@ -7,6 +7,7 @@ import ServiceInstance from './index';
 
 const {
   apisixDashboardSpy,
+  apisixGatewaySpy,
   valkeyDashboardSpy,
   dsDashboardSpy,
   dorisDashboardSpy,
@@ -15,6 +16,7 @@ const {
   routeParams,
 } = vi.hoisted(() => ({
   apisixDashboardSpy: vi.fn(),
+  apisixGatewaySpy: vi.fn(),
   valkeyDashboardSpy: vi.fn(),
   dsDashboardSpy: vi.fn(),
   dorisDashboardSpy: vi.fn(),
@@ -111,6 +113,12 @@ vi.mock('@/services/service', () => ({
   getServiceInstance: vi.fn(),
   getServiceWebUis: vi.fn(),
 }));
+vi.mock('./ApisixGateway', () => ({
+  default: (props: { clusterId: number; instanceId: number }) => {
+    apisixGatewaySpy(props);
+    return <div>gateway config</div>;
+  },
+}));
 vi.mock('./Instance', () => ({ default: () => <div>instances</div> }));
 vi.mock('./K8sResource', () => ({ default: () => null }));
 vi.mock('./Queue', () => ({ default: () => null }));
@@ -142,7 +150,7 @@ describe('APISIX service instance tabs', () => {
     await screen.findByText('APISIX dashboard cluster 7');
     const tabs = screen.getAllByRole('tab').map((tab) => tab.textContent);
 
-    expect(tabs).toEqual(['监控', '概览', '实例', '配置']);
+    expect(tabs).toEqual(['监控', '网关配置', '概览', '实例', '配置']);
     expect(screen.getByTestId('tabs')).toHaveAttribute(
       'data-active-key',
       'monitor',
@@ -153,6 +161,10 @@ describe('APISIX service instance tabs', () => {
         embedded: true,
       }),
     );
+
+    fireEvent.click(screen.getByRole('tab', { name: '网关配置' }));
+    await screen.findByText('gateway config');
+    expect(apisixGatewaySpy).toHaveBeenCalledWith({ clusterId: 7, instanceId: 9 });
   });
 
   it('opens monitoring when navigating from another service to APISIX', async () => {

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.tsx
@@ -16,6 +16,7 @@ import {
   getServiceInstance,
   getServiceWebUis,
 } from '@/services/service';
+import ApisixGatewayPanel from './ApisixGateway';
 import InstanceTab from './Instance';
 import K8sResource from './K8sResource';
 import QueueTab from './Queue';
@@ -203,6 +204,18 @@ const ServiceInstance: React.FC = () => {
       key: 'monitor',
       label: '监控',
       children: primaryMonitor,
+    });
+  }
+  if (isApisix) {
+    items.push({
+      key: 'apisixGateway',
+      label: '网关配置',
+      children: (
+        <ApisixGatewayPanel
+          clusterId={numericClusterId}
+          instanceId={numericInstanceId}
+        />
+      ),
     });
   }
   if (serviceInfo?.dashboardUrl) {

--- a/datasophon-ui-v2/src/services/service.ts
+++ b/datasophon-ui-v2/src/services/service.ts
@@ -166,3 +166,23 @@ export async function bindRoleGroup(
     { method: 'POST', params },
   );
 }
+
+/** APISIX 网关配置（网关配置 Tab） */
+export async function getApisixGateway(clusterId: number, instanceId: number) {
+  return request<DATASOPHON.ApiResponse<DATASOPHON.ApisixGatewayResponse>>(
+    `/cluster/${clusterId}/service/instance/${instanceId}/apisix/gateway`,
+    { method: 'GET' },
+  );
+}
+
+/** 保存 APISIX 网关配置（校验 + 保存 + 只下发不重启） */
+export async function saveApisixGateway(
+  clusterId: number,
+  instanceId: number,
+  gatewayYaml: string,
+) {
+  return request<DATASOPHON.ApiResponse<DATASOPHON.ApisixGatewayPushResult[]>>(
+    `/cluster/${clusterId}/service/instance/${instanceId}/apisix/gateway`,
+    { method: 'POST', data: { gatewayYaml } },
+  );
+}

--- a/datasophon-ui-v2/src/services/types/apisixGateway.d.ts
+++ b/datasophon-ui-v2/src/services/types/apisixGateway.d.ts
@@ -1,0 +1,23 @@
+declare namespace DATASOPHON {
+  /** APISIX 角色实例节点视图 */
+  interface ApisixGatewayRole {
+    hostname: string;
+    state: string;
+  }
+
+  /** GET /v2/.../apisix/gateway 响应体 */
+  interface ApisixGatewayResponse {
+    /** 用户可编辑段（upstreams/routes/global_rules）；未保存过时为向导参数拼出的初始值 */
+    gatewayYaml: string;
+    /** 模板固定输出的托管段（plugin_metadata + #END），供拼「最终 apisix.yaml」只读预览 */
+    managedSuffix: string;
+    roles: ApisixGatewayRole[];
+  }
+
+  /** 单节点下发结果 */
+  interface ApisixGatewayPushResult {
+    hostname: string;
+    success: boolean;
+    message?: string;
+  }
+}

--- a/datasophon-worker/src/test/java/com/datasophon/worker/test/ApisixStandaloneTemplateTest.java
+++ b/datasophon-worker/src/test/java/com/datasophon/worker/test/ApisixStandaloneTemplateTest.java
@@ -114,6 +114,66 @@ public class ApisixStandaloneTemplateTest {
     }
 
     @Test
+    public void rendersLegacyRouteByteIdenticallyWhenGatewayYamlEmpty() throws Exception {
+        Map<String, Object> data = routeData();
+        data.put("apisixGatewayYaml", "");
+        String withEmptyGatewayYaml = render(buildCfg(), "apisix-routes.ftl", data);
+        String legacyBaseline = render(buildCfg(), "apisix-routes.ftl", routeData());
+
+        assertTrue(withEmptyGatewayYaml.equals(legacyBaseline));
+    }
+
+    @Test
+    public void rendersGatewayYamlVerbatimWhenPresent() throws Exception {
+        String customYaml = "upstreams:\n"
+                + "  - id: 1\n"
+                + "    type: roundrobin\n"
+                + "    nodes:\n"
+                + "      '10.0.0.5:8080': 1\n"
+                + "\n"
+                + "routes:\n"
+                + "  - id: 1\n"
+                + "    uri: '/custom'\n"
+                + "    upstream_id: 1\n"
+                + "\n"
+                + "global_rules:\n"
+                + "  - id: 1\n"
+                + "    plugins:\n"
+                + "      prometheus:\n"
+                + "        prefer_name: true\n"
+                + "  - id: 2\n"
+                + "    plugins:\n"
+                + "      opentelemetry:\n"
+                + "        sampler:\n"
+                + "          name: always_on\n";
+        Map<String, Object> data = routeData();
+        data.put("apisixGatewayYaml", customYaml);
+
+        String routes = render(buildCfg(), "apisix-routes.ftl", data);
+        String yaml = routes.replace("#END\n", "");
+        Map<String, Object> document = new Yaml(new SafeConstructor(new LoaderOptions())).load(yaml);
+
+        assertTrue(routes.contains("uri: '/custom'"));
+        assertTrue(routes.contains("'10.0.0.5:8080': 1"));
+        // 托管段（plugin_metadata + #END）始终由模板固定输出，不交给 UI，防止被误删导致链路追踪静默失效
+        assertTrue(routes.contains("service.name: apisix"));
+        assertTrue(routes.contains("address: 127.0.0.1:4318"));
+        assertTrue(routes.endsWith("#END\n"));
+        assertTrue(document.containsKey("upstreams"));
+        assertTrue(document.containsKey("routes"));
+        assertTrue(document.containsKey("global_rules"));
+        assertTrue(document.containsKey("plugin_metadata"));
+        // 验收路由参数(apisixRouteUri 等)在 apisixGatewayYaml 非空时不再生效
+        assertFalse(routes.contains("uri: '/get'"));
+        // apisixGatewayYaml 自带结尾换行时，托管段前只应有一个空行分隔（不是两个）——
+        // 沙箱实测曾因 ${var} 独占一行 + 变量自身尾随换行叠加，多渲染出一个空行
+        assertTrue(routes.contains("name: always_on\n\n# opentelemetry"),
+                "apisixGatewayYaml 与托管段之间应恰好一个空行分隔");
+        assertFalse(routes.contains("name: always_on\n\n\n# opentelemetry"),
+                "apisixGatewayYaml 与托管段之间不应有多余空行");
+    }
+
+    @Test
     public void standaloneDdlUsesCustomTemplatesAndMapParameters() throws Exception {
         String ddl = Files.readString(Path.of("..", "package", "raw", "meta", "datacluster-physical", "APISIX", "service_ddl.json"));
 
@@ -131,5 +191,7 @@ public class ApisixStandaloneTemplateTest {
         assertTrue(ddl.contains("\"name\": \"apisixUpstreamPort\",\n      \"key\": \"apisixUpstreamPort\""));
         assertTrue(ddl.contains("\"name\": \"apisixPrometheusAddr\",\n      \"key\": \"apisixPrometheusAddr\""));
         assertTrue(ddl.contains("\"name\": \"apisixPrometheusPort\""));
+        assertTrue(ddl.contains("\"name\": \"apisixGatewayYaml\""));
+        assertTrue(ddl.contains("\"hidden\": true"));
     }
 }

--- a/docs/apisix-gateway-tab-实施任务清单-2026-08-04.md
+++ b/docs/apisix-gateway-tab-实施任务清单-2026-08-04.md
@@ -1,0 +1,324 @@
+# APISIX(standalone) 网关配置 Tab —— 任务执行清单
+
+> 状态图例：⬜ 未开始 / 🔄 进行中 / ✅ 已完成 / ⛔ 阻塞
+> **每完成一个任务，立即回写本文件对应行的状态与完成日期**，中断后从第一个非 ✅ 的任务继续，已完成任务不返工。
+
+## 0. Context
+
+在 APISIX(standalone) 服务详情页增加一个 Tab，以**图形化 + 代码化双视图**管理网关配置（Routes / Upstreams / Global Rules），形态模仿 APISIX 原生 Dashboard。
+
+**为什么不代理原生 Dashboard**：`deploy/deployment-standalone-doris.md` §7.9.1（2026-08-04 ddh-01 实机验证 V1–V6）已判死刑——standalone 的 `admin/init.lua` 只注册 3 个只读端点，原生 Dashboard 首屏请求 `GET /apisix/admin/services` 直接 404，**崩在 React 错误边界连登录页都到不了**；`PUT /apisix/admin/configs` 返回 202 但 `apisix.yaml` sha256 不变（不落盘），重启即丢。该节给出的替代路线原文即：「DataSophon 自建配置 Tab，复用现有 `apisix-routes.ftl` 模板热加载链路」。
+
+**已拍板的四点**：① 可读写的真正配置管理；② 图形化首期覆盖 Routes + Upstreams + Global Rules；③ 靠 APISIX 自身**文件热加载**生效，**不重启网关**；④ 图形化之外再提供代码化（YAML）视图，两者可自由切换。
+
+## 1. 方案要点
+
+**真相源 = 新增隐藏 DDL 参数 `apisixGatewayYaml`（YAML 文本）**。代码视图直接编辑它；图形化视图是它 `js-yaml.load()` 后的结构化投影。切换 = `load`/`dump`，不是两套数据。
+
+```
+Tab (ApisixGatewayPanel)   ┌─ 图形化: doc.routes/upstreams/global_rules → 三张 ProTable
+  状态 text + doc ─────────┤
+                           └─ 代码化: Monaco 编辑 text
+   读 getServiceConfig → apisixGatewayYaml → text，load 出 doc
+   写 当前视图为准 → POST 新端点
+        ↓
+  后端: 校验 YAML → 复用 saveServiceConfig 写 configJson → 有条件复位 needRestart
+      → 仅对 apisix.yaml 这个 generator 调 ServiceLifecycleUtils.configServiceRoleInstance（不停不启）
+        ↓
+  Worker: ConfigureServiceHandler → FreemakerUtils(custom) → apisix-routes.ftl
+        ↓
+  /usr/local/apisix/conf/apisix.yaml → APISIX 定期重读文件自动生效
+```
+
+**为什么真相源是 YAML 文本而非结构化 JSON**：APISIX 的 route 天然嵌套（`plugins.limit-count.count`），而 DDL 现有集合类型 `multipleWithMap` 只能表达**扁平** map（NGINX 的 `directives` 就是被迫退化成分号串 + `?split(";")`）。YAML 文本让模板只剩一行 `${apisixGatewayYaml}`，避开 FreeMarker 递归宏与缩进控制，并让代码视图变成零成本。
+
+## 2. 关键事实（已核实，不要推翻重查）
+
+|  #  |                                                                                                            事实                                                                                                             |                                 出处                                 |
+|-----|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
+| F1  | `configType: "map"` 的参数以变量名注入 FreeMarker 顶层；其余落进 `itemList`                                                                                                                                                               | `FreemakerUtils.renderCustomConfigFormat:197-219`                  |
+| F2  | Worker `replacePlaceholder` 的 switch 只覆盖 `input`/`multiple`/`multipleWithMap`，**`type:"textarea"` 完全跳过归一化**；只有 `Boolean`/`Integer` 会被 `toString()` → 长文本原样透传                                                              | `ConfigureServiceHandler.configure:99-158`                         |
+| F3  | 「多行原文整体注入模板」已有成熟先例：OTELCOLLECTOR `rawYaml`（`type:textarea`+`configType:map`+`hidden:true`），模板 `<#if (rawYaml!"")?has_content>${rawYaml}<#else>…`                                                                          | `OTELCOLLECTOR/service_ddl.json:137-147`、`templates/otelcol.ftl:1` |
+| F4  | 前端 `ConfigForm.tsx` 对 `textarea` 走 `return null` **不渲染** → 隐藏参数不会污染「配置」Tab                                                                                                                                                | `ConfigForm.tsx:125,274`                                           |
+| F5  | `saveServiceConfig` 每次 INSERT 新版本并**无条件打 `needRestart`** 三处（roleInstance/roleGroup/serviceInstance）                                                                                                                       | `ServiceInstallServiceImpl.java:188-250`                           |
+| F6  | **已有「只 configure 不重启」原语** `ServiceLifecycleUtils.configServiceRoleInstance(clusterInfo, configFileMap, roleInstance)`，无 REST 端点；现有调用方 `ClusterDeleteService.java:215`、`OtelCollectorConfigService.pushNodeConfig:120-139` | `ServiceLifecycleUtils.java:112-123`                               |
+| F7  | 前端已依赖 `js-yaml ^4.2.0`、`@monaco-editor/react ^4.7.0`，`Setting/HelmEditor.tsx` 有现成 Monaco+YAML 用法可复用                                                                                                                       | `package.json:41,51`                                               |
+| F8  | `apisix.yaml` 末尾 `#END` 是 standalone 解析终止符，必须单独占末行                                                                                                                                                                        | `apisix-routes.ftl:36`、`ApisixStandaloneTemplateTest`              |
+| F9  | 服务详情页 Tab 是 if/else 链非映射表，`hasPrimaryMonitor` 分支在 `index.tsx:175-207`                                                                                                                                                     | `Cluster/ServiceInstance/index.tsx`                                |
+| F10 | i18n 无 glob 自动加载，新命名空间须在 `locales/zh-CN.ts` 与 `locales/en-US.ts` **两处**注册，漏一处整个命名空间失效                                                                                                                                     | —                                                                  |
+
+## 3. 双视图的三条设计约束（最易出 bug 处）
+
+1. **图形化只投影它认识的部分，其余原样保留**。状态模型是一个完整 `doc` 对象，图形化只读写 `doc.routes`/`doc.upstreams`/`doc.global_rules`；其它顶层段（用户在代码视图写的 `consumers`、`ssls`）与单条 route 上的未知字段全部留在 `doc` 里，`dump` 时自然带出。表单提交用 `{...originalItem, ...formValues}` **合并而非替换**。
+2. **注释在 `load`→`dump` 往返中必然丢失**（js-yaml 固有行为，不是可修 bug，也不引入 `yawn-yaml` 等库）。用**脏标记**压损失：图形化未真正改动时切回代码视图**直接复用原始 `text` 不 dump**；已改动且原文含注释则先弹二次确认。
+3. **代码 → 图形化可能失败**。切换前先 `load` 试解析，失败则**拦在代码视图**并在 Monaco 标出错误行，不静默降级。
+
+## 4. 任务清单
+
+> 依赖关系：`T0 → T1 → T2`；`T1 → T3/T4`；`T5 → T6 → T7`；`T6 → T8 → T9`；全部 → `T10`。
+> T3/T4（后端）与 T5–T9（前端）之间无代码依赖，可并行。
+
+| ID  |               任务               | 状态 |    完成日期    |
+|-----|--------------------------------|----|------------|
+| T0  | 热加载实测（**硬前置**）                 | ✅  | 2026-08-05 |
+| T1  | DDL 新增 `apisixGatewayYaml` 参数  | ✅  | 2026-08-05 |
+| T2  | `apisix-routes.ftl` 双分支 + 模板测试 | ✅  | 2026-08-05 |
+| T3  | 后端 GET 端点                      | ✅  | 2026-08-05 |
+| T4  | 后端 POST 端点（校验 + 保存 + 只下发不重启）   | ✅  | 2026-08-05 |
+| T5  | 前端 i18n + API 封装               | ✅  | 2026-08-05 |
+| T6  | 前端 Panel 骨架 + 代码视图             | ✅  | 2026-08-05 |
+| T7  | 前端 Tab 挂载                      | ✅  | 2026-08-05 |
+| T8  | 前端图形化三张表                       | ✅  | 2026-08-05 |
+| T9  | 前端视图切换状态机                      | ✅  | 2026-08-05 |
+| T10 | 沙箱端到端验收                        | ✅  | 2026-08-05 |
+
+---
+
+### T0 · 热加载实测（硬前置，无代码产出）
+
+**为什么必须先做**：整个「不重启」前提建立在 APISIX standalone `config_provider: yaml` 会定期重读 `apisix.yaml` 上。本项目**从未实测过**（§7.9.1 只验了 Admin API 那条路）。不成立则 T1–T10 的生效方式全部需要重新设计。
+
+**做法**：沙箱 ddh-01（`192.168.10.131`，APISIX 3.17.0 唯一在跑节点）。先 `cp` 备份 `config.yaml`/`apisix.yaml` 并记录 sha256；SSH 手工往 `apisix.yaml` 加一条 route（保持 `#END` 在末行）；`curl` 轮询新路径并计时；结束后还原 `.bak` 并校验 sha256 回到基线。
+
+**验收**：不重启 apisix 即可命中新路由，且**记录实测生效延迟**（写入本文件）。
+**若不通过**：⛔ 阻塞全部后续任务，回头与用户重新选生效方式（沿用现有链路 = 保存后手动重启角色）。
+
+**实测结果（2026-08-05，ddh-01）**：
+- 备份 `apisix.yaml`/`config.yaml`，基线 sha256 = `2f903f8e...df569` / `7f6e6b20...4d15c99`
+- 向 `routes` 追加 `id:2 uri:/ddh-t0-test upstream_id:1`（`#END` 仍在末行），未重启/未 reload 命令
+- 轮询 `curl http://127.0.0.1:9080/ddh-t0-test`：**首次探测（≤0.5s 轮询间隔内）即从 APISIX 自身 `{"error_msg":"404 Route Not Found"}`（未匹配）变为后端 Jetty 的 404 Not Found（已匹配路由，转发到 8080 后端）**，证明 standalone 模式确有文件热加载，且延迟在亚秒级
+- `systemctl show apisix -p ExecMainStartTimestamp` 前后一致（`Tue 2026-08-04 22:07:58 CST`），确认无重启
+- 还原 `.bak`，两文件 sha256 均回到基线，`/ddh-t0-test` 复核已变回未匹配响应
+- **结论：T0 通过，热加载路线成立，T1–T10 按计划继续**
+
+---
+
+### T1 · DDL 新增 `apisixGatewayYaml` 参数
+
+**文件**：`package/raw/meta/datacluster-physical/APISIX/service_ddl.json`
+
+`parameters` 新增（字段组合完全照抄 OTELCOLLECTOR `rawYaml`）：
+
+```json
+{
+  "name": "apisixGatewayYaml",
+  "label": "网关配置（由网关配置 Tab 管理）",
+  "description": "非空时替换 upstreams/routes/global_rules 段，由 UI 编辑生成",
+  "required": false, "enabled": true,
+  "type": "textarea", "configType": "map",
+  "defaultValue": "", "configurableInWizard": false, "hidden": true
+}
+```
+
+并把 `apisixGatewayYaml` 追加进 `configWriter.generators[filename=apisix.yaml].includeParams`（**原有 3 个参数保留**，供 T2 的回退分支使用）。
+
+⚠️ `Generators.equals/hashCode` 只按 `filename` 比较，**不要新增重名 generator**。
+
+**验收**：JSON 可解析；`hidden:true` + `type:textarea` 组合确保它不出现在「配置」Tab（F4）。
+
+---
+
+### T2 · `apisix-routes.ftl` 双分支 + 模板测试
+
+**文件**：`package/raw/meta/datacluster-physical/APISIX/templates/apisix-routes.ftl`、`datasophon-worker/src/test/java/com/datasophon/worker/test/ApisixStandaloneTemplateTest.java`
+
+模板改为两分支；`plugin_metadata` 段与 `#END` **保持模板固定输出**（不交给 UI，避免 OTel collector 地址被误删导致链路追踪静默失效）：
+
+```ftl
+<#if (apisixGatewayYaml!"")?has_content>
+${apisixGatewayYaml}
+<#else>
+（现有 upstreams / routes / global_rules 三段原样不动）
+</#if>
+
+plugin_metadata:
+  - id: opentelemetry
+    ...（现有内容原样保留，含那两行解释性注释）
+#END
+```
+
+`global_rules` 落在可编辑分支内（用户要求可编辑），由 T4 的后端校验兜底。
+
+**验收**：`ApisixStandaloneTemplateTest` 新增两个用例覆盖两分支（非空时直出且 `#END` 仍在末行 / 为空时回退旧行为逐字节一致），**现有全部断言保留不改**。
+
+```bash
+export JH21=/Users/pro/Library/Java/JavaVirtualMachines/graalvm-jdk-21.0.7/Contents/Home
+JAVA_HOME=$JH21 ./mvnw -pl datasophon-worker -am test -s ~/.m2/setting.xml -Dtest=ApisixStandaloneTemplateTest
+```
+
+---
+
+### T3 · 后端 GET 端点
+
+**文件**：新建 `datasophon-api/src/main/java/com/datasophon/api/controller/v2/ApisixGatewayV2Controller.java` + `service/ApisixGatewayConfigService.java`
+
+`GET /v2/cluster/{clusterId}/service/instance/{instanceId}/apisix/gateway` → 返回 `{ gatewayYaml, managedSuffix, roles[] }`：
+
+- `gatewayYaml`：当前 `apisixGatewayYaml`；**为空则用 3 个向导参数（`apisixRouteUri`/`apisixUpstreamHost`/`apisixUpstreamPort`）拼出初始 YAML**，让用户首次打开就有内容可编辑
+- `managedSuffix`：模板固定输出的托管段文本（`plugin_metadata` + `#END`），供代码视图做「最终文件预览」。**由后端提供而非前端硬编码**，避免与模板漂移
+- `roles[]`：各 Apisix 角色实例 hostname/状态
+
+复用：`ClusterServiceInstanceConfigServiceImpl.getServiceInstanceConfig` 读 configJson、`ClusterServiceRoleInstanceService.getServiceRoleInstanceListByClusterIdAndRoleName(clusterId, "Apisix")`。
+
+**验收**：单测覆盖「参数为空 → 返回向导参数拼出的初始 YAML」「参数非空 → 原样返回」。
+
+---
+
+### T4 · 后端 POST 端点（校验 + 保存 + 只下发不重启）
+
+**文件**：同 T3 两个类
+
+`POST /v2/cluster/{clusterId}/service/instance/{instanceId}/apisix/gateway`，body `{ gatewayYaml: string }`：
+
+1. 校验 `serviceName == "APISIX"`，否则 400
+2. **YAML 校验**（用已有 snakeyaml / Jackson YAML）：
+   - 可解析且顶层是 map
+   - 顶层键走**黑名单而非白名单**：只禁 `plugin_metadata`（与模板托管段重复会导致 APISIX 解析异常）。其余 standalone 支持的段（`consumers`/`ssls`/`services`/`stream_routes`…）**一律放行**——代码视图的意义就是补足图形化没覆盖的高级配置，白名单会把它堵死
+   - **必须含 prometheus 与 opentelemetry 两条 global_rules**，否则 400（防 UI bug 或手写失误打断监控与链路追踪的廉价保险）
+   - 禁止出现 `#END`（终止符由模板统一输出，提前出现会截断后续内容）
+3. 记录调用前 `serviceInstance.needRestart`
+4. 复用 `ServiceInstallServiceImpl.saveServiceConfig` 写入（保证 configJson/configFileJson/MD5/版本号与「配置」Tab 完全一致）
+5. **若第 3 步为 `NO` 才复位**三处 `needRestart`（APISIX 热加载不需重启；本来就是 YES 说明用户另改过端口等真需重启项，**不清**，否则会掩盖它）
+6. 取全部 `RUNNING` 的 `Apisix` 角色实例，逐个调 `ServiceLifecycleUtils.configServiceRoleInstance`，**configFileMap 只保留 `filename == "apisix.yaml"` 的 generator**（不重写 `config.yaml`，避免误触发需重启项）
+7. 返回每节点下发结果
+
+参照现成写法：`DAGExecutor.createConfigFileMap:383-413`、`OtelCollectorConfigService.pushNodeConfig:120-139`。
+
+**验收**：单测覆盖 YAML 校验四条规则的正反例 + needRestart 有条件复位逻辑。
+⚠️ 新增 `@SpringBootTest` **必须加 `@DirtiesContext`**，否则与其他上下文争抢 gRPC 18081（已知坑，表象常被误判为 MySQL 连接问题）。本任务未用 `@SpringBootTest`，改用纯 Mockito 单测（`ApisixGatewayConfigServiceTest`），规避该坑。
+
+**实现中发现并修复的计划外缺口**：`ServiceInstallService#getServiceConfigOption` 对已安装实例只回放上次持久化的 `configJson`（`listServiceConfigByServiceInstance` 逐字节 `JSONArray.parseArray`），**不会**合并 DDL 新增但从未保存过的参数。沙箱 ddh-01 的 APISIX 实例早于 `apisixGatewayYaml` 参数存在，若不处理，GET/POST 会因为列表里根本没有这一项而静默失效（POST 写不进任何值）。已在 `ApisixGatewayConfigService.loadEffectiveConfigs` 加了兜底：找不到该参数时从 `getServiceConfigFromDdl` 补一份空值条目再继续。
+
+---
+
+### T5 · 前端 i18n + API 封装
+
+**文件**：新建 `datasophon-ui-v2/src/locales/{zh-CN,en-US}/apisixGateway.ts` + 配套 `.test.ts`；改 `src/locales/zh-CN.ts`、`src/locales/en-US.ts`；改 `src/services/service.ts`
+
+- 键统一前缀 `pages.apisixGateway.`；zh/en 两份键完全对齐；`.test.ts` 遍历断言每键存在且非空（沿用 `apisixMonitor.test.ts` 的写法）
+- **两处注册都要改**（F10）
+- API 封装沿用 `baseURL='/ddh/api/v2'`，函数放 `service.ts`（勿动 `src/services/ant-design-pro/` 生成目录）
+
+**验收**：`npm run lint` + `npm run test` 绿。
+
+---
+
+> **实现顺序说明**：T6/T8/T9 在实现时一并完成——`index.tsx` 的状态机（load/dump 切换、脏标记、注释二次确认）与 `GraphicView` 三张表天然是同一份状态的两个消费者，分三次改同一个文件返工成本更高，故一次性写完再补齐三批测试（`gatewayYaml.test.ts` 13 例、`index.test.tsx` 7 例覆盖状态机四行切换、`GlobalRuleTable.test.tsx` 覆盖内置规则不可删）。
+
+### T6 · 前端 Panel 骨架 + 代码视图
+
+**文件**：新建 `src/pages/Cluster/ServiceInstance/ApisixGateway/{index.tsx, CodeView.tsx, gatewayYaml.ts}` + 测试
+
+放在 `ServiceInstance/` 下而非 `pages/monitor/`——它是服务详情页专属的配置管理，不是监控看板。
+
+- `index.tsx` = `ApisixGatewayPanel`：顶部 `Segmented` 视图切换 + 保存按钮，持有唯一状态（`text` / `doc` / `dirtyFrom`）
+- `CodeView.tsx`：Monaco YAML 编辑器（**复用 `Setting/HelmEditor.tsx` 的现成配置，不重新调参**）+ 顶部提示条说明 `plugin_metadata`/`#END` 由平台托管 + 「预览最终 apisix.yaml」只读抽屉（拼接 T3 返回的 `managedSuffix`）
+- `gatewayYaml.ts`：`js-yaml` load/dump 封装、内置规则（id 1 prometheus / id 2 opentelemetry）锁定与保序、id 唯一性与 upstream 引用完整性校验、**注释检测**
+
+**验收**：`npm run lint`/`test` 绿；**此任务完成后代码视图即独立可用**，不依赖图形化就能跑通端到端（见 T10 的 V10）。
+
+---
+
+### T7 · 前端 Tab 挂载
+
+**文件**：`src/pages/Cluster/ServiceInstance/index.tsx`、`index.test.tsx`
+
+在现有 if/else 链（`index.tsx:175-207`）旁新增：仅 `serviceName === 'APISIX'` 时 push，位置在 `monitor` 之后、`instance` 之前。
+
+**命名**：现有监控 Tab 组件已叫 `ApisixDashboard`（`pages/monitor/ApisixMonitor/index.tsx`），故新组件叫 `ApisixGatewayPanel`，Tab 中文标签用 **「网关配置」**——同页已有「监控」Tab 在做 dashboard 的事，两个都叫 Dashboard 会让用户分不清哪个看指标、哪个改路由。若要改回原生叫法，改一处 label 字符串即可。
+
+**验收**：`index.test.tsx` 复制现有两个 `describe`（首次进入 / 从别的服务切过来），断言新 Tab 出现且 APISIX 之外的服务不出现。
+
+---
+
+### T8 · 前端图形化三张表
+
+**文件**：新建 `ApisixGateway/{GraphicView.tsx, RouteTable.tsx, UpstreamTable.tsx, GlobalRuleTable.tsx}` + 测试
+
+- `GraphicView.tsx`：左侧资源类型菜单（Routes / Upstreams / Global Rules）+ 右侧内容区，模仿原生 Dashboard 布局
+- 三张表各一个 ProTable（**本地 `dataSource`，不是 `request`**——数据来自一次性拉取的 YAML，不是分页接口）+ ProForm 抽屉增删改
+- 表单提交用 `{...originalItem, ...formValues}` **合并**，保留表单不认识的字段（约束 1）
+- 内置 global_rules（id 1/2）在表格中标记为「系统内置」，只读、不可删
+- Route 的 `plugins` **只给一个小 YAML/JSON 编辑框**，不为几十个插件各写表单——有代码视图作为完整逃生舱
+- 顶部提示「当前配置还含有 N 个仅可在代码视图编辑的段」（如 `consumers`），避免用户误以为数据丢了
+
+**验收**：单测覆盖「未知字段保留」「内置规则不可删」「upstream 引用完整性」。
+
+---
+
+### T9 · 前端视图切换状态机
+
+**文件**：`ApisixGateway/index.tsx` + 测试
+
+|       切换方向       |                            行为                             |
+|------------------|-----------------------------------------------------------|
+| 代码 → 图形化         | `load(text)` 试解析；失败则**留在代码视图**并在 Monaco 标出错误行；成功则更新 `doc` |
+| 图形化 → 代码（图形化未改动） | **直接复用原始 `text` 不 dump** —— 保住注释与原始排版                     |
+| 图形化 → 代码（图形化已改动） | `dump(doc)` 覆盖 `text`；若原 `text` 含注释，先弹二次确认告知注释将丢失         |
+| 保存               | 以**当前所在视图**为准：代码视图提交 `text`，图形化视图提交 `dump(doc)`           |
+
+**验收**：单测覆盖上表四行 + 往返保真（含注释、含 `consumers` 段、含未知字段）。
+
+---
+
+### T10 · 沙箱端到端验收
+
+沙箱 ddh-01，**先备份 `apisix.yaml` 并记录 sha256**，收尾回滚（照搬 §7.9.1 的 V1–V6 做法）。
+
+| ID  |     验证     |                                                   通过标准                                                    |
+|-----|------------|-----------------------------------------------------------------------------------------------------------|
+| V2  | 长文本透传不被破坏  | 节点 `apisix.yaml` 与 UI 提交内容字节级一致（除模板固定段）                                                                   |
+| V3  | 端到端写入      | UI 新增 route+upstream → 节点文件 sha256 变化且内容正确，`curl` 新路由通                                                    |
+| V4  | 不重启 + 不打标记 | `systemctl show apisix` 的 `ExecMainStartTimestamp` 不变；UI **不显示**「需要重启」                                    |
+| V5  | 监控/链路不断    | `9091/apisix/prometheus/metrics` 仍 200 且含 `apisix_*`；OTel span 仍上报                                        |
+| V6  | 校验兜底       | 构造缺 prometheus 规则的 YAML 直接 POST → 400，节点文件未变                                                              |
+| V7  | 向后兼容       | `apisixGatewayYaml` 为空的实例触发 configure → 结果与改动前逐字节一致                                                       |
+| V9  | 双视图往返保真    | 代码视图写含注释 + `consumers` 段 + 未知字段的 YAML → 切图形化改一条 route → 切回代码：`consumers` 与未知字段**仍在**；注释丢失前有二次确认；语法错误被拦并标行 |
+| V10 | 代码视图独立可用   | 只用代码视图新增 route 并保存生效（T6 完成后即可先验收此条）                                                                       |
+| V8  | 回滚         | 还原 `.bak`，sha256 回到基线                                                                                     |
+
+**实测结果（2026-08-05，ddh-01，真实 APISIX 实例 `clusterId=1 instanceId=23`）**：
+
+按用户指示复用 `deploy/deployment-standalone-doris.md` 记录的既有部署环境与部署手法（§7.4/§7.6 的「打包 → scp → md5 校验 → 备份旧目录（不删除）→ 复制 `conf/api.local.properties` → 启动」流程），而非本地起一个连沙箱 MySQL 的临时 Master 进程：
+
+1. 本地 `mvn clean package -pl datasophon-api -am` 打出含 T1-T4 全部改动 + 新前端的 `datasophon-manager-3.0-SNAPSHOT.tar.gz`（131MB）。
+2. 本地更新后的 `package/raw/meta/datacluster-physical/APISIX/`（含新 `apisixGatewayYaml` 参数与双分支模板）scp 到 ddh-01 的 `--productPackagesPath` 暂存目录，`datasophon-cli upload registry` 全量重新推送 Nexus（2749 文件成功，0 失败）。
+3. 停旧进程 → 目录整体备份为 `datasophon-manager-3.0-SNAPSHOT.bak-apisixgateway-fix2-<ts>`（未删除）→ 解压新版 → 复制真实 `conf/api.local.properties` → 启动。日志确认 gRPC `18081`、5 主机预热、APISIX DDL 正常载入内存。
+4. **过程中定位并修复一个真实的平台级 bug**：`ServiceLifecycleUtils.configServiceRoleInstance`（F6 引用的既有「只 configure 不重启」原语）从未填充 `ServiceRoleInfo.archInfoMap`，导致 `ServiceConfigureHandler.resolvePackageName` 在任何主机上都解析不到安装包，报「未找到匹配 CPU 架构的安装包」。这是该原语第一次被推到"需要真正按架构解析安装包"的调用路径上（此前唯一引用方 `ClusterDeleteService` 未必会触发同一分支），修复为在方法内部按 `clusterInfo.getClusterFrame() + roleInstanceEntity.getServiceName()` 查 `FrameServiceEntity` 并调 `ServicePkgNameUtils.getArchInfo` 填充，惠及该原语的全部现有与未来调用方。已本地单测覆盖，二次打包部署后确认解决。
+5. **过程中发现并修复一个格式缺陷**：`apisixGatewayYaml` 自带结尾换行 + `${var}` 独占模板一行自身也换行，导致非空分支比预期多渲染一个空行（不影响 YAML 解析、`#END` 仍在末行，纯格式问题）。改为 OTELCOLLECTOR 同款单行写法 `<#if ...>${var}<#else>` 后，`ApisixStandaloneTemplateTest` 新增字节级断言锁回归，模板重新上传 Nexus + Master `restart`（未改 Java 代码，无需重新打包）后现场复核通过。
+6. 登录用 `POST /ddh/api/v2/login/account`；写操作需要 `X-XSRF-TOKEN` 头（取自登录响应的 `XSRF-TOKEN` cookie），否则被 CSRF 过滤器拦成 403——这是走真实鉴权链路时才会暴露的细节，纯 curl 直连 controller 单测不会覆盖。
+
+逐项结果：
+
+- **V2/V3**：`GET .../apisix/gateway` 对已安装但从未设置过 `apisixGatewayYaml` 的实例，返回「向导参数拼出的初始 YAML」，与磁盘上真实 `apisix.yaml` 的可编辑段逐字节一致。`POST` 提交追加一条 `id:2 uri:/ddh-t10-test` 的新路由后，节点文件 sha256 从 `2f903f8e...1df569` 变为 `8783d670...`，`curl http://127.0.0.1:9080/ddh-t10-test` 从 APISIX 自身 `404 Route Not Found`（未命中）变为后端 Jetty 的 `404 Not Found`（已命中并转发），复用 T0 建立的"响应体来源"判定法。
+- **V4**：全程 `systemctl show apisix -p ExecMainStartTimestamp` 保持 `Tue 2026-08-04 22:07:58 CST` 不变；API 返回的 `needRestart` 全程为 `false`（含 POST 因 archInfoMap 缺失而下发失败的那一次——证明复位逻辑与下发结果解耦，符合设计）。
+- **V5**：写入前后 `9091/apisix/prometheus/metrics` 均 200，且恒定含 209 行 `apisix_*` 指标；文件里 `plugin_metadata` 段全程由模板固定输出，未被 UI 提交内容影响。
+- **V6**：构造缺 `prometheus` 规则的 YAML 直接 POST → 响应体 `errorCode:400 errorMessage:"global_rules 必须同时包含 prometheus 与 opentelemetry 两条规则"`（与本仓库 v2 接口"HTTP 200 + envelope 内 400"的既有约定一致），节点文件 sha256 未变。
+- **V7**：见上方 V2/V3 的 GET 结果——遗留实例（早于 `apisixGatewayYaml` 参数存在）触发 `configure` 后，输出与改动前的真实基线逐字节一致，验证了 `ApisixGatewayConfigService.loadEffectiveConfigs` 的兜底合并（详见 T4 记录的「计划外缺口」）在真实遗留数据上也成立。
+- **V8**：用同一个 POST 接口把 `gatewayYaml` 写回最初捕获的单路由内容（而非只手工改文件），确保 DB 与磁盘文件同时回到一致状态；修复模板空行问题后最终验证 `sha256sum /usr/local/apisix/conf/apisix.yaml` = `2f903f8eb10d6c3521f0c6862448428532df56a187c52c7c2c1e85cdef1df569`，与 T0 记录的最初基线**完全相同**。
+- **V9/V10**：纯前端状态机与保真逻辑，已由 `gatewayYaml.test.ts`（13 例）与 `ApisixGateway/index.test.tsx`（7 例，覆盖状态机四行切换 + 注释二次确认）在本地验证覆盖；本次沙箱验收未额外用真实浏览器复测，因为该部分不依赖后端真实环境（js-yaml load/dump 是纯函数）。
+
+**结论**：T10 全部子项通过，且顺带修复 1 个真实平台级 bug（`ServiceLifecycleUtils` 缺 `archInfoMap`，影响所有"只 configure 不重启"调用方）与 1 个模板格式缺陷。ddh-01 上的 Master 已停留在含全部本次改动的版本，未回滚；仅 `apisix.yaml` 测试产生的内容已还原到初始基线。
+
+---
+
+## 5. 风险与已知坑
+
+1. **T0 是唯一未经实测的前提**，不通过就停下重新决策，不要带着假设往下写。
+2. **Worker jar / 模板版本漂移**：§7.9.1 与 §9.2 都栽过——现场只推到「当时在测的那台」，导致其它节点用旧模板（ddh-01/03/04/05 曾集体落后 ddh-02）。本次模板改动后**必须同步全部五节点**并核对 MD5。**T10 现场核实：当前沙箱 APISIX 角色实例只跑在 ddh-01 一台**（`GET .../apisix/gateway` 的 `roles` 字段只返回 ddh-01），不存在多节点漂移风险；若后续该服务扩到多节点，仍需回到"全部同步 + 核对 MD5"的原则。
+3. **`global_rules` 可编辑 = 可误删监控**：三重防护——UI 锁定 id 1/2 只读、后端 POST 校验必含两插件、`plugin_metadata` 段留在模板不交给 UI。
+4. **`needRestart` 复位必须有条件**，否则会掩盖用户另改的真需重启项（如 `apisixPort`）。
+5. **注释丢失是 js-yaml 固有行为**，用脏标记 + 二次确认压到最小；不引入 `yawn-yaml` 等保留注释的库（维护状态差，收益不抵风险）。
+6. **不改动**：`config.yaml` 那个 generator、`ApisixHandlerStrategy`、监控 Tab 与 `ApisixMonitor` 的任何代码。
+7. `datasophon-ui-v2/config/proxy.ts` 是本机联调改动（指向远端沙箱），**提交前须用 `git diff --cached` 核对未包含它**。
+
+## 6. 收尾命令
+
+```bash
+export JH21=/Users/pro/Library/Java/JavaVirtualMachines/graalvm-jdk-21.0.7/Contents/Home
+JAVA_HOME=$JH21 ./mvnw spotless:apply -s ~/.m2/setting.xml
+JAVA_HOME=$JH21 ./mvnw -pl datasophon-common,datasophon-grpc-api,datasophon-ui-v2,datasophon-api \
+  -Dskip.installnodenpm -Dskip.npm -Dtest=ApisixGateway* -DfailIfNoTests=false test -s ~/.m2/setting.xml
+cd datasophon-ui-v2 && npm run lint && npm run test
+```
+

--- a/package/raw/meta/datacluster-physical/APISIX/service_ddl.json
+++ b/package/raw/meta/datacluster-physical/APISIX/service_ddl.json
@@ -86,7 +86,8 @@
         "includeParams": [
           "apisixRouteUri",
           "apisixUpstreamHost",
-          "apisixUpstreamPort"
+          "apisixUpstreamPort",
+          "apisixGatewayYaml"
         ]
       }
     ]
@@ -140,6 +141,18 @@
       "configurableInWizard": true,
       "hidden": false,
       "defaultValue": 8080
+    },
+    {
+      "name": "apisixGatewayYaml",
+      "label": "网关配置（由网关配置 Tab 管理）",
+      "description": "非空时替换 upstreams/routes/global_rules 段，由 UI 编辑生成",
+      "required": false,
+      "enabled": true,
+      "configType": "map",
+      "type": "textarea",
+      "defaultValue": "",
+      "configurableInWizard": false,
+      "hidden": true
     },
     {
       "name": "apisixPrometheusAddr",

--- a/package/raw/meta/datacluster-physical/APISIX/templates/apisix-routes.ftl
+++ b/package/raw/meta/datacluster-physical/APISIX/templates/apisix-routes.ftl
@@ -1,3 +1,4 @@
+<#if (apisixGatewayYaml!"")?has_content>${apisixGatewayYaml}<#else>
 upstreams:
   - id: 1
     type: roundrobin
@@ -19,6 +20,7 @@ global_rules:
       opentelemetry:
         sampler:
           name: always_on
+</#if>
 
 # opentelemetry 插件运行时读取的是 plugin_metadata，不是 config.yaml 的 plugin_attr——
 # 缺失时插件会静默跳过（access.log 报 "plugin_metadata is required"），不生成任何 span。


### PR DESCRIPTION
## Summary
- APISIX(standalone) 服务详情页新增「网关配置」Tab，图形化 + 代码化双视图管理 `upstreams`/`routes`/`global_rules`
- 真相源是隐藏 DDL 参数 `apisixGatewayYaml`；靠 standalone 自身的文件热加载生效，不重启网关（`config.yaml`/`ApisixHandlerStrategy`/监控 Tab 均未改动）
- 顺带修复平台级 bug：`ServiceLifecycleUtils.configServiceRoleInstance` 从未填充 `archInfoMap`，导致这个"只 configure 不重启"原语在任何主机上都无法解析安装包名（沙箱联调时第一次真正走到这条路径才暴露）

## 改动范围
- 后端：`GET`/`POST /v2/cluster/{clusterId}/service/instance/{instanceId}/apisix/gateway`（`ApisixGatewayConfigService` + Controller + DTO），DDL 新增隐藏参数，`apisix-routes.ftl` 双分支渲染（非空直出，空回退旧逻辑）
- 前端：`ApisixGatewayPanel`（Segmented 视图切换状态机）+ Monaco 代码视图 + 三张图形化表（Routes/Upstreams/Global Rules），内置 `prometheus`/`opentelemetry` 两条 global_rules 锁定不可删
- 详细任务清单与沙箱验收记录见 `docs/apisix-gateway-tab-实施任务清单-2026-08-04.md`

## Test plan
- [x] 后端单测：`ApisixGatewayConfigServiceTest`（13 例，覆盖 YAML 校验四规则、needRestart 有条件复位、遗留实例兜底）
- [x] Worker 模板测试：`ApisixStandaloneTemplateTest`（6 例，含字节级一致性 + 托管段格式回归断言）
- [x] 前端：`npm run lint`（Biome + tsc）与 `npm run test` 全绿（316 例）
- [x] 沙箱 ddh-01 真实 APISIX 实例端到端验证：新路由热加载生效（curl 前后响应体来源变化）、`ExecMainStartTimestamp` 不变、`needRestart` 不误标、`9091` Prometheus 指标全程 200、缺规则配置被 400 拦截、遗留实例（早于本参数存在）GET 结果与真实基线逐字节一致、回滚后 `apisix.yaml` sha256 与最初备份基线完全相同