### PR TITLE
feat(flink): 新增 Flink 1.20 OTLP 指标导出模块

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Datasophon 是大数据 / 云原生平台自动化部署与运维管理系统,�
 | `datasophon-ui-v2` | `datasophon-ui-v2/` | **当前默认前端**(Umi Max 4 + antd 6 + ProComponents 3) | 静态资源;`npm run build`;Node ≥ 22,npm + Biome(禁 pnpm/yarn/ESLint/Prettier) | 开发服务器 `8000` |
 | `datasophon-ui` | `datasophon-ui/` | 旧前端(React 19 + Vite + pnpm),已从 Maven 模块列表移除 | 仅历史参考,不再迭代 | `5180` |
 | `datasophon-assembly` | `datasophon-assembly/` | Maven 顶层 assembly 打包模块 | 纯 `pom` 模块,无 Java 源码;`target/datasophon-<version>-package.tar.gz` | — |
+| `datasophon-flink-metrics-otel` | `datasophon-flink-metrics-otel/` | Flink 1.20.x OTLP metrics reporter | 独立 Maven 工程;shaded Flink plugin jar,不在根 reactor | — |
 
 > 顶层 `pom.xml` 当前模块列表:`datasophon-common` → `datasophon-grpc-api` → `datasophon-worker` → `datasophon-cli-go` → `datasophon-ui-v2` → `datasophon-api` → `datasophon-k8s-agent` → `datasophon-assembly`(后者 `package` 依赖前面所有 `tar.gz` 产物)。
 
@@ -92,6 +93,13 @@ Flink 集群的作业壳 jar,`./mvnw test` **跑不到它的测试**。改动该
 ```bash
 ./mvnw -f datasophon-lineage-emitter/pom.xml test        # 21 个单元测试
 ./mvnw -f datasophon-lineage-emitter/pom.xml package     # Flink 2.0;-Pflink-1.20 切 1.20
+```
+
+**`datasophon-flink-metrics-otel` 同样不在根 reactor**。改动后必须显式验证 Flink 1.20.x 版本：
+
+```bash
+./mvnw -f datasophon-flink-metrics-otel/pom.xml clean verify
+./mvnw -f datasophon-flink-metrics-otel/pom.xml clean verify -Dflink.version=1.20.4
 ```
 
 ### 3.3 前端(`datasophon-ui-v2`,当前默认)
@@ -235,6 +243,7 @@ datasophon/
 ├── datasophon-ui-v2/             # 前端(当前默认,Umi Max + npm + Biome)
 ├── datasophon-ui/                # 旧前端(pnpm + Vite,已停止迭代)
 ├── datasophon-assembly/          # 顶层 assembly 打包
+├── datasophon-flink-metrics-otel/ # Flink 1.20.x OTLP metrics plugin(独立 Maven 工程)
 ├── deploy/                       # compose / docker / k8s 部署资产
 ├── .mcp.json                     # MCP 服务声明
 └── CLAUDE.md                     # 本文件

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ flowchart LR
 | `datasophon-ui-v2` | 当前默认 Web 前端 | Umi Max 静态资源，内嵌到 Manager 包 | 开发端口 `8000` |
 | `datasophon-k8s-agent` | 集群内签名鉴权执行边界 | Spring Boot Pod、Docker 镜像和 Helm Chart | HTTP `12552`，默认 NodePort `32552` |
 | `datasophon-assembly` | 汇总 Manager、Worker 和 CLI 交付物 | `datasophon-<version>-package.tar.gz` | — |
+| `datasophon-flink-metrics-otel` | 将 Flink 1.20.x 指标通过 OTLP/gRPC 导出到 OTel Collector | Flink metrics plugin shaded jar | — |
 
-`datasophon-ai-agent` 和 `datasophon-lineage-emitter` 是独立工程，不在根 Maven reactor 中。详细设计见 [系统架构文档](./docs/ARCHITECTURE.md)。
+`datasophon-ai-agent`、`datasophon-lineage-emitter` 和 `datasophon-flink-metrics-otel` 是独立工程，不在根 Maven reactor 中。详细设计见 [系统架构文档](./docs/ARCHITECTURE.md)。
 
 ## 技术栈
 
@@ -214,6 +215,7 @@ datasophon/
 ├── datasophon-assembly/            # 最终交付包
 ├── datasophon-ai-agent/            # 可选 AI sidecar（独立 Node 工程）
 ├── datasophon-lineage-emitter/      # 独立 Flink lineage emitter
+├── datasophon-flink-metrics-otel/   # Flink 1.20.x OTLP metrics plugin
 ├── package/                         # 安装包清单与运行期元数据
 ├── deploy/                          # Compose、Docker、K8s 部署资产
 └── docs/                            # 架构、OpenAPI、血缘及实施文档

--- a/datasophon-flink-metrics-otel/README.md
+++ b/datasophon-flink-metrics-otel/README.md
@@ -1,0 +1,64 @@
+# Flink 1.20 OpenTelemetry Metrics Reporter
+
+This standalone Maven project backports the metrics half of Apache Flink's
+`flink-metrics-otel` module to Flink 1.20.x. It intentionally does not backport
+the Flink 2.x trace reporter SPI.
+
+The module is not part of the Datasophon root Maven reactor. Run its build from
+the repository root:
+
+```bash
+JAVA_HOME=/Users/pro/Library/Java/JavaVirtualMachines/graalvm-jdk-21.0.7/Contents/Home \
+  ./mvnw -f datasophon-flink-metrics-otel/pom.xml clean verify -s ~/.m2/setting.xml
+```
+
+Override `flink.version` to verify another 1.20 patch release:
+
+```bash
+./mvnw -f datasophon-flink-metrics-otel/pom.xml clean verify \
+  -Dflink.version=1.20.4 -s ~/.m2/setting.xml
+```
+
+Install the shaded jar as a Flink plugin:
+
+```text
+$FLINK_HOME/plugins/metrics-otel/flink-metrics-otel-1.20-1.0.0-SNAPSHOT.jar
+```
+
+Configure `config.yaml` with a scalar reporter name:
+
+```yaml
+metrics:
+  reporters: otel
+  reporter:
+    otel:
+      factory.class: org.apache.flink.metrics.otel.OpenTelemetryMetricReporterFactory
+      exporter.endpoint: http://otel-collector-host:4317
+      service.name: flink-1.20
+      service.version: "1.20.5"
+      interval: 30 SECONDS
+```
+
+`metrics.reporters` must be a scalar such as `otel`, not the YAML list `[otel]`.
+For legacy `flink-conf.yaml`, use the equivalent flattened `metrics.*` keys.
+The reporter supports OTLP over gRPC only. `127.0.0.1:4317` is safe only when
+an OpenTelemetry Collector runs on every possible JobManager and TaskManager node.
+
+## Metric mapping
+
+| Flink type | OpenTelemetry type |
+| --- | --- |
+| Counter | monotonic delta Sum |
+| Gauge | Gauge; non-numeric values are skipped |
+| Meter | `<name>.count` delta Sum and `<name>.rate` Gauge |
+| Histogram | Summary with min, p50, p75, p95, p99, and max |
+
+Metric names use `flink.<logical-scope>.<metric-name>`. Flink scope variables
+become OpenTelemetry attributes after their angle brackets are removed.
+
+## Provenance
+
+The implementation is derived from Apache Flink 2.0.2's
+`flink-metrics/flink-metrics-otel` module and retains Apache license headers.
+The backport keeps the Flink 2.x factory class and configuration contract so
+operators can use the same reporter configuration on Flink 1.20 and 2.x.

--- a/datasophon-flink-metrics-otel/README.md
+++ b/datasophon-flink-metrics-otel/README.md
@@ -25,6 +25,12 @@ Install the shaded jar as a Flink plugin:
 $FLINK_HOME/plugins/metrics-otel/flink-metrics-otel-1.20-1.0.0-SNAPSHOT.jar
 ```
 
+Install it **only** under `plugins/`, never under `lib/`. The jar bundles the
+OpenTelemetry SDK, OkHttp and Okio under their original package names, without
+relocation; it is Flink's per-plugin classloader that keeps them off the user
+classpath. Dropping the jar into `lib/` removes that isolation and can shadow
+another component's OkHttp.
+
 Configure `config.yaml` with a scalar reporter name:
 
 ```yaml
@@ -53,8 +59,33 @@ an OpenTelemetry Collector runs on every possible JobManager and TaskManager nod
 | Meter | `<name>.count` delta Sum and `<name>.rate` Gauge |
 | Histogram | Summary with min, p50, p75, p95, p99, and max |
 
+A Summary's `sum` is reported as `mean * count`, where the mean comes from the
+histogram's bounded sample window while the count is the lifetime event count.
+`sum / count` therefore still yields the window mean, but the `sum` itself is an
+approximation: do not build `rate(sum)` or delta-of-sum queries on it.
+
 Metric names use `flink.<logical-scope>.<metric-name>`. Flink scope variables
 become OpenTelemetry attributes after their angle brackets are removed.
+
+## Differences from upstream
+
+This is not a byte-for-byte copy. The deviations below are deliberate. Keep this
+table in sync when re-syncing with a newer upstream release, and re-apply items
+1-5 if this module is ever replaced by the official Flink 2.x reporter --
+otherwise those fixes are silently lost.
+
+| # | Upstream | Here | Why |
+| --- | --- | --- | --- |
+| 1 | `close()` calls `lastResult.join(...)` unguarded | Null-checked | Upstream throws `NullPointerException` when a reporter is closed before its first `report()` |
+| 2 | `report()`'s `whenComplete` callback reads the `lastResult` field | Captures the result in a local variable | By the time the callback runs, the field can already hold the next interval's result, so the log line describes the wrong batch |
+| 3 | `convertHistogram` adds the max quantile twice, emitting 7 values | Emits 6: min, p50, p75, p95, p99, max | Upstream repeats `ValueAtQuantile(1.0, max)` |
+| 4 | Export failures are logged without the exception | Logs the exception | Upstream discards the stack trace |
+| 5 | `lastCollectTimeNanos` stays 0 until the first collection | Initialised in `open()` | Otherwise the first delta point claims a collection interval starting at 1970-01-01 |
+| 6 | `close()` is not idempotent and keeps the exporter reference | Idempotent via a `closed` flag, and still keeps the reference | Flink shuts the reporter scheduler down only *after* closing reporters, so a queued `report()` must hit a closed exporter rather than a null one |
+| 7 | Dispatches on `metric.getMetricType()` | Dispatches on `instanceof` | Avoids depending on the `MetricType` enum, whose constants differ across Flink versions |
+| 8 | Helper classes are `public` | Package-private | They are not public API in this module |
+
+Items 1-5 are bug fixes for defects that still exist upstream.
 
 ## Provenance
 

--- a/datasophon-flink-metrics-otel/pom.xml
+++ b/datasophon-flink-metrics-otel/pom.xml
@@ -61,7 +61,8 @@ limitations under the License.
       <artifactId>opentelemetry-sdk</artifactId>
       <version>${opentelemetry.version}</version>
     </dependency>
-    <!-- Flink 2.0.2 pins the Java-only 3.14 line; this keeps the shaded plugin free of Kotlin runtime dependencies. -->
+    <!-- OpenTelemetry 1.30.1 resolves OkHttp 4.x, which drags the Kotlin runtime into the shaded
+         plugin. Pinning the Java-only 3.14 line, as upstream flink-metrics-otel does, avoids it. -->
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>

--- a/datasophon-flink-metrics-otel/pom.xml
+++ b/datasophon-flink-metrics-otel/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.datasophon</groupId>
+  <artifactId>flink-metrics-otel-1.20</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Datasophon Flink 1.20 OpenTelemetry Metrics Reporter</name>
+
+  <properties>
+    <maven.compiler.release>11</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <flink.version>1.20.5</flink.version>
+    <opentelemetry.version>1.30.1</opentelemetry.version>
+    <okhttp.version>3.14.9</okhttp.version>
+    <junit.version>5.11.4</junit.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-core</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.flink</groupId>
+      <artifactId>flink-metrics-core</artifactId>
+      <version>${flink.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk</artifactId>
+      <version>${opentelemetry.version}</version>
+    </dependency>
+    <!-- Flink 2.0.2 pins the Java-only 3.14 line; this keeps the shaded plugin free of Kotlin runtime dependencies. -->
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>${okhttp.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <version>${opentelemetry.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-semconv</artifactId>
+      <version>${opentelemetry.version}-alpha</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>flink-metrics-otel-1.20-${project.version}</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.5.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>io.opentelemetry:*</include>
+                  <include>com.squareup.okhttp3:*</include>
+                  <include>com.squareup.okio:*</include>
+                </includes>
+              </artifactSet>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/MetricMetadata.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/MetricMetadata.java
@@ -1,0 +1,45 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.flink.metrics.otel;
+
+import java.util.Map;
+
+/** Metadata retained for a registered Flink metric. */
+final class MetricMetadata {
+
+    private final String name;
+    private final Map<String, String> variables;
+
+    MetricMetadata(String name, Map<String, String> variables) {
+        this.name = name;
+        this.variables = variables;
+    }
+
+    MetricMetadata subMetric(String suffix) {
+        return new MetricMetadata(name + "." + suffix, variables);
+    }
+
+    String getName() {
+        return name;
+    }
+
+    Map<String, String> getVariables() {
+        return variables;
+    }
+}

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
@@ -42,9 +42,13 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Histogram;
 import org.apache.flink.metrics.HistogramStatistics;
 import org.apache.flink.metrics.Meter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Converts Flink metrics to OpenTelemetry metric data. */
 final class OpenTelemetryMetricAdapter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenTelemetryMetricAdapter.class);
 
     private static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
             InstrumentationScopeInfo.create("io.confluent.flink.common.metrics");
@@ -58,6 +62,11 @@ final class OpenTelemetryMetricAdapter {
             MetricMetadata metadata) {
         long delta = count - previousCount;
         if (delta < 0) {
+            LOG.warn(
+                    "Non-monotonic counter {}: current count {} is less than previous count {}",
+                    metadata.getName(),
+                    count,
+                    previousCount);
             return Optional.empty();
         }
         return Optional.of(
@@ -82,6 +91,11 @@ final class OpenTelemetryMetricAdapter {
             CollectionMetadata collection, Gauge<?> gauge, MetricMetadata metadata) {
         Object value = gauge.getValue();
         if (!(value instanceof Number)) {
+            LOG.debug(
+                    "Couldn't adapt gauge {} with non-numeric value {} of type {}",
+                    metadata.getName(),
+                    value,
+                    value == null ? "null" : value.getClass().getName());
             return Optional.empty();
         }
         Number number = (Number) value;

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricAdapter.java
@@ -1,0 +1,177 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.flink.metrics.otel;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.ValueAtQuantile;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableDoublePointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSumData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableSummaryPointData;
+import io.opentelemetry.sdk.metrics.internal.data.ImmutableValueAtQuantile;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
+import org.apache.flink.metrics.Meter;
+
+/** Converts Flink metrics to OpenTelemetry metric data. */
+final class OpenTelemetryMetricAdapter {
+
+    private static final InstrumentationScopeInfo INSTRUMENTATION_SCOPE_INFO =
+            InstrumentationScopeInfo.create("io.confluent.flink.common.metrics");
+
+    private OpenTelemetryMetricAdapter() {}
+
+    static Optional<MetricData> convertCounter(
+            CollectionMetadata collection,
+            long count,
+            long previousCount,
+            MetricMetadata metadata) {
+        long delta = count - previousCount;
+        if (delta < 0) {
+            return Optional.empty();
+        }
+        return Optional.of(
+                ImmutableMetricData.createLongSum(
+                        collection.resource,
+                        INSTRUMENTATION_SCOPE_INFO,
+                        metadata.getName(),
+                        "",
+                        "",
+                        ImmutableSumData.create(
+                                true,
+                                AggregationTemporality.DELTA,
+                                Collections.singleton(
+                                        ImmutableLongPointData.create(
+                                                collection.startEpochNanos,
+                                                collection.epochNanos,
+                                                convertVariables(metadata.getVariables()),
+                                                delta)))));
+    }
+
+    static Optional<MetricData> convertGauge(
+            CollectionMetadata collection, Gauge<?> gauge, MetricMetadata metadata) {
+        Object value = gauge.getValue();
+        if (!(value instanceof Number)) {
+            return Optional.empty();
+        }
+        Number number = (Number) value;
+        if (number instanceof Long || number instanceof Integer) {
+            return Optional.of(
+                    ImmutableMetricData.createLongGauge(
+                            collection.resource,
+                            INSTRUMENTATION_SCOPE_INFO,
+                            metadata.getName(),
+                            "",
+                            "",
+                            ImmutableGaugeData.create(
+                                    Collections.singleton(
+                                            ImmutableLongPointData.create(
+                                                    collection.startEpochNanos,
+                                                    collection.epochNanos,
+                                                    convertVariables(metadata.getVariables()),
+                                                    number.longValue())))));
+        }
+        return Optional.of(
+                ImmutableMetricData.createDoubleGauge(
+                        collection.resource,
+                        INSTRUMENTATION_SCOPE_INFO,
+                        metadata.getName(),
+                        "",
+                        "",
+                        ImmutableGaugeData.create(
+                                Collections.singleton(
+                                        ImmutableDoublePointData.create(
+                                                collection.startEpochNanos,
+                                                collection.epochNanos,
+                                                convertVariables(metadata.getVariables()),
+                                                number.doubleValue())))));
+    }
+
+    static List<MetricData> convertMeter(
+            CollectionMetadata collection,
+            Meter meter,
+            long count,
+            long previousCount,
+            MetricMetadata metadata) {
+        List<MetricData> metrics = new ArrayList<>();
+        convertCounter(collection, count, previousCount, metadata.subMetric("count"))
+                .ifPresent(metrics::add);
+        convertGauge(collection, meter::getRate, metadata.subMetric("rate"))
+                .ifPresent(metrics::add);
+        return metrics;
+    }
+
+    static MetricData convertHistogram(
+            CollectionMetadata collection, Histogram histogram, MetricMetadata metadata) {
+        HistogramStatistics statistics = histogram.getStatistics();
+        List<ValueAtQuantile> quantiles = new ArrayList<>();
+        quantiles.add(ImmutableValueAtQuantile.create(0D, statistics.getMin()));
+        for (double quantile : new double[] {0.5D, 0.75D, 0.95D, 0.99D}) {
+            quantiles.add(ImmutableValueAtQuantile.create(quantile, statistics.getQuantile(quantile)));
+        }
+        quantiles.add(ImmutableValueAtQuantile.create(1D, statistics.getMax()));
+        return ImmutableMetricData.createDoubleSummary(
+                collection.resource,
+                INSTRUMENTATION_SCOPE_INFO,
+                metadata.getName(),
+                "",
+                "",
+                ImmutableSummaryData.create(
+                        Collections.singleton(
+                                ImmutableSummaryPointData.create(
+                                        collection.startEpochNanos,
+                                        collection.epochNanos,
+                                        convertVariables(metadata.getVariables()),
+                                        histogram.getCount(),
+                                        statistics.getMean() * histogram.getCount(),
+                                        quantiles))));
+    }
+
+    private static Attributes convertVariables(Map<String, String> variables) {
+        AttributesBuilder builder = Attributes.builder();
+        variables.forEach(builder::put);
+        return builder.build();
+    }
+
+    static final class CollectionMetadata {
+        private final Resource resource;
+        private final long startEpochNanos;
+        private final long epochNanos;
+
+        CollectionMetadata(Resource resource, long startEpochNanos, long epochNanos) {
+            this.resource = resource;
+            this.startEpochNanos = startEpochNanos;
+            this.epochNanos = epochNanos;
+        }
+    }
+}

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporter.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporter.java
@@ -22,6 +22,7 @@ import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.internal.export.MetricProducer;
 import java.time.Clock;
 import java.time.Instant;
@@ -60,7 +61,8 @@ public class OpenTelemetryMetricReporter extends OpenTelemetryReporterBase
     private final Clock clock;
     private Map<Metric, Long> lastValueSnapshots = Collections.emptyMap();
     private long lastCollectTimeNanos;
-    private CompletableResultCode lastResult;
+    private volatile CompletableResultCode lastResult;
+    private volatile boolean closed;
 
     public OpenTelemetryMetricReporter() {
         this(Clock.systemUTC());
@@ -71,25 +73,36 @@ public class OpenTelemetryMetricReporter extends OpenTelemetryReporterBase
     }
 
     @Override
-    public void open(MetricConfig config) {
+    public synchronized void open(MetricConfig config) {
+        LOG.info("Starting OpenTelemetryMetricReporter");
         super.open(config);
         OtlpGrpcMetricExporterBuilder builder = OtlpGrpcMetricExporter.builder();
         OpenTelemetryReporterOptions.configureEndpoint(config, builder::setEndpoint);
         OpenTelemetryReporterOptions.configureTimeout(config, builder::setTimeout);
         exporter = builder.build();
+        // Deltas are reported over [lastCollectTimeNanos, now]. Leaving this at 0 would make the
+        // first exported point claim a collection interval starting at 1970-01-01.
+        lastCollectTimeNanos = currentTimeNanos();
     }
 
     @Override
-    public void close() {
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
         if (exporter == null) {
             return;
         }
         exporter.flush().join(1, TimeUnit.MINUTES);
-        if (lastResult != null) {
-            lastResult.join(1, TimeUnit.MINUTES);
+        CompletableResultCode result = lastResult;
+        if (result != null) {
+            result.join(1, TimeUnit.MINUTES);
         }
+        // The exporter reference is deliberately kept: a report() already queued by Flink's
+        // reporter scheduler, which is only shut down after close(), must hit a closed exporter
+        // returning a failed result instead of a NullPointerException.
         exporter.close();
-        exporter = null;
     }
 
     @Override
@@ -104,6 +117,11 @@ public class OpenTelemetryMetricReporter extends OpenTelemetryReporterBase
             meters.put((Meter) metric, metadata);
         } else if (metric instanceof Histogram) {
             histograms.put((Histogram) metric, metadata);
+        } else {
+            LOG.warn(
+                    "Cannot add metric {} of unsupported type {}",
+                    metricName,
+                    metric.getClass().getName());
         }
     }
 
@@ -164,9 +182,13 @@ public class OpenTelemetryMetricReporter extends OpenTelemetryReporterBase
 
     @Override
     public void report() {
+        MetricExporter currentExporter = exporter;
+        if (closed || currentExporter == null) {
+            return;
+        }
         Collection<MetricData> metrics = collectAllMetrics();
         try {
-            CompletableResultCode result = exporter.export(metrics);
+            CompletableResultCode result = currentExporter.export(metrics);
             lastResult = result;
             result.whenComplete(
                     () -> {

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporter.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporter.java
@@ -1,0 +1,202 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.flink.metrics.otel;
+
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.internal.export.MetricProducer;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.LogicalScopeProvider;
+import org.apache.flink.metrics.Metric;
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.metrics.reporter.Scheduled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Exports Flink metrics through OpenTelemetry OTLP. */
+public class OpenTelemetryMetricReporter extends OpenTelemetryReporterBase
+        implements MetricReporter, MetricProducer, Scheduled {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenTelemetryMetricReporter.class);
+    private static final String LOGICAL_SCOPE_PREFIX = "flink.";
+
+    private final Map<Counter, MetricMetadata> counters = new HashMap<>();
+    private final Map<Gauge<?>, MetricMetadata> gauges = new HashMap<>();
+    private final Map<Meter, MetricMetadata> meters = new HashMap<>();
+    private final Map<Histogram, MetricMetadata> histograms = new HashMap<>();
+    private final Clock clock;
+    private Map<Metric, Long> lastValueSnapshots = Collections.emptyMap();
+    private long lastCollectTimeNanos;
+    private CompletableResultCode lastResult;
+
+    public OpenTelemetryMetricReporter() {
+        this(Clock.systemUTC());
+    }
+
+    OpenTelemetryMetricReporter(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Override
+    public void open(MetricConfig config) {
+        super.open(config);
+        OtlpGrpcMetricExporterBuilder builder = OtlpGrpcMetricExporter.builder();
+        OpenTelemetryReporterOptions.configureEndpoint(config, builder::setEndpoint);
+        OpenTelemetryReporterOptions.configureTimeout(config, builder::setTimeout);
+        exporter = builder.build();
+    }
+
+    @Override
+    public void close() {
+        if (exporter == null) {
+            return;
+        }
+        exporter.flush().join(1, TimeUnit.MINUTES);
+        if (lastResult != null) {
+            lastResult.join(1, TimeUnit.MINUTES);
+        }
+        exporter.close();
+        exporter = null;
+    }
+
+    @Override
+    public synchronized void notifyOfAddedMetric(
+            Metric metric, String metricName, MetricGroup group) {
+        MetricMetadata metadata = createMetricMetadata(metricName, group);
+        if (metric instanceof Counter) {
+            counters.put((Counter) metric, metadata);
+        } else if (metric instanceof Gauge) {
+            gauges.put((Gauge<?>) metric, metadata);
+        } else if (metric instanceof Meter) {
+            meters.put((Meter) metric, metadata);
+        } else if (metric instanceof Histogram) {
+            histograms.put((Histogram) metric, metadata);
+        }
+    }
+
+    @Override
+    public synchronized void notifyOfRemovedMetric(
+            Metric metric, String metricName, MetricGroup group) {
+        counters.remove(metric);
+        gauges.remove(metric);
+        meters.remove(metric);
+        histograms.remove(metric);
+        lastValueSnapshots.remove(metric);
+    }
+
+    @Override
+    public synchronized Collection<MetricData> collectAllMetrics() {
+        long currentTimeNanos = currentTimeNanos();
+        OpenTelemetryMetricAdapter.CollectionMetadata collection =
+                new OpenTelemetryMetricAdapter.CollectionMetadata(
+                        resource, lastCollectTimeNanos, currentTimeNanos);
+        Map<Metric, Long> currentValueSnapshots = new HashMap<>();
+        Collection<MetricData> data = new ArrayList<>();
+        counters.forEach(
+                (counter, metadata) -> {
+                    long current = counter.getCount();
+                    currentValueSnapshots.put(counter, current);
+                    OpenTelemetryMetricAdapter.convertCounter(
+                                    collection,
+                                    current,
+                                    lastValueSnapshots.getOrDefault(counter, 0L),
+                                    metadata)
+                            .ifPresent(data::add);
+                });
+        gauges.forEach(
+                (gauge, metadata) ->
+                        OpenTelemetryMetricAdapter.convertGauge(collection, gauge, metadata)
+                                .ifPresent(data::add));
+        meters.forEach(
+                (meter, metadata) -> {
+                    long current = meter.getCount();
+                    currentValueSnapshots.put(meter, current);
+                    data.addAll(
+                            OpenTelemetryMetricAdapter.convertMeter(
+                                    collection,
+                                    meter,
+                                    current,
+                                    lastValueSnapshots.getOrDefault(meter, 0L),
+                                    metadata));
+                });
+        histograms.forEach(
+                (histogram, metadata) ->
+                        data.add(
+                                OpenTelemetryMetricAdapter.convertHistogram(
+                                        collection, histogram, metadata)));
+        lastValueSnapshots = currentValueSnapshots;
+        lastCollectTimeNanos = currentTimeNanos;
+        return data;
+    }
+
+    @Override
+    public void report() {
+        Collection<MetricData> metrics = collectAllMetrics();
+        try {
+            CompletableResultCode result = exporter.export(metrics);
+            lastResult = result;
+            result.whenComplete(
+                    () -> {
+                        if (!result.isSuccess()) {
+                            LOG.warn("Failed to export {} Flink metrics through OTLP", metrics.size());
+                        }
+                    });
+        } catch (RuntimeException e) {
+            LOG.error("Failed to export {} Flink metrics through OTLP", metrics.size(), e);
+        }
+    }
+
+    private long currentTimeNanos() {
+        Instant now = clock.instant();
+        return TimeUnit.SECONDS.toNanos(now.getEpochSecond()) + now.getNano();
+    }
+
+    private static MetricMetadata createMetricMetadata(String metricName, MetricGroup group) {
+        String name =
+                LOGICAL_SCOPE_PREFIX
+                        + LogicalScopeProvider.castFrom(group)
+                                .getLogicalScope(CharacterFilter.NO_OP_FILTER)
+                        + "."
+                        + metricName;
+        Map<String, String> variables =
+                group.getAllVariables().entrySet().stream()
+                        .collect(
+                                Collectors.toMap(
+                                        entry -> VariableNameUtil.getVariableName(entry.getKey()),
+                                        Map.Entry::getValue));
+        return new MetricMetadata(name, variables);
+    }
+}

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterFactory.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterFactory.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.flink.metrics.otel;
+
+import java.util.Properties;
+import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.metrics.reporter.MetricReporterFactory;
+
+/** Creates the OpenTelemetry metric reporter. */
+public class OpenTelemetryMetricReporterFactory implements MetricReporterFactory {
+
+    @Override
+    public MetricReporter createMetricReporter(Properties properties) {
+        return new OpenTelemetryMetricReporter();
+    }
+}

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryReporterBase.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryReporterBase.java
@@ -1,0 +1,47 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.flink.metrics.otel;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.apache.flink.metrics.MetricConfig;
+
+/** Shared OpenTelemetry state for Flink reporters. */
+abstract class OpenTelemetryReporterBase {
+
+    protected Resource resource = Resource.getDefault();
+    protected MetricExporter exporter;
+
+    protected void open(MetricConfig config) {
+        AttributesBuilder attributes = io.opentelemetry.api.common.Attributes.builder();
+        if (config.containsKey(OpenTelemetryReporterOptions.SERVICE_NAME.key())) {
+            attributes.put(
+                    ResourceAttributes.SERVICE_NAME,
+                    config.getProperty(OpenTelemetryReporterOptions.SERVICE_NAME.key()));
+        }
+        if (config.containsKey(OpenTelemetryReporterOptions.SERVICE_VERSION.key())) {
+            attributes.put(
+                    ResourceAttributes.SERVICE_VERSION,
+                    config.getProperty(OpenTelemetryReporterOptions.SERVICE_VERSION.key()));
+        }
+        resource = resource.merge(Resource.create(attributes.build()));
+    }
+}

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryReporterBase.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryReporterBase.java
@@ -28,7 +28,7 @@ import org.apache.flink.metrics.MetricConfig;
 abstract class OpenTelemetryReporterBase {
 
     protected Resource resource = Resource.getDefault();
-    protected MetricExporter exporter;
+    protected volatile MetricExporter exporter;
 
     protected void open(MetricConfig config) {
         AttributesBuilder attributes = io.opentelemetry.api.common.Attributes.builder();

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryReporterOptions.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/OpenTelemetryReporterOptions.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.flink.metrics.otel;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.util.TimeUtils;
+
+/** Supported configuration for the OpenTelemetry reporter. */
+final class OpenTelemetryReporterOptions {
+
+    static final ConfigOption<String> EXPORTER_ENDPOINT =
+            ConfigOptions.key("exporter.endpoint").stringType().noDefaultValue();
+    static final ConfigOption<String> EXPORTER_TIMEOUT =
+            ConfigOptions.key("exporter.timeout").stringType().noDefaultValue();
+    static final ConfigOption<String> SERVICE_NAME =
+            ConfigOptions.key("service.name").stringType().noDefaultValue();
+    static final ConfigOption<String> SERVICE_VERSION =
+            ConfigOptions.key("service.version").stringType().noDefaultValue();
+
+    private OpenTelemetryReporterOptions() {}
+
+    static void configureEndpoint(MetricConfig config, Consumer<String> consumer) {
+        String key = EXPORTER_ENDPOINT.key();
+        if (!config.containsKey(key)) {
+            throw new IllegalArgumentException("Must set " + key);
+        }
+        consumer.accept(config.getProperty(key));
+    }
+
+    static void configureTimeout(MetricConfig config, Consumer<Duration> consumer) {
+        String key = EXPORTER_TIMEOUT.key();
+        if (config.containsKey(key)) {
+            consumer.accept(TimeUtils.parseDuration(config.getProperty(key)));
+        }
+    }
+}

--- a/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/VariableNameUtil.java
+++ b/datasophon-flink-metrics-otel/src/main/java/org/apache/flink/metrics/otel/VariableNameUtil.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.flink.metrics.otel;
+
+/** Normalizes Flink scope variable names for OpenTelemetry attributes. */
+final class VariableNameUtil {
+
+    private VariableNameUtil() {}
+
+    static String getVariableName(String value) {
+        if (value.length() >= 2 && value.charAt(0) == '<' && value.charAt(value.length() - 1) == '>') {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+}

--- a/datasophon-flink-metrics-otel/src/main/resources/META-INF/LICENSE
+++ b/datasophon-flink-metrics-otel/src/main/resources/META-INF/LICENSE
@@ -1,0 +1,161 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control with
+that entity. For the purposes of this definition, "control" means (i) the
+power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty percent
+(50%) or more of the outstanding shares, or (iii) beneficial ownership of
+such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent, as a
+whole, an original work of authorship. For the purposes of this License,
+Derivative Works shall not include works that remain separable from, or
+merely link (or bind by name) to the interfaces of, the Work and Derivative
+Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Licensor or its representatives,
+including but not limited to communication on electronic mailing lists,
+source code control systems, and issue tracking systems that are managed by,
+or on behalf of, the Licensor for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or otherwise
+designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on
+behalf of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work, where such license applies only to those
+patent claims licensable by such Contributor that are necessarily infringed
+by their Contribution(s) alone or by combination of their Contribution(s)
+with the Work to which such Contribution(s) was submitted. If You institute
+patent litigation against any entity (including a cross-claim or counterclaim
+in a lawsuit) alleging that the Work or a Contribution incorporated within
+the Work constitutes direct or contributory patent infringement, then any
+patent licenses granted to You under this License for that Work shall
+terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from
+the Source form of the Work, excluding those notices that do not pertain to
+any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy of
+the attribution notices contained within such NOTICE file, excluding those
+notices that do not pertain to any part of the Derivative Works, in at least
+one of the following places: within a NOTICE text file distributed as part of
+the Derivative Works; within the Source form or documentation, if provided
+along with the Derivative Works; or, within a display generated by the
+Derivative Works, if and wherever such third-party notices normally appear.
+The contents of the NOTICE file are for informational purposes only and do
+not modify the License. You may add Your own attribution notices within
+Derivative Works that You distribute, alongside or as an addendum to the
+NOTICE text from the Work, provided that such additional attribution notices
+cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and distribution
+of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein
+shall supersede or modify the terms of any separate license agreement you may
+have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as
+required for reasonable and customary use in describing the origin of the
+Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability
+to use the Work (including but not limited to damages for loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses), even if such Contributor has been advised of
+the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work
+or Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/datasophon-flink-metrics-otel/src/main/resources/META-INF/NOTICE
+++ b/datasophon-flink-metrics-otel/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,10 @@
+Datasophon Flink 1.20 OpenTelemetry Metrics Reporter
+Copyright 2024-2026 Datasophon Contributors
+
+This product contains a backport derived from Apache Flink's
+flink-metrics-otel module.
+
+Apache Flink
+Copyright 2014-2026 The Apache Software Foundation
+
+The derived source is used under the Apache License, Version 2.0.

--- a/datasophon-flink-metrics-otel/src/main/resources/META-INF/NOTICE
+++ b/datasophon-flink-metrics-otel/src/main/resources/META-INF/NOTICE
@@ -8,3 +8,18 @@ Apache Flink
 Copyright 2014-2026 The Apache Software Foundation
 
 The derived source is used under the Apache License, Version 2.0.
+
+This product bundles the following third-party dependencies into the shaded
+plugin jar. Each is licensed under the Apache License, Version 2.0.
+
+OpenTelemetry Java (io.opentelemetry) 1.30.1 / 1.30.1-alpha
+Copyright The OpenTelemetry Authors
+https://github.com/open-telemetry/opentelemetry-java
+
+OkHttp (com.squareup.okhttp3) 3.14.9
+Copyright Square, Inc.
+https://github.com/square/okhttp
+
+Okio (com.squareup.okio) 1.17.2
+Copyright Square, Inc.
+https://github.com/square/okio

--- a/datasophon-flink-metrics-otel/src/main/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
+++ b/datasophon-flink-metrics-otel/src/main/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
@@ -1,0 +1,1 @@
+org.apache.flink.metrics.otel.OpenTelemetryMetricReporterFactory

--- a/datasophon-flink-metrics-otel/src/test/java/com/datasophon/flink/otel/MetricReporterPluginTest.java
+++ b/datasophon-flink-metrics-otel/src/test/java/com/datasophon/flink/otel/MetricReporterPluginTest.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package com.datasophon.flink.otel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import org.apache.flink.metrics.reporter.MetricReporterFactory;
+import org.junit.jupiter.api.Test;
+
+class MetricReporterPluginTest {
+
+    @Test
+    void discoversOpenTelemetryReporterFactoryThroughFlinkSpi() {
+        List<String> factoryClassNames =
+                ServiceLoader.load(MetricReporterFactory.class).stream()
+                        .map(provider -> provider.type().getName())
+                        .filter(name -> name.equals("org.apache.flink.metrics.otel.OpenTelemetryMetricReporterFactory"))
+                        .collect(Collectors.toList());
+
+        assertEquals(
+                List.of("org.apache.flink.metrics.otel.OpenTelemetryMetricReporterFactory"),
+                factoryClassNames);
+    }
+}

--- a/datasophon-flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterTest.java
+++ b/datasophon-flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterTest.java
@@ -20,21 +20,27 @@ package org.apache.flink.metrics.otel;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricDataType;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.flink.metrics.CharacterFilter;
@@ -225,6 +231,54 @@ class OpenTelemetryMetricReporterTest {
 
         assertDoesNotThrow(() -> reporter.notifyOfRemovedMetric(counter, "records", group));
         assertTrue(reporter.collectAllMetrics().isEmpty());
+    }
+
+    @Test
+    void initializesCollectionStartTimeOnOpenInsteadOfEpochZero() {
+        Instant openedAt = Instant.parse("2026-08-24T10:15:30.123456789Z");
+        OpenTelemetryMetricReporter reporter =
+                new OpenTelemetryMetricReporter(Clock.fixed(openedAt, ZoneOffset.UTC));
+        MetricConfig config = new MetricConfig();
+        config.setProperty("exporter.endpoint", "http://127.0.0.1:4317");
+        reporter.open(config);
+        SimpleCounter counter = new SimpleCounter();
+        counter.inc(5L);
+        reporter.notifyOfAddedMetric(counter, "records", new TestMetricGroup());
+
+        LongPointData point =
+                onlyMetric(reporter.collectAllMetrics())
+                        .getLongSumData()
+                        .getPoints()
+                        .iterator()
+                        .next();
+
+        long openedAtNanos =
+                TimeUnit.SECONDS.toNanos(openedAt.getEpochSecond()) + openedAt.getNano();
+        assertEquals(openedAtNanos, point.getStartEpochNanos());
+        assertEquals(openedAtNanos, point.getEpochNanos());
+        reporter.close();
+    }
+
+    @Test
+    void stopsExportingAfterCloseAndClosesIdempotently() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+        RecordingMetricExporter exporter = new RecordingMetricExporter();
+        reporter.exporter = exporter;
+        SimpleCounter counter = new SimpleCounter();
+        counter.inc(3L);
+        reporter.notifyOfAddedMetric(counter, "records", new TestMetricGroup());
+
+        reporter.close();
+        assertTrue(exporter.shutdown);
+
+        // Flink shuts the reporter scheduler down only after close(), so a queued report() must
+        // neither throw nor export. Clearing the exporter reference instead would turn that
+        // report() into a NullPointerException that report()'s own catch block hides, so assert
+        // the reference survives rather than relying on the absence of a throw.
+        assertSame(exporter, reporter.exporter);
+        assertDoesNotThrow(reporter::report);
+        assertTrue(exporter.exported.isEmpty());
+        assertDoesNotThrow(reporter::close);
     }
 
     private static MetricData onlyMetric(Collection<MetricData> metrics) {

--- a/datasophon-flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterTest.java
+++ b/datasophon-flink-metrics-otel/src/test/java/org/apache/flink/metrics/otel/OpenTelemetryMetricReporterTest.java
@@ -1,0 +1,334 @@
+/*
+ *
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.flink.metrics.otel;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricDataType;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.HistogramStatistics;
+import org.apache.flink.metrics.LogicalScopeProvider;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MetricConfig;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.junit.jupiter.api.Test;
+
+class OpenTelemetryMetricReporterTest {
+
+    @Test
+    void exportsCounterAsDottedDeltaSumWithFlinkAttributes() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+        SimpleCounter counter = new SimpleCounter();
+        reporter.notifyOfAddedMetric(counter, "numRecordsOut", new TestMetricGroup());
+
+        counter.inc(50);
+        MetricData first = onlyMetric(reporter.collectAllMetrics());
+        assertEquals("flink.taskmanager.job.task.operator.numRecordsOut", first.getName());
+        assertEquals(AggregationTemporality.DELTA, first.getLongSumData().getAggregationTemporality());
+        assertTrue(first.getLongSumData().isMonotonic());
+        assertEquals(50L, first.getLongSumData().getPoints().iterator().next().getValue());
+        assertEquals(
+                "job-123",
+                first.getLongSumData()
+                        .getPoints()
+                        .iterator()
+                        .next()
+                        .getAttributes()
+                        .get(AttributeKey.stringKey("job_id")));
+
+        counter.inc(7);
+        MetricData second = onlyMetric(reporter.collectAllMetrics());
+        assertEquals(7L, second.getLongSumData().getPoints().iterator().next().getValue());
+    }
+
+    @Test
+    void exportsNumericGaugeWithoutChangingItsValue() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+        Gauge<Long> gauge = () -> 1728L;
+        reporter.notifyOfAddedMetric(gauge, "Heap.Used", new TestMetricGroup());
+
+        MetricData metric = onlyMetric(reporter.collectAllMetrics());
+
+        assertEquals("flink.taskmanager.job.task.operator.Heap.Used", metric.getName());
+        assertEquals(MetricDataType.LONG_GAUGE, metric.getType());
+        assertEquals(1728L, metric.getLongGaugeData().getPoints().iterator().next().getValue());
+    }
+
+    @Test
+    void skipsNonNumericGauge() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+        reporter.notifyOfAddedMetric((Gauge<String>) () -> "ready", "status", new TestMetricGroup());
+
+        assertTrue(reporter.collectAllMetrics().isEmpty());
+    }
+
+    @Test
+    void exportsMeterAsDeltaCountAndCurrentRate() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+        AtomicLong count = new AtomicLong(40L);
+        AtomicReference<Double> rate = new AtomicReference<>(2.5D);
+        Meter meter =
+                new Meter() {
+                    @Override
+                    public void markEvent() {
+                        count.incrementAndGet();
+                    }
+
+                    @Override
+                    public void markEvent(long n) {
+                        count.addAndGet(n);
+                    }
+
+                    @Override
+                    public double getRate() {
+                        return rate.get();
+                    }
+
+                    @Override
+                    public long getCount() {
+                        return count.get();
+                    }
+                };
+        reporter.notifyOfAddedMetric(meter, "recordsOutPerSecond", new TestMetricGroup());
+
+        Map<String, MetricData> first = metricsByName(reporter.collectAllMetrics());
+        assertEquals(40L, longPoint(first.get("flink.taskmanager.job.task.operator.recordsOutPerSecond.count")));
+        assertEquals(
+                2.5D,
+                first.get("flink.taskmanager.job.task.operator.recordsOutPerSecond.rate")
+                        .getDoubleGaugeData()
+                        .getPoints()
+                        .iterator()
+                        .next()
+                        .getValue());
+
+        count.set(47L);
+        assertEquals(
+                7L,
+                longPoint(
+                        metricsByName(reporter.collectAllMetrics())
+                                .get("flink.taskmanager.job.task.operator.recordsOutPerSecond.count")));
+    }
+
+    @Test
+    void exportsHistogramAsSummary() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+        Histogram histogram =
+                new Histogram() {
+                    @Override
+                    public void update(long value) {}
+
+                    @Override
+                    public long getCount() {
+                        return 3L;
+                    }
+
+                    @Override
+                    public HistogramStatistics getStatistics() {
+                        return new FixedHistogramStatistics();
+                    }
+                };
+        reporter.notifyOfAddedMetric(histogram, "checkpointAlignment", new TestMetricGroup());
+
+        MetricData metric = onlyMetric(reporter.collectAllMetrics());
+
+        assertEquals(MetricDataType.SUMMARY, metric.getType());
+        assertEquals(3L, metric.getSummaryData().getPoints().iterator().next().getCount());
+        assertEquals(30D, metric.getSummaryData().getPoints().iterator().next().getSum());
+        assertEquals(6, metric.getSummaryData().getPoints().iterator().next().getValues().size());
+    }
+
+    @Test
+    void appliesOtelResourceConfigurationAndClosesBeforeFirstReport() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+        MetricConfig config = new MetricConfig();
+        config.setProperty("exporter.endpoint", "http://127.0.0.1:4317");
+        config.setProperty("service.name", "flink-cdc");
+        config.setProperty("service.version", "1.20.5");
+
+        reporter.open(config);
+        SimpleCounter counter = new SimpleCounter();
+        reporter.notifyOfAddedMetric(counter, "records", new TestMetricGroup());
+        MetricData metric = onlyMetric(reporter.collectAllMetrics());
+
+        assertEquals("flink-cdc", metric.getResource().getAttribute(ResourceAttributes.SERVICE_NAME));
+        assertEquals("1.20.5", metric.getResource().getAttribute(ResourceAttributes.SERVICE_VERSION));
+        reporter.close();
+    }
+
+    @Test
+    void requiresExporterEndpoint() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+
+        assertThrows(IllegalArgumentException.class, () -> reporter.open(new MetricConfig()));
+    }
+
+    @Test
+    void reportSendsCollectedMetricsToConfiguredExporter() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+        RecordingMetricExporter exporter = new RecordingMetricExporter();
+        reporter.exporter = exporter;
+        SimpleCounter counter = new SimpleCounter();
+        counter.inc(9L);
+        reporter.notifyOfAddedMetric(counter, "records", new TestMetricGroup());
+
+        reporter.report();
+
+        assertEquals(1, exporter.exported.size());
+        assertEquals(9L, longPoint(exporter.exported.get(0)));
+        reporter.close();
+        assertTrue(exporter.shutdown);
+    }
+
+    @Test
+    void removesMetricBeforeFirstCollection() {
+        OpenTelemetryMetricReporter reporter = new OpenTelemetryMetricReporter();
+        SimpleCounter counter = new SimpleCounter();
+        TestMetricGroup group = new TestMetricGroup();
+        reporter.notifyOfAddedMetric(counter, "records", group);
+
+        assertDoesNotThrow(() -> reporter.notifyOfRemovedMetric(counter, "records", group));
+        assertTrue(reporter.collectAllMetrics().isEmpty());
+    }
+
+    private static MetricData onlyMetric(Collection<MetricData> metrics) {
+        assertEquals(1, metrics.size());
+        return metrics.iterator().next();
+    }
+
+    private static Map<String, MetricData> metricsByName(Collection<MetricData> metrics) {
+        return metrics.stream()
+                .collect(
+                        java.util.stream.Collectors.toMap(
+                                MetricData::getName, metric -> metric));
+    }
+
+    private static long longPoint(MetricData metric) {
+        return metric.getLongSumData().getPoints().iterator().next().getValue();
+    }
+
+    private static final class TestMetricGroup extends UnregisteredMetricsGroup
+            implements LogicalScopeProvider {
+
+        @Override
+        public String getLogicalScope(CharacterFilter filter) {
+            return "taskmanager.job.task.operator";
+        }
+
+        @Override
+        public String getLogicalScope(CharacterFilter filter, char delimiter) {
+            return "taskmanager.job.task.operator";
+        }
+
+        @Override
+        public MetricGroup getWrappedMetricGroup() {
+            return this;
+        }
+
+        @Override
+        public Map<String, String> getAllVariables() {
+            return Map.of("<job_id>", "job-123");
+        }
+    }
+
+    private static final class FixedHistogramStatistics extends HistogramStatistics {
+
+        @Override
+        public double getQuantile(double quantile) {
+            return quantile * 10D;
+        }
+
+        @Override
+        public long[] getValues() {
+            return new long[] {5L, 10L, 15L};
+        }
+
+        @Override
+        public int size() {
+            return 3;
+        }
+
+        @Override
+        public double getMean() {
+            return 10D;
+        }
+
+        @Override
+        public double getStdDev() {
+            return 4.08D;
+        }
+
+        @Override
+        public long getMax() {
+            return 15L;
+        }
+
+        @Override
+        public long getMin() {
+            return 5L;
+        }
+    }
+
+    private static final class RecordingMetricExporter implements MetricExporter {
+        private final List<MetricData> exported = new ArrayList<>();
+        private boolean shutdown;
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+            return AggregationTemporality.DELTA;
+        }
+
+        @Override
+        public CompletableResultCode export(Collection<MetricData> metrics) {
+            exported.addAll(metrics);
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+            shutdown = true;
+            return CompletableResultCode.ofSuccess();
+        }
+    }
+}

--- a/deploy/deployment-standalone-doris.md
+++ b/deploy/deployment-standalone-doris.md
@@ -259,4 +259,12 @@ Doris 网络优先级固定 `fe_priority_networks=192.168.10.0/24`、`be_priorit
 
 验证完成后已取消示例作业、停止临时集群，并删除 `/data/install_datasophon/flink-otel-final-20260823-1701`。临时端口全部释放；现有 Flink 1.20.4 CDC 集群 REST `8081` 仍为 1 个 TaskManager、4 个可用 slot，原 JobManager/TaskManager 进程保持运行。Doris 中带唯一 `service.name` 的验收数据作为链路证据保留。
 
-**结论：`PASSED`。** Flink 1.20.x reporter 可按 Flink 2.0 的 metrics OTLP 契约运行，并在本环境完成 Flink → OTLP/gRPC → OTel Collector → Doris 的真实链路验证。
+### 6.3 验证覆盖边界与后续事项
+
+以下三点在本次现场验证中**未覆盖**，记录于此避免被 §6.2 的 `PASSED` 结论掩盖：
+
+1. **Histogram → Summary 链路未验证。** §6.2 只观测到 Gauge 与 Sum 两类数据行，无 Summary 行。`otel_metrics_summary` 此前有过 quantile 相关缺陷,该路径需单独补验。
+2. **jar 指纹已失效。** §6.1 记录的 SHA-256 对应代码评审整改**之前**的构建产物。整改（关闭期竞态、`lastCollectTimeNanos` 初始化、日志恢复、NOTICE 补全）后 jar 内容已变，重新部署前须重新构建、重新记录指纹并复验本节链路。
+3. **尚未接入平台自动分发。** `FLINK/service_ddl.json` 无 `metrics.reporter` 相关参数，Worker 侧无下发逻辑,`package/` 未纳入该 jar。当前只能人工将 jar 放入各节点 `$FLINK_HOME/plugins/metrics-otel/`；纳入平台受管部署需单独规划。
+
+**结论：`PASSED`(范围以 §6.2 表格所列检查项为准,不含 §6.3 所列未覆盖项)。** Flink 1.20.x reporter 可按 Flink 2.0 的 metrics OTLP 契约运行，并在本环境完成 Flink → OTLP/gRPC → OTel Collector → Doris 的真实链路验证。

--- a/deploy/deployment-standalone-doris.md
+++ b/deploy/deployment-standalone-doris.md
@@ -224,3 +224,39 @@ Doris 网络优先级固定 `fe_priority_networks=192.168.10.0/24`、`be_priorit
 ## 5. 后续：阶段 B Hadoop 扩展
 
 阶段 B 单独规划并审批 HDFS、YARN、Hive、Spark3、Kyuubi 的角色、磁盘、端口和容量。完成前不得将 Kyuubi 计入阶段 A 的「无 Hadoop」验收。
+
+---
+
+## 6. Flink 1.20.x OTLP metrics reporter 验证（2026-08-23）
+
+本节记录 `datasophon-flink-metrics-otel` 的独立现场验证，不改写 §3～§4 的历史升级过程。验证时 Doris 当前状态为 `1 FE + 3 BE` 全部 Alive，版本均为 `doris-4.1.3-rc02-7126cf65d96`。
+
+### 6.1 验证拓扑与隔离措施
+
+| 项 | 验证值 |
+|---|---|
+| Flink | `ddh-02`，Flink `1.20.4` standalone 临时集群 |
+| Reporter | `datasophon-flink-metrics-otel/target/flink-metrics-otel-1.20-1.0.0-SNAPSHOT.jar` |
+| Reporter SHA-256 | `75ac35b2a8effd1874386bc268f65ce5acf86c079d24b11eaef5c95bd4243599` |
+| OTLP 接收端 | `ddh-02:4317`，OTel Collector `0.156.0` |
+| Doris 查询端 | `ddh-01:9030`，数据库 `otel` |
+| 唯一资源标识 | `service.name=flink-120-otel-final-20260823-1701` |
+| 隔离端口 | REST `18091`；RPC/data/blob `16122`～`16125` |
+
+临时集群从现有 Flink 1.20.4 安装目录复制，但使用独立配置、PID、日志、checkpoint 和端口；未停止或修改现有 `flink-cluster-cdc`。Reporter 以 Flink plugin 方式放入 `plugins/metrics-otel/`，JobManager 与 TaskManager 日志均确认以 5 秒周期加载 `org.apache.flink.metrics.otel.OpenTelemetryMetricReporter`。
+
+### 6.2 验证结果
+
+| 检查项 | 结果 | 证据 |
+|---|---|---|
+| Flink plugin SPI 加载 | PASSED | JobManager/TaskManager 均创建 `metrics-otel` plugin loader，无 `ClassNotFoundException` / `NoClassDefFoundError` |
+| OTLP/gRPC → Collector → Doris | PASSED | 唯一 `service.name` 最终写入 Gauge `1033` 行、Sum `84` 行 |
+| Counter/Meter 语义 | PASSED | Sum 行为 `aggregation_temporality=Delta`、`is_monotonic=1` |
+| 指标命名 | PASSED | Doris 可见 `flink.jobmanager.*`、`flink.taskmanager.*` 点分逻辑作用域名称 |
+| 作业属性 | PASSED | 内置 `StateMachineExample` 作业 `7aec49673f177729fecd40cb28d42c83` 产生 `207` 条含 `job_id` 的 Gauge 行，同时包含 `job_name`、`host` |
+| 导出错误 | PASSED | 临时集群日志无 OTLP 导出失败；Collector 日志无该 `service.name` 对应 error/warn |
+| 兼容性构建 | PASSED | Flink `1.20.0`、`1.20.4`、`1.20.5` 均完成 `clean verify` |
+
+验证完成后已取消示例作业、停止临时集群，并删除 `/data/install_datasophon/flink-otel-final-20260823-1701`。临时端口全部释放；现有 Flink 1.20.4 CDC 集群 REST `8081` 仍为 1 个 TaskManager、4 个可用 slot，原 JobManager/TaskManager 进程保持运行。Doris 中带唯一 `service.name` 的验收数据作为链路证据保留。
+
+**结论：`PASSED`。** Flink 1.20.x reporter 可按 Flink 2.0 的 metrics OTLP 契约运行，并在本环境完成 Flink → OTLP/gRPC → OTel Collector → Doris 的真实链路验证。

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,10 +90,13 @@ flowchart LR
 | `datasophon-common`    | 公共库(K8s 客户端、模型、命令消息、Nexus) | 库,无进程                   | —                            | fabric8 K8s client、fastjson2、Jackson          |
 | `datasophon-cli-go`    | 节点初始化 CLI                  | Go 二进制 `datasophon-cli` | —                            | Go 1.21、Cobra、`golang.org/x/crypto/ssh`       |
 | `datasophon-k8s-agent` | K8s 内 Agent                | Spring Boot Web         | HTTP(可配置)                    | RSA 签名鉴权                                      |
+| `datasophon-flink-metrics-otel` | Flink 1.20.x OTLP 指标插件 | Flink plugin shaded jar | — | Flink Metrics SPI、OpenTelemetry OTLP/gRPC |
 | `datasophon-ui`        | 前端                         | 静态资源,Nginx/Spring 静态服务  | —                            | React 19、Antd 6、Antd Pro 2.8、Vite、pnpm        |
 | `datasophon-cli`(Java) | **历史遗留**,逐步被 `cli-go` 替代   | 命令行                     | —                            | 仅用于兼容                                         |
 
 > ⚠️ **Pekko(原 Akka)已于 2026-05-23 完全移除**(commit `d0b93b09`)。Master↔Worker 跨进程通信改为 gRPC,Master 内部本地调度改为 Spring `@Async` / `@Scheduled`。后文涉及"原 Actor"字样均为代码注释中的历史脚注,不再真实存在。
+
+`datasophon-flink-metrics-otel` 与 `datasophon-lineage-emitter` 不加入根 Maven reactor，需使用各自的 `pom.xml` 独立构建。前者保留 Flink 2.0 `flink-metrics-otel` 的 factory/config 契约，仅向 Flink 1.20.x 回移 metrics reporter，不包含 Flink 2.x trace reporter SPI。
 
 ### 3.2 datasophon-api 包结构
 
@@ -476,6 +479,7 @@ erDiagram
 | datasophon-worker    | `target/` 包含可执行脚本 + 全量 jar                                             |
 | datasophon-cli-go    | `dist/datasophon-cli-{linux,darwin}-{amd64,arm64}`                     |
 | datasophon-k8s-agent | Docker 镜像(`docker/`)+ Helm Chart(`helm/`)                              |
+| datasophon-flink-metrics-otel | `target/flink-metrics-otel-1.20-<version>.jar`（独立构建的 shaded plugin） |
 
 ### 7.2 部署形态
 


### PR DESCRIPTION
## 概要

- 新增独立 Maven 模块 `datasophon-flink-metrics-otel`，参考 Apache Flink 2.0.2 `flink-metrics-otel` 将 metrics reporter 回移到 Flink 1.20.x
- 提供 Flink Metrics SPI factory 和 OTLP/gRPC exporter，支持 Counter、Gauge、Meter、Histogram 及逻辑作用域属性
- 保持 Flink 2.x factory/config 契约；模块不加入根 reactor，也不回移 Flink 2.x trace reporter SPI
- 补充模块安装说明、架构索引和 standalone Doris 现场验收记录

## 验证

- Flink `1.20.0`、`1.20.4`、`1.20.5`：`clean verify` 通过
- 当前测试：10 项通过（指标语义、SPI discovery、必填 endpoint、非数值 Gauge、export/close）
- shaded jar 为 Java 11 字节码，不包含 Flink core class 或 Kotlin runtime
- 最终 jar SHA-256：`75ac35b2a8effd1874386bc268f65ce5acf86c079d24b11eaef5c95bd4243599`

## 现场链路

在 `deploy/deployment-standalone-doris.md` 环境以隔离 Flink 1.20.4 临时集群验证：

- Flink → OTLP/gRPC → OTel Collector 0.156.0 → Doris 4.1.3 通过
- Doris 写入 Gauge 1033 行、Delta Sum 84 行
- 207 条作业指标包含 `job_id`、`job_name`、`host`
- Sum 为 `aggregation_temporality=Delta`、`is_monotonic=1`
- 验证后已取消示例作业并删除临时集群，原 CDC 集群保持 1 TM / 4 slots 健康