### PR TITLE
feat(doris): 服务详情「活动任务」Tab，按大版本兼容 3.x/4.x

### DIFF
--- a/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
@@ -26,8 +26,10 @@ import com.datasophon.api.controller.ApiController;
 import com.datasophon.api.dto.ApiResponse;
 import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
 import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
+import com.datasophon.api.dto.v2.DorisActiveTaskVO;
 import com.datasophon.api.service.doris.DorisActiveTaskFacade;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -51,5 +53,12 @@ public class DorisActiveTaskController extends ApiController {
                                                               @PathVariable Integer instanceId,
                                                               @RequestBody(required = false) DorisActiveTaskQueryDTO query) {
         return ApiResponse.ok(facade.query(clusterId, instanceId, query));
+    }
+
+    @GetMapping("/active-tasks/{taskId}")
+    public ApiResponse<DorisActiveTaskVO> activeTaskDetail(@PathVariable Integer clusterId,
+                                                           @PathVariable Integer instanceId,
+                                                           @PathVariable String taskId) {
+        return ApiResponse.ok(facade.queryDetail(clusterId, instanceId, taskId));
     }
 }

--- a/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
@@ -27,6 +27,7 @@ import com.datasophon.api.dto.ApiResponse;
 import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
 import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
 import com.datasophon.api.dto.v2.DorisActiveTaskVO;
+import com.datasophon.api.security.SystemAdminGuard;
 import com.datasophon.api.service.doris.DorisActiveTaskFacade;
 
 import org.springframework.web.bind.annotation.GetMapping;
@@ -42,9 +43,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class DorisActiveTaskController extends ApiController {
 
     private final DorisActiveTaskFacade facade;
+    private final SystemAdminGuard adminGuard;
 
-    public DorisActiveTaskController(DorisActiveTaskFacade facade) {
+    public DorisActiveTaskController(DorisActiveTaskFacade facade, SystemAdminGuard adminGuard) {
         this.facade = facade;
+        this.adminGuard = adminGuard;
     }
 
     @PostMapping("/active-tasks")
@@ -52,6 +55,7 @@ public class DorisActiveTaskController extends ApiController {
                                                               @PathVariable Integer clusterId,
                                                               @PathVariable Integer instanceId,
                                                               @RequestBody(required = false) DorisActiveTaskQueryDTO query) {
+        adminGuard.requireAdmin();
         return ApiResponse.ok(facade.query(clusterId, instanceId, query));
     }
 
@@ -59,6 +63,7 @@ public class DorisActiveTaskController extends ApiController {
     public ApiResponse<DorisActiveTaskVO> activeTaskDetail(@PathVariable Integer clusterId,
                                                            @PathVariable Integer instanceId,
                                                            @PathVariable String taskId) {
+        adminGuard.requireAdmin();
         return ApiResponse.ok(facade.queryDetail(clusterId, instanceId, taskId));
     }
 }

--- a/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
@@ -26,6 +26,7 @@ import com.datasophon.api.controller.ApiController;
 import com.datasophon.api.dto.ApiResponse;
 import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
 import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
+import com.datasophon.api.service.doris.DorisActiveTaskFacade;
 
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,16 +34,22 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** v2 Doris active-task contract stub. */
+/** v2 Doris active-task endpoint. */
 @RestController
 @RequestMapping("/v2/cluster/{clusterId}/service/{instanceId}/doris")
 public class DorisActiveTaskController extends ApiController {
+
+    private final DorisActiveTaskFacade facade;
+
+    public DorisActiveTaskController(DorisActiveTaskFacade facade) {
+        this.facade = facade;
+    }
 
     @PostMapping("/active-tasks")
     public ApiResponse<DorisActiveTaskResponseVO> activeTasks(
                                                               @PathVariable Integer clusterId,
                                                               @PathVariable Integer instanceId,
                                                               @RequestBody(required = false) DorisActiveTaskQueryDTO query) {
-        return ApiResponse.ok(DorisActiveTaskResponseVO.empty());
+        return ApiResponse.ok(facade.query(clusterId, instanceId, query));
     }
 }

--- a/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
@@ -40,9 +40,9 @@ public class DorisActiveTaskController extends ApiController {
 
     @PostMapping("/active-tasks")
     public ApiResponse<DorisActiveTaskResponseVO> activeTasks(
-            @PathVariable Integer clusterId,
-            @PathVariable Integer instanceId,
-            @RequestBody(required = false) DorisActiveTaskQueryDTO query) {
+                                                              @PathVariable Integer clusterId,
+                                                              @PathVariable Integer instanceId,
+                                                              @RequestBody(required = false) DorisActiveTaskQueryDTO query) {
         return ApiResponse.ok(DorisActiveTaskResponseVO.empty());
     }
 }

--- a/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/controller/v2/DorisActiveTaskController.java
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.controller.v2;
+
+import com.datasophon.api.controller.ApiController;
+import com.datasophon.api.dto.ApiResponse;
+import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
+import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** v2 Doris active-task contract stub. */
+@RestController
+@RequestMapping("/v2/cluster/{clusterId}/service/{instanceId}/doris")
+public class DorisActiveTaskController extends ApiController {
+
+    @PostMapping("/active-tasks")
+    public ApiResponse<DorisActiveTaskResponseVO> activeTasks(
+            @PathVariable Integer clusterId,
+            @PathVariable Integer instanceId,
+            @RequestBody(required = false) DorisActiveTaskQueryDTO query) {
+        return ApiResponse.ok(DorisActiveTaskResponseVO.empty());
+    }
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
@@ -39,6 +39,8 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javax.sql.DataSource;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -158,7 +160,7 @@ public class DorisAdminReaderFactory {
             old.close();
         }
         return new DorisAdminConnection(JdbcClient.create(entry.dataSource()), endpoint.host(), endpoint.port(),
-                username, degraded, degradedReason);
+                username, degraded, degradedReason, entry.dataSource());
     }
 
     private Endpoint physicalEndpoint(Integer clusterId) {
@@ -246,7 +248,12 @@ public class DorisAdminReaderFactory {
     }
 
     public record DorisAdminConnection(JdbcClient client, String host, int port, String username,
-                                       boolean degraded, String degradedReason) {
+                                       boolean degraded, String degradedReason, DataSource dataSource) {
+        public DorisAdminConnection(JdbcClient client, String host, int port, String username,
+                                    boolean degraded, String degradedReason) {
+            this(client, host, port, username, degraded, degradedReason, null);
+        }
+
         public String hostPort() {
             return host + ":" + port;
         }

--- a/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
@@ -41,6 +41,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
 
@@ -70,6 +71,7 @@ public class DorisAdminReaderFactory {
     private final ConnectionVerifier connectionVerifier;
     private final Map<Integer, PoolEntry> pools = new ConcurrentHashMap<>();
 
+    @Autowired
     public DorisAdminReaderFactory(ClusterServiceRoleInstanceService roleService,
                                    ClusterVariableService variableService,
                                    OtelCredentialService credentialService,

--- a/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
@@ -32,7 +32,9 @@ import com.datasophon.dao.entity.ClusterVariable;
 import com.datasophon.dao.enums.ServiceRoleState;
 
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -70,7 +72,7 @@ public class DorisAdminReaderFactory {
     private final ClusterVariableService variableService;
     private final OtelCredentialService credentialService;
     private final ExternalOtelDatasourceProvider externalDatasourceProvider;
-    private final ConnectionVerifier connectionVerifier;
+    private final VersionProbe versionProbe;
     private final Map<Integer, PoolEntry> pools = new ConcurrentHashMap<>();
 
     @Autowired
@@ -79,19 +81,19 @@ public class DorisAdminReaderFactory {
                                    OtelCredentialService credentialService,
                                    ExternalOtelDatasourceProvider externalDatasourceProvider) {
         this(roleService, variableService, credentialService, externalDatasourceProvider,
-                DorisAdminReaderFactory::verifyConnection);
+                DorisAdminReaderFactory::probeVersion);
     }
 
     DorisAdminReaderFactory(ClusterServiceRoleInstanceService roleService,
                             ClusterVariableService variableService,
                             OtelCredentialService credentialService,
                             ExternalOtelDatasourceProvider externalDatasourceProvider,
-                            ConnectionVerifier connectionVerifier) {
+                            VersionProbe versionProbe) {
         this.roleService = roleService;
         this.variableService = variableService;
         this.credentialService = credentialService;
         this.externalDatasourceProvider = externalDatasourceProvider;
-        this.connectionVerifier = connectionVerifier;
+        this.versionProbe = versionProbe;
     }
 
     /**
@@ -138,8 +140,10 @@ public class DorisAdminReaderFactory {
                 return current;
             }
             HikariDataSource dataSource = newDataSource(key);
+            String serverVersion;
             try {
-                if (!connectionVerifier.verify(dataSource)) {
+                serverVersion = versionProbe.probe(dataSource);
+                if (serverVersion == null) {
                     dataSource.close();
                     throw new DorisConnectionException();
                 }
@@ -150,17 +154,20 @@ public class DorisAdminReaderFactory {
                 }
                 throw new DorisConnectionException();
             }
+            DorisVersionProfile profile = DorisVersionProfile.of(serverVersion);
+            log.info("Doris active-task reader for cluster {} connected to {} as {}, version={}, profile={}",
+                    clusterId, endpoint.hostPort(), username, serverVersion, profile);
             if (current != null) {
                 obsolete.set(current.dataSource());
             }
-            return new PoolEntry(key, dataSource);
+            return new PoolEntry(key, dataSource, profile, serverVersion);
         });
         HikariDataSource old = obsolete.get();
         if (old != null) {
             old.close();
         }
         return new DorisAdminConnection(JdbcClient.create(entry.dataSource()), endpoint.host(), endpoint.port(),
-                username, degraded, degradedReason, entry.dataSource());
+                username, degraded, degradedReason, entry.dataSource(), entry.profile(), entry.serverVersion());
     }
 
     private Endpoint physicalEndpoint(Integer clusterId) {
@@ -214,9 +221,20 @@ public class DorisAdminReaderFactory {
         return dataSource;
     }
 
-    private static boolean verifyConnection(HikariDataSource dataSource) throws SQLException {
-        try (Connection ignored = dataSource.getConnection()) {
-            return true;
+    /**
+     * 一次握手同时完成「连得上吗」与「什么版本」。
+     *
+     * <p>必须用 {@code @@version_comment}：{@code version()} 为 MySQL 协议兼容恒返回 5.7.99。
+     * 连得上但读不出版本时返回空串，由 {@link DorisVersionProfile#of(String)} 落到最新已知档位，
+     * 不因为一个探测语句失败就把整个功能判死。
+     */
+    private static String probeVersion(HikariDataSource dataSource) throws SQLException {
+        try (
+                Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT @@version_comment")) {
+            String version = resultSet.next() ? resultSet.getString(1) : null;
+            return version == null ? "" : version;
         }
     }
 
@@ -242,16 +260,19 @@ public class DorisAdminReaderFactory {
         return entry == null ? null : entry.dataSource();
     }
 
+    /** 连接探测：返回服务端版本串；返回 {@code null} 表示连不上。 */
     @FunctionalInterface
-    interface ConnectionVerifier {
-        boolean verify(HikariDataSource dataSource) throws SQLException;
+    interface VersionProbe {
+        String probe(HikariDataSource dataSource) throws SQLException;
     }
 
     public record DorisAdminConnection(JdbcClient client, String host, int port, String username,
-                                       boolean degraded, String degradedReason, DataSource dataSource) {
+                                       boolean degraded, String degradedReason, DataSource dataSource,
+                                       DorisVersionProfile profile, String serverVersion) {
         public DorisAdminConnection(JdbcClient client, String host, int port, String username,
                                     boolean degraded, String degradedReason) {
-            this(client, host, port, username, degraded, degradedReason, null);
+            this(client, host, port, username, degraded, degradedReason, null,
+                    DorisVersionProfile.V4, "");
         }
 
         public String hostPort() {
@@ -276,6 +297,7 @@ public class DorisAdminReaderFactory {
     private record PoolKey(String host, int port, String username, String password) {
     }
 
-    private record PoolEntry(PoolKey key, HikariDataSource dataSource) {
+    private record PoolEntry(PoolKey key, HikariDataSource dataSource,
+                             DorisVersionProfile profile, String serverVersion) {
     }
 }

--- a/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
@@ -1,0 +1,272 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.doris;
+
+import com.datasophon.api.observability.ExternalOtelDatasourceProvider;
+import com.datasophon.api.observability.OtelCredentialService;
+import com.datasophon.api.observability.OtelCredentials;
+import com.datasophon.api.service.ClusterServiceRoleInstanceService;
+import com.datasophon.api.service.ClusterVariableService;
+import com.datasophon.dao.entity.ClusterServiceRoleInstanceEntity;
+import com.datasophon.dao.entity.ClusterVariable;
+import com.datasophon.dao.enums.ServiceRoleState;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Component;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import jakarta.annotation.PreDestroy;
+
+/** Creates the separate Doris connection used by the active-task read path. */
+@Component
+public class DorisAdminReaderFactory {
+
+    public static final String ROOT_USER = "root";
+    public static final String READER_USER = "otel_reader";
+    public static final int DEFAULT_QUERY_PORT = 9030;
+    public static final String ROOT_FALLBACK_REASON = "root 连接不可用，已回落到只读账号";
+
+    private static final int CONNECTION_TIMEOUT_MS = 5_000;
+    private static final int READ_TIMEOUT_MS = 10_000;
+    private static final String DORIS_FE_ROLE = "DorisFE";
+
+    private static final Logger log = LoggerFactory.getLogger(DorisAdminReaderFactory.class);
+
+    private final ClusterServiceRoleInstanceService roleService;
+    private final ClusterVariableService variableService;
+    private final OtelCredentialService credentialService;
+    private final ExternalOtelDatasourceProvider externalDatasourceProvider;
+    private final ConnectionVerifier connectionVerifier;
+    private final Map<Integer, PoolEntry> pools = new ConcurrentHashMap<>();
+
+    public DorisAdminReaderFactory(ClusterServiceRoleInstanceService roleService,
+                                   ClusterVariableService variableService,
+                                   OtelCredentialService credentialService,
+                                   ExternalOtelDatasourceProvider externalDatasourceProvider) {
+        this(roleService, variableService, credentialService, externalDatasourceProvider,
+                DorisAdminReaderFactory::verifyConnection);
+    }
+
+    DorisAdminReaderFactory(ClusterServiceRoleInstanceService roleService,
+                            ClusterVariableService variableService,
+                            OtelCredentialService credentialService,
+                            ExternalOtelDatasourceProvider externalDatasourceProvider,
+                            ConnectionVerifier connectionVerifier) {
+        this.roleService = roleService;
+        this.variableService = variableService;
+        this.credentialService = credentialService;
+        this.externalDatasourceProvider = externalDatasourceProvider;
+        this.connectionVerifier = connectionVerifier;
+    }
+
+    /**
+     * Resolves a read connection and reports the endpoint actually used.
+     *
+     * <p>Physical clusters try the stored root password first. Imported clusters have no platform
+     * root password source and use the already provisioned otel_reader account directly.
+     */
+    public DorisAdminConnection create(Integer clusterId) {
+        Optional<ExternalOtelDatasourceProvider.ExternalDatasource> external =
+                externalDatasourceProvider.find(clusterId);
+        if (external.isPresent()) {
+            ExternalOtelDatasourceProvider.ExternalDatasource datasource = external.get();
+            int port = parsePort(datasource.port());
+            return createReaderConnection(clusterId, datasource.host(), port, false, null);
+        }
+
+        Endpoint endpoint = physicalEndpoint(clusterId);
+        String rootPassword = variableValue(clusterId, "root_password");
+        if (rootPassword != null && !rootPassword.isBlank()) {
+            try {
+                return createConnection(clusterId, endpoint, ROOT_USER, rootPassword, false, null);
+            } catch (DorisConnectionException e) {
+                log.warn("Doris root connection unavailable for cluster {} at {}, using reader account",
+                        clusterId, endpoint.hostPort());
+            }
+        }
+        return createReaderConnection(clusterId, endpoint.host(), endpoint.port(), true, ROOT_FALLBACK_REASON);
+    }
+
+    private DorisAdminConnection createReaderConnection(Integer clusterId, String host, int port,
+                                                         boolean degraded, String degradedReason) {
+        OtelCredentials credentials = credentialService.getOrCreate(clusterId);
+        return createConnection(clusterId, new Endpoint(host, port), READER_USER,
+                credentials.readerPassword(), degraded, degradedReason);
+    }
+
+    private DorisAdminConnection createConnection(Integer clusterId, Endpoint endpoint, String username,
+                                                  String password, boolean degraded, String degradedReason) {
+        PoolKey key = new PoolKey(endpoint.host(), endpoint.port(), username, password);
+        AtomicReference<HikariDataSource> obsolete = new AtomicReference<>();
+        PoolEntry entry = pools.compute(clusterId, (id, current) -> {
+            if (current != null && current.key().equals(key)) {
+                return current;
+            }
+            HikariDataSource dataSource = newDataSource(key);
+            try {
+                if (!connectionVerifier.verify(dataSource)) {
+                    dataSource.close();
+                    throw new DorisConnectionException();
+                }
+            } catch (SQLException | RuntimeException e) {
+                dataSource.close();
+                if (e instanceof DorisConnectionException connectionException) {
+                    throw connectionException;
+                }
+                throw new DorisConnectionException();
+            }
+            if (current != null) {
+                obsolete.set(current.dataSource());
+            }
+            return new PoolEntry(key, dataSource);
+        });
+        HikariDataSource old = obsolete.get();
+        if (old != null) {
+            old.close();
+        }
+        return new DorisAdminConnection(JdbcClient.create(entry.dataSource()), endpoint.host(), endpoint.port(),
+                username, degraded, degradedReason);
+    }
+
+    private Endpoint physicalEndpoint(Integer clusterId) {
+        List<ClusterServiceRoleInstanceEntity> frontends = roleService
+                .getServiceRoleInstanceListByClusterIdAndRoleName(clusterId, DORIS_FE_ROLE)
+                .stream()
+                .filter(role -> ServiceRoleState.RUNNING.equals(role.getServiceRoleState())
+                        || ServiceRoleState.EXISTS_ALARM.equals(role.getServiceRoleState()))
+                .toList();
+        if (frontends.isEmpty()) {
+            throw new DorisConnectionException();
+        }
+        return new Endpoint(frontends.get(0).getHostname(),
+                parsePort(variableValue(clusterId, "query_port")));
+    }
+
+    private String variableValue(Integer clusterId, String name) {
+        ClusterVariable variable = variableService.getVariableByVariableName(clusterId, "DORIS", name);
+        return variable == null ? null : variable.getVariableValue();
+    }
+
+    private static int parsePort(String port) {
+        if (port == null || port.isBlank()) {
+            return DEFAULT_QUERY_PORT;
+        }
+        try {
+            int value = Integer.parseInt(port);
+            if (value > 0 && value <= 65_535) {
+                return value;
+            }
+        } catch (NumberFormatException ignored) {
+            // The caller gets the same safe connection failure as any other invalid endpoint.
+        }
+        throw new DorisConnectionException();
+    }
+
+    private static HikariDataSource newDataSource(PoolKey key) {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver");
+        dataSource.setJdbcUrl("jdbc:mysql://" + key.host() + ":" + key.port()
+                + "/?useUnicode=true&characterEncoding=utf8&useSSL=false"
+                + "&connectTimeout=" + CONNECTION_TIMEOUT_MS + "&socketTimeout=" + READ_TIMEOUT_MS);
+        dataSource.setUsername(key.username());
+        dataSource.setPassword(key.password());
+        dataSource.setPoolName("doris-active-task-" + key.host() + "-" + key.port());
+        dataSource.setMaximumPoolSize(8);
+        dataSource.setMinimumIdle(0);
+        dataSource.setConnectionTimeout(CONNECTION_TIMEOUT_MS);
+        dataSource.setValidationTimeout(CONNECTION_TIMEOUT_MS);
+        dataSource.setInitializationFailTimeout(-1);
+        return dataSource;
+    }
+
+    private static boolean verifyConnection(HikariDataSource dataSource) throws SQLException {
+        try (Connection ignored = dataSource.getConnection()) {
+            return true;
+        }
+    }
+
+    @PreDestroy
+    public void close() {
+        pools.values().forEach(entry -> entry.dataSource().close());
+        pools.clear();
+    }
+
+    void invalidate(Integer clusterId) {
+        PoolEntry removed = pools.remove(clusterId);
+        if (removed != null) {
+            removed.dataSource().close();
+        }
+    }
+
+    int poolSizeForTest() {
+        return pools.size();
+    }
+
+    HikariDataSource dataSourceForTest(Integer clusterId) {
+        PoolEntry entry = pools.get(clusterId);
+        return entry == null ? null : entry.dataSource();
+    }
+
+    @FunctionalInterface
+    interface ConnectionVerifier {
+        boolean verify(HikariDataSource dataSource) throws SQLException;
+    }
+
+    public record DorisAdminConnection(JdbcClient client, String host, int port, String username,
+                                       boolean degraded, String degradedReason) {
+        public String hostPort() {
+            return host + ":" + port;
+        }
+    }
+
+    public static final class DorisConnectionException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public DorisConnectionException() {
+            super("Doris connection unavailable");
+        }
+    }
+
+    private record Endpoint(String host, int port) {
+        String hostPort() {
+            return host + ":" + port;
+        }
+    }
+
+    private record PoolKey(String host, int port, String username, String password) {
+    }
+
+    private record PoolEntry(PoolKey key, HikariDataSource dataSource) {
+    }
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/doris/DorisAdminReaderFactory.java
@@ -119,7 +119,7 @@ public class DorisAdminReaderFactory {
     }
 
     private DorisAdminConnection createReaderConnection(Integer clusterId, String host, int port,
-                                                         boolean degraded, String degradedReason) {
+                                                        boolean degraded, String degradedReason) {
         OtelCredentials credentials = credentialService.getOrCreate(clusterId);
         return createConnection(clusterId, new Endpoint(host, port), READER_USER,
                 credentials.readerPassword(), degraded, degradedReason);

--- a/datasophon-api/src/main/java/com/datasophon/api/doris/DorisVersionProfile.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/doris/DorisVersionProfile.java
@@ -98,6 +98,8 @@ public enum DorisVersionProfile {
     private final boolean supported;
     private final String activeQueriesSql;
     private final String backendActiveTasksSql;
+    private final String activeQueriesByIdSql;
+    private final String backendActiveTasksByIdSql;
     private final String processlistSql;
     private final List<String> unsupportedFields;
 
@@ -107,6 +109,11 @@ public enum DorisVersionProfile {
         this.supported = supported;
         this.activeQueriesSql = select(activeQueriesColumns, "active_queries", null);
         this.backendActiveTasksSql = select(backendActiveTasksColumns, "backend_active_tasks", null);
+        // 详情路径把 taskId 下推到这两张表：它们是唯一会随负载涨到 SOURCE_LIMIT 的来源。
+        // 过滤列固定用 QUERY_ID —— 3.x/4.x 两个档位都声明了它，故不引入版本分叉。
+        this.activeQueriesByIdSql = select(activeQueriesColumns, "active_queries", "QUERY_ID = ?");
+        this.backendActiveTasksByIdSql =
+                select(backendActiveTasksColumns, "backend_active_tasks", "QUERY_ID = ?");
         this.processlistSql = select(processlistColumns, "processlist", "Command = 'Query'");
         this.unsupportedFields = List.copyOf(unsupportedFields);
     }
@@ -135,6 +142,16 @@ public enum DorisVersionProfile {
 
     public String backendActiveTasksSql() {
         return backendActiveTasksSql;
+    }
+
+    /** 详情路径用：同 {@link #activeQueriesSql()} 的列集，附 {@code QUERY_ID = ?} 占位符。 */
+    public String activeQueriesByIdSql() {
+        return activeQueriesByIdSql;
+    }
+
+    /** 详情路径用：同 {@link #backendActiveTasksSql()} 的列集，附 {@code QUERY_ID = ?} 占位符。 */
+    public String backendActiveTasksByIdSql() {
+        return backendActiveTasksByIdSql;
     }
 
     public String processlistSql() {

--- a/datasophon-api/src/main/java/com/datasophon/api/doris/DorisVersionProfile.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/doris/DorisVersionProfile.java
@@ -1,0 +1,158 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.doris;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 按 Doris 大版本区分的活动任务取数档位。
+ *
+ * <p>三张 {@code information_schema} 表的列在大版本之间既有增删、又有命名风格切换，
+ * 因此一套固定 SQL 跨版本必然失败。实测结论（2026-09-03，两个环境各自 {@code DESC} 得到）：
+ *
+ * <table border="1">
+ * <caption>列差异</caption>
+ * <tr><th>表</th><th>3.x（远端 K8s 存算分离，doris-3.0.8-rc01 Cloud Mode）</th>
+ *     <th>4.x（ddh-01，doris-4.1.3-rc02）</th></tr>
+ * <tr><td>active_queries</td><td>10 列，<b>无 USER</b></td><td>11 列，有 USER</td></tr>
+ * <tr><td>backend_active_tasks</td><td>12 列，<b>无 WORKLOAD_GROUP_ID、无 SPILL_*</b></td>
+ *     <td>15 列</td></tr>
+ * <tr><td>processlist</td><td>大写下划线 {@code QUERY_ID/HOST/USER}</td>
+ *     <td>驼峰 {@code QueryId/Host/User}</td></tr>
+ * <tr><td>workload_groups</td><td colspan="2">{@code ID/NAME} 两版一致，故不在本枚举内区分</td></tr>
+ * </table>
+ *
+ * <p>设计要点：<b>每个档位的 SELECT 负责把列名别名归一</b>成同一套 key（见 3.x 的
+ * {@code QUERY_ID AS QueryId}），因此下游合并、聚合、筛选逻辑完全不需要知道版本；
+ * 缺失的列直接不出现在 SELECT 里，读取时取到 {@code null}，并由 {@link #unsupportedFields()}
+ * 显式向前端声明「本版本没有这个字段」，而不是静默留空。
+ */
+public enum DorisVersionProfile {
+
+    /**
+     * 2.x —— 预留档位，暂不支持。
+     *
+     * <p>不在本枚举里给 SQL：2.x 的 {@code backend_active_tasks} 与 {@code active_queries}
+     * 列集合尚未实测，凭文档猜列会重演本次「SQL 报错被兜成 502」的故障。将来支持时，
+     * 按 3.x/4.x 同样的方式先 {@code DESC} 实测、再在此填入列清单并把 supported 改为 true。
+     */
+    V2(false, List.of(), List.of(), List.of(), List.of()),
+
+    /** 3.x —— 远端 K8s 存算分离环境实测（doris-3.0.8-rc01 Cloud Mode）。 */
+    V3(true,
+            List.of("QUERY_ID", "QUERY_START_TIME", "QUERY_TIME_MS", "WORKLOAD_GROUP_ID",
+                    "FRONTEND_INSTANCE", "QUEUE_START_TIME", "QUEUE_END_TIME", "QUERY_STATUS", "`SQL`"),
+            List.of("QUERY_ID", "BE_ID", "FE_HOST", "QUERY_TYPE",
+                    "TASK_TIME_MS", "TASK_CPU_TIME_MS", "SCAN_ROWS", "SCAN_BYTES",
+                    "BE_PEAK_MEMORY_BYTES", "CURRENT_USED_MEMORY_BYTES",
+                    "SHUFFLE_SEND_BYTES", "SHUFFLE_SEND_ROWS"),
+            List.of("QUERY_ID AS QueryId", "HOST AS Host", "`USER` AS `User`"),
+            List.of("spillBytes", "loadWorkloadGroup")),
+
+    /** 4.x 及更高 —— ddh-01 物理集群实测（doris-4.1.3-rc02），列最全。 */
+    V4(true,
+            List.of("QUERY_ID", "QUERY_START_TIME", "QUERY_TIME_MS", "WORKLOAD_GROUP_ID",
+                    "FRONTEND_INSTANCE", "QUEUE_START_TIME", "QUEUE_END_TIME", "QUERY_STATUS",
+                    "`USER`", "`SQL`"),
+            List.of("QUERY_ID", "BE_ID", "FE_HOST", "WORKLOAD_GROUP_ID", "QUERY_TYPE",
+                    "TASK_TIME_MS", "TASK_CPU_TIME_MS", "SCAN_ROWS", "SCAN_BYTES",
+                    "BE_PEAK_MEMORY_BYTES", "CURRENT_USED_MEMORY_BYTES",
+                    "SHUFFLE_SEND_BYTES", "SHUFFLE_SEND_ROWS",
+                    "SPILL_WRITE_BYTES_TO_LOCAL_STORAGE", "SPILL_READ_BYTES_FROM_LOCAL_STORAGE"),
+            List.of("QueryId", "Host", "`User`"),
+            List.of());
+
+    /** 单表单次取数上限；超过即认为数据源侧已被截断。 */
+    public static final int SOURCE_LIMIT = 20_000;
+
+    /**
+     * 版本号来自 {@code SELECT @@version_comment}（形如
+     * {@code Doris version doris-3.0.8-rc01-09b0cc49a6 (Cloud Mode)}）。
+     * <b>不能用 {@code version()}</b>——它为 MySQL 协议兼容恒返回 {@code 5.7.99}。
+     */
+    private static final Pattern MAJOR_VERSION =
+            Pattern.compile("doris[- ](?:version[- ])?(\\d+)\\.", Pattern.CASE_INSENSITIVE);
+
+    private final boolean supported;
+    private final String activeQueriesSql;
+    private final String backendActiveTasksSql;
+    private final String processlistSql;
+    private final List<String> unsupportedFields;
+
+    DorisVersionProfile(boolean supported, List<String> activeQueriesColumns,
+                        List<String> backendActiveTasksColumns, List<String> processlistColumns,
+                        List<String> unsupportedFields) {
+        this.supported = supported;
+        this.activeQueriesSql = select(activeQueriesColumns, "active_queries", null);
+        this.backendActiveTasksSql = select(backendActiveTasksColumns, "backend_active_tasks", null);
+        this.processlistSql = select(processlistColumns, "processlist", "Command = 'Query'");
+        this.unsupportedFields = List.copyOf(unsupportedFields);
+    }
+
+    /** 未识别的版本串按最新已知档位尝试，不直接判死——新版本通常是加列而非删列。 */
+    public static DorisVersionProfile of(String versionComment) {
+        Matcher matcher = MAJOR_VERSION.matcher(versionComment == null ? "" : versionComment);
+        if (!matcher.find()) {
+            return V4;
+        }
+        return switch (Integer.parseInt(matcher.group(1))) {
+            case 2 -> V2;
+            case 3 -> V3;
+            default -> V4;
+        };
+    }
+
+    /** false 表示本版本整体不支持活动任务查询，调用方应给出「版本不支持」而不是连接失败。 */
+    public boolean supported() {
+        return supported;
+    }
+
+    public String activeQueriesSql() {
+        return activeQueriesSql;
+    }
+
+    public String backendActiveTasksSql() {
+        return backendActiveTasksSql;
+    }
+
+    public String processlistSql() {
+        return processlistSql;
+    }
+
+    /** 本版本确定拿不到的字段名，交前端明示「该版本不支持」，避免被当成空值缺陷。 */
+    public List<String> unsupportedFields() {
+        return unsupportedFields;
+    }
+
+    private static String select(List<String> columns, String table, String where) {
+        if (columns.isEmpty()) {
+            return null;
+        }
+        return "SELECT " + String.join(", ", columns)
+                + " FROM information_schema." + table
+                + (where == null ? "" : " WHERE " + where)
+                + " LIMIT " + SOURCE_LIMIT;
+    }
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskQueryDTO.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskQueryDTO.java
@@ -1,0 +1,39 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.dto.v2;
+
+import java.util.List;
+
+import lombok.Data;
+
+/** Filters for a Doris active-task snapshot. */
+@Data
+public class DorisActiveTaskQueryDTO {
+
+    private String keyword;
+    private List<String> types;
+    private String user;
+    private String feHost;
+    private Long minMemoryBytes;
+    private Long minElapsedMs;
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskResponseVO.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskResponseVO.java
@@ -1,0 +1,48 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.dto.v2;
+
+import java.util.List;
+
+import lombok.Data;
+
+/** Response contract for a Doris active-task snapshot. */
+@Data
+public class DorisActiveTaskResponseVO {
+
+    private List<DorisActiveTaskVO> tasks = List.of();
+    private boolean degraded;
+    private String degradedReason;
+    private List<String> partialFailures = List.of();
+    private boolean truncated;
+    private boolean sourceTruncated;
+    private long total;
+    private int returned;
+    private String connectedHostPort;
+
+    public static DorisActiveTaskResponseVO empty() {
+        DorisActiveTaskResponseVO response = new DorisActiveTaskResponseVO();
+        response.setConnectedHostPort("");
+        return response;
+    }
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskResponseVO.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskResponseVO.java
@@ -39,6 +39,10 @@ public class DorisActiveTaskResponseVO {
     private long total;
     private int returned;
     private String connectedHostPort;
+    /** 服务端版本串（{@code @@version_comment} 原文），供页面自证连的是哪个版本。 */
+    private String serverVersion = "";
+    /** 当前 Doris 大版本确定拿不到的字段，前端据此显示「该版本不支持」而不是空值。 */
+    private List<String> unsupportedFields = List.of();
 
     public static DorisActiveTaskResponseVO empty() {
         DorisActiveTaskResponseVO response = new DorisActiveTaskResponseVO();

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskVO.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskVO.java
@@ -35,6 +35,7 @@ public class DorisActiveTaskVO {
     private String user;
     private String clientAddress;
     private String sql;
+    private String detailSql;
     private Long elapsedMs;
     private String startTime;
     private Long currentMemoryBytes;

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskVO.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisActiveTaskVO.java
@@ -1,0 +1,57 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.dto.v2;
+
+import java.util.List;
+
+import lombok.Data;
+
+/** One Query or Load row in a Doris active-task snapshot. */
+@Data
+public class DorisActiveTaskVO {
+
+    private String taskId;
+    private String type;
+    private String user;
+    private String clientAddress;
+    private String sql;
+    private Long elapsedMs;
+    private String startTime;
+    private Long currentMemoryBytes;
+    private Long peakMemoryBytes;
+    private Long scanRows;
+    private Long scanBytes;
+    private Long cpuTimeMs;
+    private Long shuffleSendBytes;
+    private Long shuffleSendRows;
+    private Long spillWriteBytesToLocalStorage;
+    private Long spillReadBytesFromLocalStorage;
+    private Long workloadGroupId;
+    private String workloadGroupName;
+    private String feHost;
+    private String queryStatus;
+    private String queueStartTime;
+    private String queueEndTime;
+    private Boolean truncated;
+    private List<DorisBeTaskDetailVO> beDetails;
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisBeTaskDetailVO.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/dto/v2/DorisBeTaskDetailVO.java
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.dto.v2;
+
+import lombok.Data;
+
+/** Per-BE resource values for one active task. */
+@Data
+public class DorisBeTaskDetailVO {
+
+    private String beId;
+    private Long peakMemoryBytes;
+    private Long currentMemoryBytes;
+    private Long scanRows;
+    private Long scanBytes;
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/enums/Status.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/enums/Status.java
@@ -28,11 +28,11 @@ import com.alibaba.fastjson2.JSONObject;
  * status enum
  */
 public enum Status {
-    
+
     SUCCESS(200, "success", "成功"),
-    
+
     INTERNAL_SERVER_ERROR_ARGS(10000, "Internal Server Error: {0}", "服务端异常: {0}"),
-    
+
     USER_NAME_EXIST(10003, "user name already exists", "用户名已存在"),
     USER_NAME_NULL(10004, "user name is null", "用户名不能为空"),
     USER_NOT_EXIST(10010, "user {0} not exists", "用户[{0}]不存在"),
@@ -45,7 +45,7 @@ public enum Status {
     LOGIN_SUCCESS(10042, "login success", "登录成功"),
     IP_IS_EMPTY(10125, "ip is empty", "IP地址不能为空"),
     DELETE_USER_BY_ID_ERROR(10093, "delete user by id error", "删除用户错误"),
-    
+
     START_CHECK_HOST(10000, "start check host", "开始主机校验"),
     CHECK_HOST_SUCCESS(10001, "check host success", "主机校验成功"),
     NEED_JAVA_ENVIRONMENT(10002, "need java environment", "缺少Java环境"),
@@ -53,7 +53,7 @@ public enum Status {
     NEED_HOSTNAME(10004, "need hostname", "无法获取主机名"),
     CAN_NOT_GET_IP(10005, "can not get ip", "无法获取ip地址"),
     INSTALL_SERVICE(10006, "Install Service ", "安装服务"),
-    
+
     CLUSTER_CODE_EXISTS(10007, "cluster code exists", "集群编码已存在"),
     ALERT_GROUP_TIPS_ONE(10008,
             "an alarm group has been bound to an alarm indicator, delete the bound alarm indicator first",
@@ -98,29 +98,29 @@ public enum Status {
     DORIS_CONNECT_FAILED(10201, "failed to connect to Doris FE", "连接 Doris FE 失败"),
     DORIS_CAPABILITY_UNSUPPORTED(10202, "current Doris version does not support active task query",
             "当前 Doris 版本不支持活动任务查询"),
-    ;
-    
+            ;
+
     private final int code;
     private final String enMsg;
     private final String zhMsg;
-    
+
     Status(int code, String enMsg, String zhMsg) {
         this.code = code;
         this.enMsg = enMsg;
         this.zhMsg = zhMsg;
     }
-    
+
     public int getCode() {
         return this.code;
     }
-    
+
     public JSONObject toJson() {
         JSONObject json = new JSONObject();
         json.put("code", this.code);
         json.put("msg", getMsg());
         return json;
     }
-    
+
     public String getMsg() {
         return this.zhMsg;
     }

--- a/datasophon-api/src/main/java/com/datasophon/api/enums/Status.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/enums/Status.java
@@ -93,6 +93,11 @@ public enum Status {
     NO_SERVICE_ROLE_SELECTED(10041, "No service role selected", "未选择需要安装的服务实例"),
     TWO_KYUUBISERVERS_NEED_TO_BE_DEPLOYED(10042, "two kyuubiServer deployments are required", "KyuubiServer需要两个节点"),
     THREE_ETCD_NEED_TO_BE_DEPLOYED(10043, "three etcd deployments are required", "Etcd需要三个节点"),
+    INSTANCE_MISMATCH(10200, "service instance does not belong to the cluster or is not a Doris service",
+            "服务实例不属于该集群或不是 Doris 服务"),
+    DORIS_CONNECT_FAILED(10201, "failed to connect to Doris FE", "连接 Doris FE 失败"),
+    DORIS_CAPABILITY_UNSUPPORTED(10202, "current Doris version does not support active task query",
+            "当前 Doris 版本不支持活动任务查询"),
     ;
     
     private final int code;

--- a/datasophon-api/src/main/java/com/datasophon/api/security/SystemAdminGuard.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/security/SystemAdminGuard.java
@@ -1,0 +1,53 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.security;
+
+import com.datasophon.api.enums.Status;
+import com.datasophon.api.utils.SecurityUtils;
+import com.datasophon.common.Constants;
+import com.datasophon.dao.entity.UserInfoEntity;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+/** 仅允许系统管理员访问 Doris 活动任务查询。 */
+@Component
+public class SystemAdminGuard {
+
+    private final HttpServletRequest request;
+
+    public SystemAdminGuard(HttpServletRequest request) {
+        this.request = request;
+    }
+
+    public void requireAdmin() {
+        UserInfoEntity user = (UserInfoEntity) request.getAttribute(Constants.SESSION_USER);
+        if (user == null || !SecurityUtils.isAdmin(user)) {
+            throw new ResponseStatusException(FORBIDDEN, Status.USER_NO_OPERATION_PERM.getMsg());
+        }
+    }
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/security/SystemAdminGuard.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/security/SystemAdminGuard.java
@@ -22,6 +22,8 @@
 
 package com.datasophon.api.security;
 
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
 import com.datasophon.api.enums.Status;
 import com.datasophon.api.utils.SecurityUtils;
 import com.datasophon.common.Constants;
@@ -31,8 +33,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.servlet.http.HttpServletRequest;
-
-import static org.springframework.http.HttpStatus.FORBIDDEN;
 
 /** 仅允许系统管理员访问 Doris 活动任务查询。 */
 @Component

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
@@ -28,6 +28,7 @@ import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
 import com.datasophon.api.doris.DorisAdminReaderFactory;
 import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
 import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
+import com.datasophon.api.dto.v2.DorisActiveTaskVO;
 import com.datasophon.api.enums.Status;
 import com.datasophon.api.security.SystemAdminGuard;
 
@@ -61,6 +62,20 @@ public class DorisActiveTaskFacade {
             DorisAdminReaderFactory.DorisAdminConnection connection = readerFactory.create(clusterId);
             return queryService.query(clusterId, connection,
                     filter == null ? new DorisActiveTaskQueryDTO() : filter);
+        } catch (DorisActiveTaskQueryService.CapabilityUnsupportedException exception) {
+            throw new ResponseStatusException(NOT_IMPLEMENTED,
+                    Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
+        } catch (RuntimeException exception) {
+            throw new ResponseStatusException(BAD_GATEWAY, Status.DORIS_CONNECT_FAILED.getMsg());
+        }
+    }
+
+    public DorisActiveTaskVO queryDetail(Integer clusterId, Integer instanceId, String taskId) {
+        adminGuard.requireAdmin();
+        instanceValidator.requireDorisInstance(clusterId, instanceId);
+        try {
+            DorisAdminReaderFactory.DorisAdminConnection connection = readerFactory.create(clusterId);
+            return queryService.queryDetail(clusterId, connection, taskId);
         } catch (DorisActiveTaskQueryService.CapabilityUnsupportedException exception) {
             throw new ResponseStatusException(NOT_IMPLEMENTED,
                     Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
@@ -56,12 +56,13 @@ public class DorisActiveTaskFacade {
 
     public DorisActiveTaskResponseVO query(Integer clusterId, Integer instanceId,
                                            DorisActiveTaskQueryDTO filter) {
+        long deadlineNanos = System.nanoTime() + DorisActiveTaskQueryService.REQUEST_TIMEOUT_MS * 1_000_000L;
         adminGuard.requireAdmin();
         instanceValidator.requireDorisInstance(clusterId, instanceId);
         try {
             DorisAdminReaderFactory.DorisAdminConnection connection = readerFactory.create(clusterId);
             return queryService.query(clusterId, connection,
-                    filter == null ? new DorisActiveTaskQueryDTO() : filter);
+                    filter == null ? new DorisActiveTaskQueryDTO() : filter, deadlineNanos);
         } catch (DorisActiveTaskQueryService.CapabilityUnsupportedException exception) {
             throw new ResponseStatusException(NOT_IMPLEMENTED,
                     Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
@@ -71,11 +72,12 @@ public class DorisActiveTaskFacade {
     }
 
     public DorisActiveTaskVO queryDetail(Integer clusterId, Integer instanceId, String taskId) {
+        long deadlineNanos = System.nanoTime() + DorisActiveTaskQueryService.REQUEST_TIMEOUT_MS * 1_000_000L;
         adminGuard.requireAdmin();
         instanceValidator.requireDorisInstance(clusterId, instanceId);
         try {
             DorisAdminReaderFactory.DorisAdminConnection connection = readerFactory.create(clusterId);
-            return queryService.queryDetail(clusterId, connection, taskId);
+            return queryService.queryDetail(clusterId, connection, taskId, deadlineNanos);
         } catch (DorisActiveTaskQueryService.CapabilityUnsupportedException exception) {
             throw new ResponseStatusException(NOT_IMPLEMENTED,
                     Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
@@ -60,13 +60,29 @@ public class DorisActiveTaskFacade {
 
     public DorisActiveTaskResponseVO query(Integer clusterId, Integer instanceId,
                                            DorisActiveTaskQueryDTO filter) {
+        DorisActiveTaskQueryDTO effectiveFilter = filter == null ? new DorisActiveTaskQueryDTO() : filter;
+        return execute(clusterId, instanceId,
+                (connection, deadlineNanos) -> queryService.query(clusterId, connection, effectiveFilter,
+                        deadlineNanos));
+    }
+
+    public DorisActiveTaskVO queryDetail(Integer clusterId, Integer instanceId, String taskId) {
+        return execute(clusterId, instanceId,
+                (connection, deadlineNanos) -> queryService.queryDetail(clusterId, connection, taskId,
+                        deadlineNanos));
+    }
+
+    /**
+     * 鉴权 → 实例校验 → 建连 → 查询的公共外壳。
+     *
+     * <p>deadline 在鉴权与建连之前就起算，因此 15s 预算覆盖整个请求而不仅是 SQL 执行。
+     */
+    private <T> T execute(Integer clusterId, Integer instanceId, ActiveTaskAction<T> action) {
         long deadlineNanos = System.nanoTime() + DorisActiveTaskQueryService.REQUEST_TIMEOUT_MS * 1_000_000L;
         adminGuard.requireAdmin();
         instanceValidator.requireDorisInstance(clusterId, instanceId);
         try {
-            DorisAdminReaderFactory.DorisAdminConnection connection = readerFactory.create(clusterId);
-            return queryService.query(clusterId, connection,
-                    filter == null ? new DorisActiveTaskQueryDTO() : filter, deadlineNanos);
+            return action.apply(readerFactory.create(clusterId), deadlineNanos);
         } catch (DorisActiveTaskQueryService.CapabilityUnsupportedException exception) {
             throw new ResponseStatusException(NOT_IMPLEMENTED,
                     Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
@@ -78,21 +94,8 @@ public class DorisActiveTaskFacade {
         }
     }
 
-    public DorisActiveTaskVO queryDetail(Integer clusterId, Integer instanceId, String taskId) {
-        long deadlineNanos = System.nanoTime() + DorisActiveTaskQueryService.REQUEST_TIMEOUT_MS * 1_000_000L;
-        adminGuard.requireAdmin();
-        instanceValidator.requireDorisInstance(clusterId, instanceId);
-        try {
-            DorisAdminReaderFactory.DorisAdminConnection connection = readerFactory.create(clusterId);
-            return queryService.queryDetail(clusterId, connection, taskId, deadlineNanos);
-        } catch (DorisActiveTaskQueryService.CapabilityUnsupportedException exception) {
-            throw new ResponseStatusException(NOT_IMPLEMENTED,
-                    Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
-        } catch (RuntimeException exception) {
-            // 对外只给固定文案（不泄露 jdbc 串），但真实原因必须留在日志里：
-            // Doris 3.x 的字段不兼容曾整个伪装成「连接失败」，没有这行日志就只能靠翻 schema 反推。
-            log.warn("Doris active-task query failed for cluster {} instance {}", clusterId, instanceId, exception);
-            throw new ResponseStatusException(BAD_GATEWAY, Status.DORIS_CONNECT_FAILED.getMsg());
-        }
+    @FunctionalInterface
+    private interface ActiveTaskAction<T> {
+        T apply(DorisAdminReaderFactory.DorisAdminConnection connection, long deadlineNanos);
     }
 }

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.service.doris;
+
+import static org.springframework.http.HttpStatus.BAD_GATEWAY;
+import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
+
+import com.datasophon.api.doris.DorisAdminReaderFactory;
+import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
+import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
+import com.datasophon.api.enums.Status;
+import com.datasophon.api.security.SystemAdminGuard;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Orchestrates authorization, instance validation, connection, and active-task querying. */
+@Service
+public class DorisActiveTaskFacade {
+
+    private final SystemAdminGuard adminGuard;
+    private final DorisServiceInstanceValidator instanceValidator;
+    private final DorisAdminReaderFactory readerFactory;
+    private final DorisActiveTaskQueryService queryService;
+
+    public DorisActiveTaskFacade(SystemAdminGuard adminGuard,
+                                 DorisServiceInstanceValidator instanceValidator,
+                                 DorisAdminReaderFactory readerFactory,
+                                 DorisActiveTaskQueryService queryService) {
+        this.adminGuard = adminGuard;
+        this.instanceValidator = instanceValidator;
+        this.readerFactory = readerFactory;
+        this.queryService = queryService;
+    }
+
+    public DorisActiveTaskResponseVO query(Integer clusterId, Integer instanceId,
+                                           DorisActiveTaskQueryDTO filter) {
+        adminGuard.requireAdmin();
+        instanceValidator.requireDorisInstance(clusterId, instanceId);
+        try {
+            DorisAdminReaderFactory.DorisAdminConnection connection = readerFactory.create(clusterId);
+            return queryService.query(clusterId, connection,
+                    filter == null ? new DorisActiveTaskQueryDTO() : filter);
+        } catch (DorisActiveTaskQueryService.CapabilityUnsupportedException exception) {
+            throw new ResponseStatusException(NOT_IMPLEMENTED,
+                    Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
+        } catch (RuntimeException exception) {
+            throw new ResponseStatusException(BAD_GATEWAY, Status.DORIS_CONNECT_FAILED.getMsg());
+        }
+    }
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskFacade.java
@@ -32,12 +32,16 @@ import com.datasophon.api.dto.v2.DorisActiveTaskVO;
 import com.datasophon.api.enums.Status;
 import com.datasophon.api.security.SystemAdminGuard;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 /** Orchestrates authorization, instance validation, connection, and active-task querying. */
 @Service
 public class DorisActiveTaskFacade {
+
+    private static final Logger log = LoggerFactory.getLogger(DorisActiveTaskFacade.class);
 
     private final SystemAdminGuard adminGuard;
     private final DorisServiceInstanceValidator instanceValidator;
@@ -67,6 +71,9 @@ public class DorisActiveTaskFacade {
             throw new ResponseStatusException(NOT_IMPLEMENTED,
                     Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
         } catch (RuntimeException exception) {
+            // 对外只给固定文案（不泄露 jdbc 串），但真实原因必须留在日志里：
+            // Doris 3.x 的字段不兼容曾整个伪装成「连接失败」，没有这行日志就只能靠翻 schema 反推。
+            log.warn("Doris active-task query failed for cluster {} instance {}", clusterId, instanceId, exception);
             throw new ResponseStatusException(BAD_GATEWAY, Status.DORIS_CONNECT_FAILED.getMsg());
         }
     }
@@ -82,6 +89,9 @@ public class DorisActiveTaskFacade {
             throw new ResponseStatusException(NOT_IMPLEMENTED,
                     Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
         } catch (RuntimeException exception) {
+            // 对外只给固定文案（不泄露 jdbc 串），但真实原因必须留在日志里：
+            // Doris 3.x 的字段不兼容曾整个伪装成「连接失败」，没有这行日志就只能靠翻 schema 反推。
+            log.warn("Doris active-task query failed for cluster {} instance {}", clusterId, instanceId, exception);
             throw new ResponseStatusException(BAD_GATEWAY, Status.DORIS_CONNECT_FAILED.getMsg());
         }
     }

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
@@ -43,9 +43,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Service;
 
@@ -86,36 +88,63 @@ public class DorisActiveTaskQueryService {
     public static final int LIST_SQL_LIMIT_BYTES = 1_024;
     public static final int DETAIL_SQL_LIMIT_BYTES = 256 * 1_024;
     public static final int RESPONSE_LIMIT = 2_000;
+    public static final int REQUEST_TIMEOUT_MS = 15_000;
 
     private static final String CLIENT_ADDRESS_FAILURE = "clientAddress";
     private static final String WORKLOAD_GROUP_FAILURE = "workloadGroup";
+    private static final int STATEMENT_TIMEOUT_MS = 10_000;
 
     private final ClusterHostService hostService;
     private final BiFunction<JdbcClient, String, List<Map<String, Object>>> rowQuery;
+    private final LongSupplier nanoTime;
 
     @Autowired
     public DorisActiveTaskQueryService(ClusterHostService hostService) {
-        this(hostService, DorisActiveTaskQueryService::queryRows);
+        this(hostService, DorisActiveTaskQueryService::queryRows, System::nanoTime);
     }
 
     DorisActiveTaskQueryService(ClusterHostService hostService,
                                 BiFunction<JdbcClient, String, List<Map<String, Object>>> rowQuery) {
+        this(hostService, rowQuery, System::nanoTime);
+    }
+
+    DorisActiveTaskQueryService(ClusterHostService hostService,
+                                BiFunction<JdbcClient, String, List<Map<String, Object>>> rowQuery,
+                                LongSupplier nanoTime) {
         this.hostService = hostService;
         this.rowQuery = rowQuery;
+        this.nanoTime = nanoTime;
     }
 
     /** Executes the four fixed statements and returns a response ready for the facade. */
     public DorisActiveTaskResponseVO query(Integer clusterId,
                                            DorisAdminReaderFactory.DorisAdminConnection connection,
                                            DorisActiveTaskQueryDTO filter) {
-        return query(clusterId, connection, filter, null);
+        return query(clusterId, connection, filter, null,
+                nanoTime.getAsLong() + REQUEST_TIMEOUT_MS * 1_000_000L);
     }
 
     /** Returns one task with the larger detail-level SQL bound. */
     public DorisActiveTaskVO queryDetail(Integer clusterId,
                                          DorisAdminReaderFactory.DorisAdminConnection connection,
                                          String taskId) {
-        return query(clusterId, connection, new DorisActiveTaskQueryDTO(), taskId).getTasks().stream()
+        return query(clusterId, connection, new DorisActiveTaskQueryDTO(), taskId,
+                nanoTime.getAsLong() + REQUEST_TIMEOUT_MS * 1_000_000L).getTasks().stream()
+                .filter(task -> taskId.equals(task.getTaskId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    DorisActiveTaskResponseVO query(Integer clusterId,
+                                    DorisAdminReaderFactory.DorisAdminConnection connection,
+                                    DorisActiveTaskQueryDTO filter, long deadlineNanos) {
+        return query(clusterId, connection, filter, null, deadlineNanos);
+    }
+
+    DorisActiveTaskVO queryDetail(Integer clusterId,
+                                  DorisAdminReaderFactory.DorisAdminConnection connection,
+                                  String taskId, long deadlineNanos) {
+        return query(clusterId, connection, new DorisActiveTaskQueryDTO(), taskId, deadlineNanos).getTasks().stream()
                 .filter(task -> taskId.equals(task.getTaskId()))
                 .findFirst()
                 .orElse(null);
@@ -124,14 +153,15 @@ public class DorisActiveTaskQueryService {
     private DorisActiveTaskResponseVO query(Integer clusterId,
                                             DorisAdminReaderFactory.DorisAdminConnection connection,
                                             DorisActiveTaskQueryDTO filter,
-                                            String detailTaskId) {
-        List<Map<String, Object>> metadata = requiredRows(connection.client(), ACTIVE_QUERIES_SQL);
-        List<Map<String, Object>> resources = requiredRows(connection.client(), BACKEND_ACTIVE_TASKS_SQL);
+                                            String detailTaskId, long deadlineNanos) {
+        List<Map<String, Object>> metadata = requiredRows(connection, ACTIVE_QUERIES_SQL, deadlineNanos);
+        List<Map<String, Object>> resources = requiredRows(connection, BACKEND_ACTIVE_TASKS_SQL, deadlineNanos);
         List<String> partialFailures = new ArrayList<>();
-        List<Map<String, Object>> processlist = optionalRows(connection.client(), PROCESSLIST_SQL,
-                CLIENT_ADDRESS_FAILURE, partialFailures);
-        List<Map<String, Object>> workloadGroups = optionalRows(connection.client(), WORKLOAD_GROUPS_SQL,
-                WORKLOAD_GROUP_FAILURE, partialFailures);
+        List<Map<String, Object>> processlist = optionalRows(connection, PROCESSLIST_SQL,
+                CLIENT_ADDRESS_FAILURE, partialFailures, deadlineNanos);
+        List<Map<String, Object>> workloadGroups = optionalRows(connection, WORKLOAD_GROUPS_SQL,
+                WORKLOAD_GROUP_FAILURE, partialFailures, deadlineNanos);
+        ensureWithinDeadline(deadlineNanos);
 
         boolean sourceTruncated = atSourceLimit(metadata) || atSourceLimit(resources)
                 || atSourceLimit(processlist) || atSourceLimit(workloadGroups);
@@ -196,9 +226,10 @@ public class DorisActiveTaskQueryService {
         return new TruncatedText(sql.substring(0, end), true);
     }
 
-    private List<Map<String, Object>> requiredRows(JdbcClient client, String sql) {
+    private List<Map<String, Object>> requiredRows(DorisAdminReaderFactory.DorisAdminConnection connection,
+                                                   String sql, long deadlineNanos) {
         try {
-            return rowQuery.apply(client, sql);
+            return rows(connection, sql, deadlineNanos);
         } catch (RuntimeException exception) {
             if (looksLikeMissingTable(exception)) {
                 throw new CapabilityUnsupportedException();
@@ -207,13 +238,39 @@ public class DorisActiveTaskQueryService {
         }
     }
 
-    private List<Map<String, Object>> optionalRows(JdbcClient client, String sql, String failure,
-                                                   List<String> partialFailures) {
+    private List<Map<String, Object>> optionalRows(DorisAdminReaderFactory.DorisAdminConnection connection,
+                                                   String sql, String failure, List<String> partialFailures,
+                                                   long deadlineNanos) {
         try {
-            return rowQuery.apply(client, sql);
+            return rows(connection, sql, deadlineNanos);
+        } catch (RequestTimeoutException exception) {
+            throw exception;
         } catch (RuntimeException exception) {
             partialFailures.add(failure);
             return List.of();
+        }
+    }
+
+    private List<Map<String, Object>> rows(DorisAdminReaderFactory.DorisAdminConnection connection,
+                                           String sql, long deadlineNanos) {
+        ensureWithinDeadline(deadlineNanos);
+        if (connection.dataSource() == null) {
+            return rowQuery.apply(connection.client(), sql);
+        }
+        long remainingNanos = deadlineNanos - nanoTime.getAsLong();
+        int timeoutSeconds = (int) Math.min(STATEMENT_TIMEOUT_MS / 1_000,
+                remainingNanos / 1_000_000_000L);
+        if (timeoutSeconds < 1) {
+            throw new RequestTimeoutException();
+        }
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(connection.dataSource());
+        jdbcTemplate.setQueryTimeout(timeoutSeconds);
+        return jdbcTemplate.queryForList(sql);
+    }
+
+    private void ensureWithinDeadline(long deadlineNanos) {
+        if (deadlineNanos - nanoTime.getAsLong() < 1_000_000_000L) {
+            throw new RequestTimeoutException();
         }
     }
 
@@ -492,6 +549,14 @@ public class DorisActiveTaskQueryService {
 
         public CapabilityUnsupportedException() {
             super(Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
+        }
+    }
+
+    static final class RequestTimeoutException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        RequestTimeoutException() {
+            super("Doris active-task request timed out");
         }
     }
 }

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Service;
 
@@ -92,6 +93,7 @@ public class DorisActiveTaskQueryService {
     private final ClusterHostService hostService;
     private final BiFunction<JdbcClient, String, List<Map<String, Object>>> rowQuery;
 
+    @Autowired
     public DorisActiveTaskQueryService(ClusterHostService hostService) {
         this(hostService, DorisActiveTaskQueryService::queryRows);
     }

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
@@ -270,7 +270,7 @@ public class DorisActiveTaskQueryService {
         }
         if (filter.getTypes() != null && !filter.getTypes().isEmpty()
                 && filter.getTypes().stream().noneMatch(type -> type != null
-                        && type.equalsIgnoreCase(task.getType()))) {
+                        && matchesType(type, task))) {
             return false;
         }
         if (!contains(lower(filter.getUser()), task.getUser())
@@ -279,6 +279,14 @@ public class DorisActiveTaskQueryService {
         }
         return atLeast(task.getCurrentMemoryBytes(), filter.getMinMemoryBytes())
                 && atLeast(task.getElapsedMs(), filter.getMinElapsedMs());
+    }
+
+    private boolean matchesType(String type, DorisActiveTaskVO task) {
+        if ("QUEUED".equalsIgnoreCase(type)) {
+            return "QUERY".equalsIgnoreCase(task.getType())
+                    && "QUEUED".equalsIgnoreCase(task.getQueryStatus());
+        }
+        return type.equalsIgnoreCase(task.getType());
     }
 
     private static final Comparator<TaskRecord> TASK_ORDER = Comparator

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
@@ -61,7 +60,6 @@ public class DorisActiveTaskQueryService {
             SELECT Id, Name FROM information_schema.workload_groups;
             """;
 
-    public static final int SOURCE_LIMIT = DorisVersionProfile.SOURCE_LIMIT;
     public static final int LIST_SQL_LIMIT_BYTES = 1_024;
     public static final int DETAIL_SQL_LIMIT_BYTES = 256 * 1_024;
     public static final int RESPONSE_LIMIT = 2_000;
@@ -72,7 +70,7 @@ public class DorisActiveTaskQueryService {
     private static final int STATEMENT_TIMEOUT_MS = 10_000;
 
     private final ClusterHostService hostService;
-    private final BiFunction<JdbcClient, String, List<Map<String, Object>>> rowQuery;
+    private final RowQuery rowQuery;
     private final LongSupplier nanoTime;
 
     @Autowired
@@ -80,13 +78,11 @@ public class DorisActiveTaskQueryService {
         this(hostService, DorisActiveTaskQueryService::queryRows, System::nanoTime);
     }
 
-    DorisActiveTaskQueryService(ClusterHostService hostService,
-                                BiFunction<JdbcClient, String, List<Map<String, Object>>> rowQuery) {
+    DorisActiveTaskQueryService(ClusterHostService hostService, RowQuery rowQuery) {
         this(hostService, rowQuery, System::nanoTime);
     }
 
-    DorisActiveTaskQueryService(ClusterHostService hostService,
-                                BiFunction<JdbcClient, String, List<Map<String, Object>>> rowQuery,
+    DorisActiveTaskQueryService(ClusterHostService hostService, RowQuery rowQuery,
                                 LongSupplier nanoTime) {
         this.hostService = hostService;
         this.rowQuery = rowQuery;
@@ -105,11 +101,8 @@ public class DorisActiveTaskQueryService {
     public DorisActiveTaskVO queryDetail(Integer clusterId,
                                          DorisAdminReaderFactory.DorisAdminConnection connection,
                                          String taskId) {
-        return query(clusterId, connection, new DorisActiveTaskQueryDTO(), taskId,
-                nanoTime.getAsLong() + REQUEST_TIMEOUT_MS * 1_000_000L).getTasks().stream()
-                .filter(task -> taskId.equals(task.getTaskId()))
-                .findFirst()
-                .orElse(null);
+        return firstTask(query(clusterId, connection, new DorisActiveTaskQueryDTO(), taskId,
+                nanoTime.getAsLong() + REQUEST_TIMEOUT_MS * 1_000_000L));
     }
 
     DorisActiveTaskResponseVO query(Integer clusterId,
@@ -121,10 +114,13 @@ public class DorisActiveTaskQueryService {
     DorisActiveTaskVO queryDetail(Integer clusterId,
                                   DorisAdminReaderFactory.DorisAdminConnection connection,
                                   String taskId, long deadlineNanos) {
-        return query(clusterId, connection, new DorisActiveTaskQueryDTO(), taskId, deadlineNanos).getTasks().stream()
-                .filter(task -> taskId.equals(task.getTaskId()))
-                .findFirst()
-                .orElse(null);
+        return firstTask(query(clusterId, connection, new DorisActiveTaskQueryDTO(), taskId, deadlineNanos));
+    }
+
+    /** 详情路径的 {@code query} 已按 taskId 过滤，结果至多一条。 */
+    private static DorisActiveTaskVO firstTask(DorisActiveTaskResponseVO response) {
+        List<DorisActiveTaskVO> tasks = response.getTasks();
+        return tasks.isEmpty() ? null : tasks.get(0);
     }
 
     private DorisActiveTaskResponseVO query(Integer clusterId,
@@ -135,10 +131,16 @@ public class DorisActiveTaskQueryService {
         if (!profile.supported()) {
             throw new CapabilityUnsupportedException();
         }
-        List<Map<String, Object>> metadata =
-                requiredRows(connection, profile.activeQueriesSql(), deadlineNanos);
-        List<Map<String, Object>> resources =
-                requiredRows(connection, profile.backendActiveTasksSql(), deadlineNanos);
+        // 详情只要一条任务：把 taskId 下推到这两张随负载增长的表，避免为一行重跑两次全量扫描。
+        // processlist / workload_groups 的行数由连接数与配置决定（ddh-01 实测 6 行 / 2 行），
+        // 不随查询数增长，因此不下推，也就不必碰 3.x 与 4.x 不同的 processlist 列名。
+        boolean detail = detailTaskId != null;
+        Object[] idArg = detail ? new Object[]{detailTaskId} : new Object[0];
+        List<Map<String, Object>> metadata = requiredRows(connection,
+                detail ? profile.activeQueriesByIdSql() : profile.activeQueriesSql(), deadlineNanos, idArg);
+        List<Map<String, Object>> resources = requiredRows(connection,
+                detail ? profile.backendActiveTasksByIdSql() : profile.backendActiveTasksSql(),
+                deadlineNanos, idArg);
         List<String> partialFailures = new ArrayList<>();
         List<Map<String, Object>> processlist = optionalRows(connection, profile.processlistSql(),
                 CLIENT_ADDRESS_FAILURE, partialFailures, deadlineNanos);
@@ -150,8 +152,8 @@ public class DorisActiveTaskQueryService {
                 || atSourceLimit(processlist) || atSourceLimit(workloadGroups);
         Map<String, Map<String, Object>> queryById = indexById(metadata);
         Map<String, List<Map<String, Object>>> resourcesById = groupById(resources);
-        Map<String, String> clientsByQueryId = byQueryId(processlist, "HOST");
-        Map<String, String> usersByQueryId = byQueryId(processlist, "USER");
+        Map<String, String> clientsByQueryId = byQueryId(processlist, "Host");
+        Map<String, String> usersByQueryId = byQueryId(processlist, "User");
         Map<String, String> workloadNames = workloadNames(workloadGroups);
         Map<String, String> hostNames = hostNames(clusterId);
 
@@ -213,9 +215,9 @@ public class DorisActiveTaskQueryService {
     }
 
     private List<Map<String, Object>> requiredRows(DorisAdminReaderFactory.DorisAdminConnection connection,
-                                                   String sql, long deadlineNanos) {
+                                                   String sql, long deadlineNanos, Object... args) {
         try {
-            return rows(connection, sql, deadlineNanos);
+            return rows(connection, sql, deadlineNanos, args);
         } catch (RuntimeException exception) {
             if (looksLikeMissingTable(exception)) {
                 throw new CapabilityUnsupportedException();
@@ -238,10 +240,10 @@ public class DorisActiveTaskQueryService {
     }
 
     private List<Map<String, Object>> rows(DorisAdminReaderFactory.DorisAdminConnection connection,
-                                           String sql, long deadlineNanos) {
+                                           String sql, long deadlineNanos, Object... args) {
         ensureWithinDeadline(deadlineNanos);
         if (connection.dataSource() == null) {
-            return rowQuery.apply(connection.client(), sql);
+            return rowQuery.apply(connection.client(), sql, args);
         }
         long remainingNanos = deadlineNanos - nanoTime.getAsLong();
         int timeoutSeconds = (int) Math.min(STATEMENT_TIMEOUT_MS / 1_000,
@@ -251,7 +253,7 @@ public class DorisActiveTaskQueryService {
         }
         JdbcTemplate jdbcTemplate = new JdbcTemplate(connection.dataSource());
         jdbcTemplate.setQueryTimeout(timeoutSeconds);
-        return jdbcTemplate.queryForList(sql);
+        return args.length == 0 ? jdbcTemplate.queryForList(sql) : jdbcTemplate.queryForList(sql, args);
     }
 
     private void ensureWithinDeadline(long deadlineNanos) {
@@ -377,11 +379,11 @@ public class DorisActiveTaskQueryService {
     private Map<String, String> byQueryId(List<Map<String, Object>> rows, String column) {
         Map<String, String> values = new HashMap<>();
         for (Map<String, Object> row : rows) {
-            String command = text(row, "COMMAND");
+            String command = text(row, "Command");
             if (command != null && !"QUERY".equalsIgnoreCase(command)) {
                 continue;
             }
-            String id = text(row, "QUERYID");
+            String id = text(row, "QueryId");
             if (id != null) {
                 values.putIfAbsent(id, text(row, column));
             }
@@ -391,7 +393,7 @@ public class DorisActiveTaskQueryService {
 
     private Map<String, String> workloadNames(List<Map<String, Object>> rows) {
         return rows.stream()
-                .map(row -> new String[]{text(row, "ID"), text(row, "NAME")})
+                .map(row -> new String[]{text(row, "Id"), text(row, "Name")})
                 .filter(entry -> entry[0] != null && entry[1] != null)
                 .collect(Collectors.toMap(entry -> entry[0], entry -> entry[1], (first, ignored) -> first));
     }
@@ -432,12 +434,20 @@ public class DorisActiveTaskQueryService {
         return result;
     }
 
-    private static List<Map<String, Object>> queryRows(JdbcClient client, String sql) {
-        return client.sql(sql).query().listOfRows();
+    private static List<Map<String, Object>> queryRows(JdbcClient client, String sql, Object... args) {
+        return args.length == 0
+                ? client.sql(sql).query().listOfRows()
+                : client.sql(sql).params(args).query().listOfRows();
+    }
+
+    /** 取数接缝：生产走 JDBC，测试注入假数据。带 args 以便详情路径参数化下推 taskId。 */
+    @FunctionalInterface
+    interface RowQuery {
+        List<Map<String, Object>> apply(JdbcClient client, String sql, Object... args);
     }
 
     private static boolean atSourceLimit(Collection<?> rows) {
-        return rows.size() == SOURCE_LIMIT;
+        return rows.size() == DorisVersionProfile.SOURCE_LIMIT;
     }
 
     private static boolean atLeast(Long value, Long minimum) {

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
@@ -23,6 +23,7 @@
 package com.datasophon.api.service.doris;
 
 import com.datasophon.api.doris.DorisAdminReaderFactory;
+import com.datasophon.api.doris.DorisVersionProfile;
 import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
 import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
 import com.datasophon.api.dto.v2.DorisActiveTaskVO;
@@ -55,36 +56,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class DorisActiveTaskQueryService {
 
-    public static final String ACTIVE_QUERIES_SQL = """
-            SELECT QUERY_ID, QUERY_START_TIME, QUERY_TIME_MS, WORKLOAD_GROUP_ID,
-                   FRONTEND_INSTANCE, QUEUE_START_TIME, QUEUE_END_TIME, QUERY_STATUS,
-                   `USER`, `SQL`
-            FROM information_schema.active_queries
-            LIMIT 20000;
-            """;
-
-    public static final String BACKEND_ACTIVE_TASKS_SQL = """
-            SELECT QUERY_ID, BE_ID, FE_HOST, WORKLOAD_GROUP_ID, QUERY_TYPE,
-                   TASK_TIME_MS, TASK_CPU_TIME_MS, SCAN_ROWS, SCAN_BYTES,
-                   BE_PEAK_MEMORY_BYTES, CURRENT_USED_MEMORY_BYTES,
-                   SHUFFLE_SEND_BYTES, SHUFFLE_SEND_ROWS,
-                   SPILL_WRITE_BYTES_TO_LOCAL_STORAGE, SPILL_READ_BYTES_FROM_LOCAL_STORAGE
-            FROM information_schema.backend_active_tasks
-            LIMIT 20000;
-            """;
-
-    public static final String PROCESSLIST_SQL = """
-            SELECT QueryId, Host
-            FROM information_schema.processlist
-            WHERE Command = 'Query'
-            LIMIT 20000;
-            """;
-
+    /** 三张主表的 SQL 按 Doris 大版本取自 {@link DorisVersionProfile}；本表两版列名一致，无需区分。 */
     public static final String WORKLOAD_GROUPS_SQL = """
             SELECT Id, Name FROM information_schema.workload_groups;
             """;
 
-    public static final int SOURCE_LIMIT = 20_000;
+    public static final int SOURCE_LIMIT = DorisVersionProfile.SOURCE_LIMIT;
     public static final int LIST_SQL_LIMIT_BYTES = 1_024;
     public static final int DETAIL_SQL_LIMIT_BYTES = 256 * 1_024;
     public static final int RESPONSE_LIMIT = 2_000;
@@ -154,10 +131,16 @@ public class DorisActiveTaskQueryService {
                                             DorisAdminReaderFactory.DorisAdminConnection connection,
                                             DorisActiveTaskQueryDTO filter,
                                             String detailTaskId, long deadlineNanos) {
-        List<Map<String, Object>> metadata = requiredRows(connection, ACTIVE_QUERIES_SQL, deadlineNanos);
-        List<Map<String, Object>> resources = requiredRows(connection, BACKEND_ACTIVE_TASKS_SQL, deadlineNanos);
+        DorisVersionProfile profile = connection.profile();
+        if (!profile.supported()) {
+            throw new CapabilityUnsupportedException();
+        }
+        List<Map<String, Object>> metadata =
+                requiredRows(connection, profile.activeQueriesSql(), deadlineNanos);
+        List<Map<String, Object>> resources =
+                requiredRows(connection, profile.backendActiveTasksSql(), deadlineNanos);
         List<String> partialFailures = new ArrayList<>();
-        List<Map<String, Object>> processlist = optionalRows(connection, PROCESSLIST_SQL,
+        List<Map<String, Object>> processlist = optionalRows(connection, profile.processlistSql(),
                 CLIENT_ADDRESS_FAILURE, partialFailures, deadlineNanos);
         List<Map<String, Object>> workloadGroups = optionalRows(connection, WORKLOAD_GROUPS_SQL,
                 WORKLOAD_GROUP_FAILURE, partialFailures, deadlineNanos);
@@ -167,7 +150,8 @@ public class DorisActiveTaskQueryService {
                 || atSourceLimit(processlist) || atSourceLimit(workloadGroups);
         Map<String, Map<String, Object>> queryById = indexById(metadata);
         Map<String, List<Map<String, Object>>> resourcesById = groupById(resources);
-        Map<String, String> clientsByQueryId = clientsByQueryId(processlist);
+        Map<String, String> clientsByQueryId = byQueryId(processlist, "HOST");
+        Map<String, String> usersByQueryId = byQueryId(processlist, "USER");
         Map<String, String> workloadNames = workloadNames(workloadGroups);
         Map<String, String> hostNames = hostNames(clusterId);
 
@@ -175,7 +159,7 @@ public class DorisActiveTaskQueryService {
         ids.addAll(resourcesById.keySet());
         List<TaskRecord> allTasks = ids.stream()
                 .map(id -> buildTask(id, queryById.get(id), resourcesById.getOrDefault(id, List.of()),
-                        clientsByQueryId, workloadNames, hostNames))
+                        clientsByQueryId, usersByQueryId, workloadNames, hostNames))
                 .toList();
         List<TaskRecord> filtered = allTasks.stream()
                 .filter(task -> detailTaskId == null ? matches(task, filter)
@@ -197,6 +181,8 @@ public class DorisActiveTaskQueryService {
         response.setTotal(filtered.size());
         response.setReturned(returnedTasks.size());
         response.setConnectedHostPort(connection.hostPort());
+        response.setServerVersion(connection.serverVersion());
+        response.setUnsupportedFields(profile.unsupportedFields());
         return response;
     }
 
@@ -275,8 +261,8 @@ public class DorisActiveTaskQueryService {
     }
 
     private TaskRecord buildTask(String id, Map<String, Object> metadata, List<Map<String, Object>> resourceRows,
-                                 Map<String, String> clientsByQueryId, Map<String, String> workloadNames,
-                                 Map<String, String> hostNames) {
+                                 Map<String, String> clientsByQueryId, Map<String, String> usersByQueryId,
+                                 Map<String, String> workloadNames, Map<String, String> hostNames) {
         Map<String, Object> firstResource = resourceRows.isEmpty() ? Map.of() : resourceRows.get(0);
         String queryType = text(firstResource, "QUERY_TYPE");
         boolean query = metadata != null || "SELECT".equalsIgnoreCase(queryType)
@@ -292,7 +278,9 @@ public class DorisActiveTaskQueryService {
         DorisActiveTaskVO task = new DorisActiveTaskVO();
         task.setTaskId(id);
         task.setType(type);
-        task.setUser(query && metadata != null ? text(metadata, "USER") : null);
+        // Doris 3.x 的 active_queries 没有 USER 列，退回 processlist 的同名列（4.x 取不到才会走到）。
+        String user = metadata == null ? null : text(metadata, "USER");
+        task.setUser(query ? (user == null ? usersByQueryId.get(id) : user) : null);
         task.setClientAddress(query ? clientsByQueryId.get(id) : null);
         task.setSql(query ? listSql.text() : null);
         task.setElapsedMs(elapsed);
@@ -311,7 +299,8 @@ public class DorisActiveTaskQueryService {
                 : number(metadata, "WORKLOAD_GROUP_ID");
         task.setWorkloadGroupId(workloadGroupId);
         task.setWorkloadGroupName(workloadGroupId == null ? null : workloadNames.get(String.valueOf(workloadGroupId)));
-        String rawFeHost = metadata == null ? text(firstResource, "FE_HOST") : text(metadata, "FRONTEND_INSTANCE");
+        String rawFeHost = shortenFeHost(
+                metadata == null ? text(firstResource, "FE_HOST") : text(metadata, "FRONTEND_INSTANCE"));
         task.setFeHost(metadata == null && rawFeHost != null
                 ? hostNames.getOrDefault(rawFeHost, rawFeHost)
                 : rawFeHost);
@@ -379,8 +368,14 @@ public class DorisActiveTaskQueryService {
             .thenComparing(record -> record.task().getElapsedMs(), Comparator.nullsLast(Comparator.reverseOrder()))
             .thenComparing(record -> valueOrEmpty(record.task().getTaskId()));
 
-    private Map<String, String> clientsByQueryId(List<Map<String, Object>> rows) {
-        Map<String, String> clients = new HashMap<>();
+    /**
+     * 按 QueryId 索引 processlist 的某一列。
+     *
+     * <p>{@code QueryId} 在 Sleep/EOF 连接上保留的是上一条查询的 ID，因此必须叠加
+     * {@code Command} 过滤（SQL 里已过滤一次，这里对手工构造的行再兜一次）。
+     */
+    private Map<String, String> byQueryId(List<Map<String, Object>> rows, String column) {
+        Map<String, String> values = new HashMap<>();
         for (Map<String, Object> row : rows) {
             String command = text(row, "COMMAND");
             if (command != null && !"QUERY".equalsIgnoreCase(command)) {
@@ -388,10 +383,10 @@ public class DorisActiveTaskQueryService {
             }
             String id = text(row, "QUERYID");
             if (id != null) {
-                clients.putIfAbsent(id, text(row, "HOST"));
+                values.putIfAbsent(id, text(row, column));
             }
         }
-        return clients;
+        return values;
     }
 
     private Map<String, String> workloadNames(List<Map<String, Object>> rows) {
@@ -518,6 +513,19 @@ public class DorisActiveTaskQueryService {
             }
         }
         return null;
+    }
+
+    /**
+     * K8s 上的 Doris FE 报的是 Pod FQDN
+     * {@code <pod>.<service>.<namespace>.svc.cluster.local}（实测 96 字符，会撑爆列宽），
+     * 只保留 {@code <pod>.<namespace>}。不含 {@code .svc.} 的值（IP、主机名）原样返回。
+     */
+    private static String shortenFeHost(String host) {
+        if (host == null || !host.contains(".svc.")) {
+            return host;
+        }
+        String[] parts = host.split("\\.");
+        return parts.length < 3 ? host : parts[0] + "." + parts[2];
     }
 
     private static String normalizeBlank(String value) {

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
@@ -108,16 +108,14 @@ public class DorisActiveTaskQueryService {
     public DorisActiveTaskResponseVO query(Integer clusterId,
                                            DorisAdminReaderFactory.DorisAdminConnection connection,
                                            DorisActiveTaskQueryDTO filter) {
-        return query(clusterId, connection, filter, false);
+        return query(clusterId, connection, filter, null);
     }
 
     /** Returns one task with the larger detail-level SQL bound. */
     public DorisActiveTaskVO queryDetail(Integer clusterId,
                                          DorisAdminReaderFactory.DorisAdminConnection connection,
                                          String taskId) {
-        DorisActiveTaskQueryDTO filter = new DorisActiveTaskQueryDTO();
-        filter.setKeyword(taskId);
-        return query(clusterId, connection, filter, true).getTasks().stream()
+        return query(clusterId, connection, new DorisActiveTaskQueryDTO(), taskId).getTasks().stream()
                 .filter(task -> taskId.equals(task.getTaskId()))
                 .findFirst()
                 .orElse(null);
@@ -126,7 +124,7 @@ public class DorisActiveTaskQueryService {
     private DorisActiveTaskResponseVO query(Integer clusterId,
                                             DorisAdminReaderFactory.DorisAdminConnection connection,
                                             DorisActiveTaskQueryDTO filter,
-                                            boolean includeDetailSql) {
+                                            String detailTaskId) {
         List<Map<String, Object>> metadata = requiredRows(connection.client(), ACTIVE_QUERIES_SQL);
         List<Map<String, Object>> resources = requiredRows(connection.client(), BACKEND_ACTIVE_TASKS_SQL);
         List<String> partialFailures = new ArrayList<>();
@@ -147,15 +145,16 @@ public class DorisActiveTaskQueryService {
         ids.addAll(resourcesById.keySet());
         List<TaskRecord> allTasks = ids.stream()
                 .map(id -> buildTask(id, queryById.get(id), resourcesById.getOrDefault(id, List.of()),
-                        clientsByQueryId, workloadNames, hostNames, includeDetailSql))
+                        clientsByQueryId, workloadNames, hostNames))
                 .toList();
         List<TaskRecord> filtered = allTasks.stream()
-                .filter(task -> matches(task, filter))
+                .filter(task -> detailTaskId == null ? matches(task, filter)
+                        : detailTaskId.equals(task.task().getTaskId()))
                 .sorted(TASK_ORDER)
                 .toList();
         List<DorisActiveTaskVO> returnedTasks = filtered.stream()
                 .limit(RESPONSE_LIMIT)
-                .map(TaskRecord::task)
+                .map(task -> detailTaskId == null ? task.task() : withDetailSql(task))
                 .toList();
 
         DorisActiveTaskResponseVO response = new DorisActiveTaskResponseVO();
@@ -220,7 +219,7 @@ public class DorisActiveTaskQueryService {
 
     private TaskRecord buildTask(String id, Map<String, Object> metadata, List<Map<String, Object>> resourceRows,
                                  Map<String, String> clientsByQueryId, Map<String, String> workloadNames,
-                                 Map<String, String> hostNames, boolean includeDetailSql) {
+                                 Map<String, String> hostNames) {
         Map<String, Object> firstResource = resourceRows.isEmpty() ? Map.of() : resourceRows.get(0);
         String queryType = text(firstResource, "QUERY_TYPE");
         boolean query = metadata != null || "SELECT".equalsIgnoreCase(queryType)
@@ -228,7 +227,6 @@ public class DorisActiveTaskQueryService {
         String type = query ? "QUERY" : "LOAD";
         String fullSql = metadata == null ? null : text(metadata, "SQL");
         TruncatedText listSql = truncateSql(fullSql, LIST_SQL_LIMIT_BYTES);
-        TruncatedText detailSql = includeDetailSql ? truncateSql(fullSql, DETAIL_SQL_LIMIT_BYTES) : null;
         Long elapsed = metadata == null ? max(resourceRows, "TASK_TIME_MS") : number(metadata, "QUERY_TIME_MS");
         if (elapsed == null && metadata != null) {
             elapsed = max(resourceRows, "TASK_TIME_MS");
@@ -240,7 +238,6 @@ public class DorisActiveTaskQueryService {
         task.setUser(query && metadata != null ? text(metadata, "USER") : null);
         task.setClientAddress(query ? clientsByQueryId.get(id) : null);
         task.setSql(query ? listSql.text() : null);
-        task.setDetailSql(query && detailSql != null ? detailSql.text() : null);
         task.setElapsedMs(elapsed);
         task.setStartTime(metadata == null ? null : text(metadata, "QUERY_START_TIME"));
         task.setCurrentMemoryBytes(sum(resourceRows, "CURRENT_USED_MEMORY_BYTES"));
@@ -264,11 +261,18 @@ public class DorisActiveTaskQueryService {
         task.setQueryStatus(metadata == null ? null : text(metadata, "QUERY_STATUS"));
         task.setQueueStartTime(metadata == null ? null : text(metadata, "QUEUE_START_TIME"));
         task.setQueueEndTime(metadata == null ? null : text(metadata, "QUEUE_END_TIME"));
-        task.setTruncated(detailSql == null ? listSql.truncated() : detailSql.truncated());
+        task.setTruncated(listSql.truncated());
         task.setBeDetails(resourceRows.stream()
                 .map(row -> beDetail(row, query))
                 .toList());
         return new TaskRecord(task, fullSql);
+    }
+
+    private DorisActiveTaskVO withDetailSql(TaskRecord record) {
+        TruncatedText detailSql = truncateSql(record.fullSql(), DETAIL_SQL_LIMIT_BYTES);
+        record.task().setDetailSql(detailSql.text());
+        record.task().setTruncated(detailSql.truncated());
+        return record.task();
     }
 
     private DorisBeTaskDetailVO beDetail(Map<String, Object> row, boolean query) {

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
@@ -1,0 +1,460 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.service.doris;
+
+import com.datasophon.api.doris.DorisAdminReaderFactory;
+import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
+import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
+import com.datasophon.api.dto.v2.DorisActiveTaskVO;
+import com.datasophon.api.dto.v2.DorisBeTaskDetailVO;
+import com.datasophon.api.enums.Status;
+import com.datasophon.api.service.host.ClusterHostService;
+import com.datasophon.dao.entity.ClusterHostDO;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
+
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Service;
+
+/** Reads, merges, filters, and limits one Doris active-task snapshot. */
+@Service
+public class DorisActiveTaskQueryService {
+
+    public static final String ACTIVE_QUERIES_SQL = """
+            SELECT QUERY_ID, QUERY_START_TIME, QUERY_TIME_MS, WORKLOAD_GROUP_ID,
+                   FRONTEND_INSTANCE, QUEUE_START_TIME, QUEUE_END_TIME, QUERY_STATUS,
+                   `USER`, `SQL`
+            FROM information_schema.active_queries
+            LIMIT 20000;
+            """;
+
+    public static final String BACKEND_ACTIVE_TASKS_SQL = """
+            SELECT QUERY_ID, BE_ID, FE_HOST, WORKLOAD_GROUP_ID, QUERY_TYPE,
+                   TASK_TIME_MS, TASK_CPU_TIME_MS, SCAN_ROWS, SCAN_BYTES,
+                   BE_PEAK_MEMORY_BYTES, CURRENT_USED_MEMORY_BYTES,
+                   SHUFFLE_SEND_BYTES, SHUFFLE_SEND_ROWS,
+                   SPILL_WRITE_BYTES_TO_LOCAL_STORAGE, SPILL_READ_BYTES_FROM_LOCAL_STORAGE
+            FROM information_schema.backend_active_tasks
+            LIMIT 20000;
+            """;
+
+    public static final String PROCESSLIST_SQL = """
+            SELECT QueryId, Host
+            FROM information_schema.processlist
+            WHERE Command = 'Query'
+            LIMIT 20000;
+            """;
+
+    public static final String WORKLOAD_GROUPS_SQL = """
+            SELECT Id, Name FROM information_schema.workload_groups;
+            """;
+
+    public static final int SOURCE_LIMIT = 20_000;
+    public static final int LIST_SQL_LIMIT_BYTES = 1_024;
+    public static final int DETAIL_SQL_LIMIT_BYTES = 256 * 1_024;
+    public static final int RESPONSE_LIMIT = 2_000;
+
+    private static final String CLIENT_ADDRESS_FAILURE = "clientAddress";
+    private static final String WORKLOAD_GROUP_FAILURE = "workloadGroup";
+
+    private final ClusterHostService hostService;
+    private final BiFunction<JdbcClient, String, List<Map<String, Object>>> rowQuery;
+
+    public DorisActiveTaskQueryService(ClusterHostService hostService) {
+        this(hostService, DorisActiveTaskQueryService::queryRows);
+    }
+
+    DorisActiveTaskQueryService(ClusterHostService hostService,
+                                BiFunction<JdbcClient, String, List<Map<String, Object>>> rowQuery) {
+        this.hostService = hostService;
+        this.rowQuery = rowQuery;
+    }
+
+    /** Executes the four fixed statements and returns a response ready for the facade. */
+    public DorisActiveTaskResponseVO query(Integer clusterId,
+                                           DorisAdminReaderFactory.DorisAdminConnection connection,
+                                           DorisActiveTaskQueryDTO filter) {
+        List<Map<String, Object>> metadata = requiredRows(connection.client(), ACTIVE_QUERIES_SQL);
+        List<Map<String, Object>> resources = requiredRows(connection.client(), BACKEND_ACTIVE_TASKS_SQL);
+        List<String> partialFailures = new ArrayList<>();
+        List<Map<String, Object>> processlist = optionalRows(connection.client(), PROCESSLIST_SQL,
+                CLIENT_ADDRESS_FAILURE, partialFailures);
+        List<Map<String, Object>> workloadGroups = optionalRows(connection.client(), WORKLOAD_GROUPS_SQL,
+                WORKLOAD_GROUP_FAILURE, partialFailures);
+
+        boolean sourceTruncated = atSourceLimit(metadata) || atSourceLimit(resources)
+                || atSourceLimit(processlist) || atSourceLimit(workloadGroups);
+        Map<String, Map<String, Object>> queryById = indexById(metadata);
+        Map<String, List<Map<String, Object>>> resourcesById = groupById(resources);
+        Map<String, String> clientsByQueryId = clientsByQueryId(processlist);
+        Map<String, String> workloadNames = workloadNames(workloadGroups);
+        Map<String, String> hostNames = hostNames(clusterId);
+
+        Set<String> ids = new LinkedHashSet<>(queryById.keySet());
+        ids.addAll(resourcesById.keySet());
+        List<TaskRecord> allTasks = ids.stream()
+                .map(id -> buildTask(id, queryById.get(id), resourcesById.getOrDefault(id, List.of()),
+                        clientsByQueryId, workloadNames, hostNames))
+                .toList();
+        List<TaskRecord> filtered = allTasks.stream()
+                .filter(task -> matches(task, filter))
+                .sorted(TASK_ORDER)
+                .toList();
+        List<DorisActiveTaskVO> returnedTasks = filtered.stream()
+                .limit(RESPONSE_LIMIT)
+                .map(TaskRecord::task)
+                .toList();
+
+        DorisActiveTaskResponseVO response = new DorisActiveTaskResponseVO();
+        response.setTasks(returnedTasks);
+        response.setDegraded(connection.degraded());
+        response.setDegradedReason(connection.degradedReason());
+        response.setPartialFailures(partialFailures);
+        response.setTruncated(filtered.size() > RESPONSE_LIMIT);
+        response.setSourceTruncated(sourceTruncated);
+        response.setTotal(filtered.size());
+        response.setReturned(returnedTasks.size());
+        response.setConnectedHostPort(connection.hostPort());
+        return response;
+    }
+
+    public static TruncatedText truncateSql(String sql, int maxBytes) {
+        if (sql == null) {
+            return new TruncatedText(null, false);
+        }
+        if (maxBytes <= 0) {
+            return new TruncatedText("", !sql.isEmpty());
+        }
+        int byteLength = sql.getBytes(StandardCharsets.UTF_8).length;
+        if (byteLength <= maxBytes) {
+            return new TruncatedText(sql, false);
+        }
+        int bytes = 0;
+        int end = 0;
+        while (end < sql.length()) {
+            int codePoint = sql.codePointAt(end);
+            int codePointBytes = new String(Character.toChars(codePoint))
+                    .getBytes(StandardCharsets.UTF_8).length;
+            if (bytes + codePointBytes > maxBytes) {
+                break;
+            }
+            bytes += codePointBytes;
+            end += Character.charCount(codePoint);
+        }
+        return new TruncatedText(sql.substring(0, end), true);
+    }
+
+    private List<Map<String, Object>> requiredRows(JdbcClient client, String sql) {
+        try {
+            return rowQuery.apply(client, sql);
+        } catch (RuntimeException exception) {
+            if (looksLikeMissingTable(exception)) {
+                throw new CapabilityUnsupportedException();
+            }
+            throw exception;
+        }
+    }
+
+    private List<Map<String, Object>> optionalRows(JdbcClient client, String sql, String failure,
+                                                   List<String> partialFailures) {
+        try {
+            return rowQuery.apply(client, sql);
+        } catch (RuntimeException exception) {
+            partialFailures.add(failure);
+            return List.of();
+        }
+    }
+
+    private TaskRecord buildTask(String id, Map<String, Object> metadata, List<Map<String, Object>> resourceRows,
+                                 Map<String, String> clientsByQueryId, Map<String, String> workloadNames,
+                                 Map<String, String> hostNames) {
+        Map<String, Object> firstResource = resourceRows.isEmpty() ? Map.of() : resourceRows.get(0);
+        String queryType = text(firstResource, "QUERY_TYPE");
+        boolean query = metadata != null || "SELECT".equalsIgnoreCase(queryType)
+                || "QUERY".equalsIgnoreCase(queryType);
+        String type = query ? "QUERY" : "LOAD";
+        String fullSql = metadata == null ? null : text(metadata, "SQL");
+        TruncatedText listSql = truncateSql(fullSql, LIST_SQL_LIMIT_BYTES);
+        Long elapsed = metadata == null ? max(resourceRows, "TASK_TIME_MS") : number(metadata, "QUERY_TIME_MS");
+        if (elapsed == null && metadata != null) {
+            elapsed = max(resourceRows, "TASK_TIME_MS");
+        }
+
+        DorisActiveTaskVO task = new DorisActiveTaskVO();
+        task.setTaskId(id);
+        task.setType(type);
+        task.setUser(query && metadata != null ? text(metadata, "USER") : null);
+        task.setClientAddress(query ? clientsByQueryId.get(id) : null);
+        task.setSql(query ? listSql.text() : null);
+        task.setElapsedMs(elapsed);
+        task.setStartTime(metadata == null ? null : text(metadata, "QUERY_START_TIME"));
+        task.setCurrentMemoryBytes(sum(resourceRows, "CURRENT_USED_MEMORY_BYTES"));
+        task.setPeakMemoryBytes(max(resourceRows, "BE_PEAK_MEMORY_BYTES"));
+        task.setScanRows(sum(resourceRows, "SCAN_ROWS"));
+        task.setScanBytes(query ? sum(resourceRows, "SCAN_BYTES") : null);
+        task.setCpuTimeMs(sum(resourceRows, "TASK_CPU_TIME_MS"));
+        task.setShuffleSendBytes(sum(resourceRows, "SHUFFLE_SEND_BYTES"));
+        task.setShuffleSendRows(sum(resourceRows, "SHUFFLE_SEND_ROWS"));
+        task.setSpillWriteBytesToLocalStorage(sum(resourceRows, "SPILL_WRITE_BYTES_TO_LOCAL_STORAGE"));
+        task.setSpillReadBytesFromLocalStorage(sum(resourceRows, "SPILL_READ_BYTES_FROM_LOCAL_STORAGE"));
+        Long workloadGroupId = metadata == null
+                ? number(firstResource, "WORKLOAD_GROUP_ID")
+                : number(metadata, "WORKLOAD_GROUP_ID");
+        task.setWorkloadGroupId(workloadGroupId);
+        task.setWorkloadGroupName(workloadGroupId == null ? null : workloadNames.get(String.valueOf(workloadGroupId)));
+        String rawFeHost = metadata == null ? text(firstResource, "FE_HOST") : text(metadata, "FRONTEND_INSTANCE");
+        task.setFeHost(metadata == null ? hostNames.getOrDefault(rawFeHost, rawFeHost) : rawFeHost);
+        task.setQueryStatus(metadata == null ? null : text(metadata, "QUERY_STATUS"));
+        task.setQueueStartTime(metadata == null ? null : text(metadata, "QUEUE_START_TIME"));
+        task.setQueueEndTime(metadata == null ? null : text(metadata, "QUEUE_END_TIME"));
+        task.setTruncated(listSql.truncated());
+        task.setBeDetails(resourceRows.stream()
+                .map(row -> beDetail(row, query))
+                .toList());
+        return new TaskRecord(task, fullSql);
+    }
+
+    private DorisBeTaskDetailVO beDetail(Map<String, Object> row, boolean query) {
+        DorisBeTaskDetailVO detail = new DorisBeTaskDetailVO();
+        detail.setBeId(text(row, "BE_ID"));
+        detail.setPeakMemoryBytes(number(row, "BE_PEAK_MEMORY_BYTES"));
+        detail.setCurrentMemoryBytes(number(row, "CURRENT_USED_MEMORY_BYTES"));
+        detail.setScanRows(number(row, "SCAN_ROWS"));
+        detail.setScanBytes(query ? number(row, "SCAN_BYTES") : null);
+        return detail;
+    }
+
+    private boolean matches(TaskRecord record, DorisActiveTaskQueryDTO filter) {
+        if (filter == null) {
+            return true;
+        }
+        String keyword = lower(filter.getKeyword());
+        DorisActiveTaskVO task = record.task();
+        if (keyword != null && !contains(keyword, task.getTaskId())
+                && !contains(keyword, task.getUser()) && !contains(keyword, record.fullSql())) {
+            return false;
+        }
+        if (filter.getTypes() != null && !filter.getTypes().isEmpty()
+                && filter.getTypes().stream().noneMatch(type -> type != null
+                && type.equalsIgnoreCase(task.getType()))) {
+            return false;
+        }
+        if (!contains(lower(filter.getUser()), task.getUser())
+                || !contains(lower(filter.getFeHost()), task.getFeHost())) {
+            return false;
+        }
+        return atLeast(task.getCurrentMemoryBytes(), filter.getMinMemoryBytes())
+                && atLeast(task.getElapsedMs(), filter.getMinElapsedMs());
+    }
+
+    private static final Comparator<TaskRecord> TASK_ORDER = Comparator
+            .comparing((TaskRecord record) -> record.task().getCurrentMemoryBytes(),
+                    Comparator.nullsLast(Comparator.reverseOrder()))
+            .thenComparing(record -> record.task().getElapsedMs(), Comparator.nullsLast(Comparator.reverseOrder()))
+            .thenComparing(record -> valueOrEmpty(record.task().getTaskId()));
+
+    private Map<String, String> clientsByQueryId(List<Map<String, Object>> rows) {
+        Map<String, String> clients = new HashMap<>();
+        for (Map<String, Object> row : rows) {
+            String command = text(row, "COMMAND");
+            if (command != null && !"QUERY".equalsIgnoreCase(command)) {
+                continue;
+            }
+            String id = text(row, "QUERYID");
+            if (id != null) {
+                clients.putIfAbsent(id, text(row, "HOST"));
+            }
+        }
+        return clients;
+    }
+
+    private Map<String, String> workloadNames(List<Map<String, Object>> rows) {
+        return rows.stream()
+                .map(row -> new String[] {text(row, "ID"), text(row, "NAME")})
+                .filter(entry -> entry[0] != null && entry[1] != null)
+                .collect(Collectors.toMap(entry -> entry[0], entry -> entry[1], (first, ignored) -> first));
+    }
+
+    private Map<String, String> hostNames(Integer clusterId) {
+        if (hostService == null) {
+            return Map.of();
+        }
+        try {
+            return hostService.getHostListByClusterId(clusterId).stream()
+                    .filter(host -> host.getIp() != null && host.getHostname() != null)
+                    .collect(Collectors.toMap(ClusterHostDO::getIp, ClusterHostDO::getHostname,
+                            (first, ignored) -> first));
+        } catch (RuntimeException ignored) {
+            return Map.of();
+        }
+    }
+
+    private static Map<String, Map<String, Object>> indexById(List<Map<String, Object>> rows) {
+        Map<String, Map<String, Object>> result = new LinkedHashMap<>();
+        for (Map<String, Object> row : rows) {
+            String id = text(row, "QUERY_ID");
+            if (id != null) {
+                result.putIfAbsent(id, row);
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, List<Map<String, Object>>> groupById(List<Map<String, Object>> rows) {
+        Map<String, List<Map<String, Object>>> result = new LinkedHashMap<>();
+        for (Map<String, Object> row : rows) {
+            String id = text(row, "QUERY_ID");
+            if (id != null) {
+                result.computeIfAbsent(id, ignored -> new ArrayList<>()).add(row);
+            }
+        }
+        return result;
+    }
+
+    private static List<Map<String, Object>> queryRows(JdbcClient client, String sql) {
+        return client.sql(sql).query().listOfRows();
+    }
+
+    private static boolean atSourceLimit(Collection<?> rows) {
+        return rows.size() == SOURCE_LIMIT;
+    }
+
+    private static boolean atLeast(Long value, Long minimum) {
+        return minimum == null || value != null && value >= minimum;
+    }
+
+    private static boolean contains(String needle, String value) {
+        return needle == null || value != null && value.toLowerCase(Locale.ROOT).contains(needle);
+    }
+
+    private static String lower(String value) {
+        String normalized = normalizeBlank(value);
+        return normalized == null ? null : normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private static String valueOrEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    private static String text(Map<String, Object> row, String key) {
+        Object value = value(row, key);
+        return value == null ? null : normalizeBlank(String.valueOf(value));
+    }
+
+    private static Long number(Map<String, Object> row, String key) {
+        Object value = value(row, key);
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Long.valueOf(String.valueOf(value));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Long sum(List<Map<String, Object>> rows, String key) {
+        long total = 0;
+        boolean present = false;
+        for (Map<String, Object> row : rows) {
+            Long value = number(row, key);
+            if (value != null) {
+                present = true;
+                total += value;
+            }
+        }
+        return present ? total : null;
+    }
+
+    private static Long max(List<Map<String, Object>> rows, String key) {
+        Long maximum = null;
+        for (Map<String, Object> row : rows) {
+            Long value = number(row, key);
+            if (value != null && (maximum == null || value > maximum)) {
+                maximum = value;
+            }
+        }
+        return maximum;
+    }
+
+    private static Object value(Map<String, Object> row, String key) {
+        Object value = row.get(key);
+        if (value != null || row.containsKey(key)) {
+            return value;
+        }
+        String upperKey = key.toUpperCase(Locale.ROOT);
+        for (Map.Entry<String, Object> entry : row.entrySet()) {
+            if (entry.getKey().toUpperCase(Locale.ROOT).equals(upperKey)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static String normalizeBlank(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    private static boolean looksLikeMissingTable(Throwable throwable) {
+        for (Throwable current = throwable; current != null; current = current.getCause()) {
+            String message = current.getMessage();
+            if (message != null) {
+                String lower = message.toLowerCase(Locale.ROOT);
+                if (lower.contains("doesn't exist") || lower.contains("does not exist")
+                        || lower.contains("unknown table") || lower.contains("table not found")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    public record TruncatedText(String text, boolean truncated) {
+    }
+
+    private record TaskRecord(DorisActiveTaskVO task, String fullSql) {
+    }
+
+    public static final class CapabilityUnsupportedException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        public CapabilityUnsupportedException() {
+            super(Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
+        }
+    }
+}

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
@@ -108,6 +108,25 @@ public class DorisActiveTaskQueryService {
     public DorisActiveTaskResponseVO query(Integer clusterId,
                                            DorisAdminReaderFactory.DorisAdminConnection connection,
                                            DorisActiveTaskQueryDTO filter) {
+        return query(clusterId, connection, filter, false);
+    }
+
+    /** Returns one task with the larger detail-level SQL bound. */
+    public DorisActiveTaskVO queryDetail(Integer clusterId,
+                                         DorisAdminReaderFactory.DorisAdminConnection connection,
+                                         String taskId) {
+        DorisActiveTaskQueryDTO filter = new DorisActiveTaskQueryDTO();
+        filter.setKeyword(taskId);
+        return query(clusterId, connection, filter, true).getTasks().stream()
+                .filter(task -> taskId.equals(task.getTaskId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private DorisActiveTaskResponseVO query(Integer clusterId,
+                                            DorisAdminReaderFactory.DorisAdminConnection connection,
+                                            DorisActiveTaskQueryDTO filter,
+                                            boolean includeDetailSql) {
         List<Map<String, Object>> metadata = requiredRows(connection.client(), ACTIVE_QUERIES_SQL);
         List<Map<String, Object>> resources = requiredRows(connection.client(), BACKEND_ACTIVE_TASKS_SQL);
         List<String> partialFailures = new ArrayList<>();
@@ -128,7 +147,7 @@ public class DorisActiveTaskQueryService {
         ids.addAll(resourcesById.keySet());
         List<TaskRecord> allTasks = ids.stream()
                 .map(id -> buildTask(id, queryById.get(id), resourcesById.getOrDefault(id, List.of()),
-                        clientsByQueryId, workloadNames, hostNames))
+                        clientsByQueryId, workloadNames, hostNames, includeDetailSql))
                 .toList();
         List<TaskRecord> filtered = allTasks.stream()
                 .filter(task -> matches(task, filter))
@@ -201,7 +220,7 @@ public class DorisActiveTaskQueryService {
 
     private TaskRecord buildTask(String id, Map<String, Object> metadata, List<Map<String, Object>> resourceRows,
                                  Map<String, String> clientsByQueryId, Map<String, String> workloadNames,
-                                 Map<String, String> hostNames) {
+                                 Map<String, String> hostNames, boolean includeDetailSql) {
         Map<String, Object> firstResource = resourceRows.isEmpty() ? Map.of() : resourceRows.get(0);
         String queryType = text(firstResource, "QUERY_TYPE");
         boolean query = metadata != null || "SELECT".equalsIgnoreCase(queryType)
@@ -209,6 +228,7 @@ public class DorisActiveTaskQueryService {
         String type = query ? "QUERY" : "LOAD";
         String fullSql = metadata == null ? null : text(metadata, "SQL");
         TruncatedText listSql = truncateSql(fullSql, LIST_SQL_LIMIT_BYTES);
+        TruncatedText detailSql = includeDetailSql ? truncateSql(fullSql, DETAIL_SQL_LIMIT_BYTES) : null;
         Long elapsed = metadata == null ? max(resourceRows, "TASK_TIME_MS") : number(metadata, "QUERY_TIME_MS");
         if (elapsed == null && metadata != null) {
             elapsed = max(resourceRows, "TASK_TIME_MS");
@@ -220,6 +240,7 @@ public class DorisActiveTaskQueryService {
         task.setUser(query && metadata != null ? text(metadata, "USER") : null);
         task.setClientAddress(query ? clientsByQueryId.get(id) : null);
         task.setSql(query ? listSql.text() : null);
+        task.setDetailSql(query && detailSql != null ? detailSql.text() : null);
         task.setElapsedMs(elapsed);
         task.setStartTime(metadata == null ? null : text(metadata, "QUERY_START_TIME"));
         task.setCurrentMemoryBytes(sum(resourceRows, "CURRENT_USED_MEMORY_BYTES"));
@@ -243,7 +264,7 @@ public class DorisActiveTaskQueryService {
         task.setQueryStatus(metadata == null ? null : text(metadata, "QUERY_STATUS"));
         task.setQueueStartTime(metadata == null ? null : text(metadata, "QUEUE_START_TIME"));
         task.setQueueEndTime(metadata == null ? null : text(metadata, "QUEUE_END_TIME"));
-        task.setTruncated(listSql.truncated());
+        task.setTruncated(detailSql == null ? listSql.truncated() : detailSql.truncated());
         task.setBeDetails(resourceRows.stream()
                 .map(row -> beDetail(row, query))
                 .toList());

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisActiveTaskQueryService.java
@@ -235,7 +235,9 @@ public class DorisActiveTaskQueryService {
         task.setWorkloadGroupId(workloadGroupId);
         task.setWorkloadGroupName(workloadGroupId == null ? null : workloadNames.get(String.valueOf(workloadGroupId)));
         String rawFeHost = metadata == null ? text(firstResource, "FE_HOST") : text(metadata, "FRONTEND_INSTANCE");
-        task.setFeHost(metadata == null ? hostNames.getOrDefault(rawFeHost, rawFeHost) : rawFeHost);
+        task.setFeHost(metadata == null && rawFeHost != null
+                ? hostNames.getOrDefault(rawFeHost, rawFeHost)
+                : rawFeHost);
         task.setQueryStatus(metadata == null ? null : text(metadata, "QUERY_STATUS"));
         task.setQueueStartTime(metadata == null ? null : text(metadata, "QUEUE_START_TIME"));
         task.setQueueEndTime(metadata == null ? null : text(metadata, "QUEUE_END_TIME"));
@@ -268,7 +270,7 @@ public class DorisActiveTaskQueryService {
         }
         if (filter.getTypes() != null && !filter.getTypes().isEmpty()
                 && filter.getTypes().stream().noneMatch(type -> type != null
-                && type.equalsIgnoreCase(task.getType()))) {
+                        && type.equalsIgnoreCase(task.getType()))) {
             return false;
         }
         if (!contains(lower(filter.getUser()), task.getUser())
@@ -302,7 +304,7 @@ public class DorisActiveTaskQueryService {
 
     private Map<String, String> workloadNames(List<Map<String, Object>> rows) {
         return rows.stream()
-                .map(row -> new String[] {text(row, "ID"), text(row, "NAME")})
+                .map(row -> new String[]{text(row, "ID"), text(row, "NAME")})
                 .filter(entry -> entry[0] != null && entry[1] != null)
                 .collect(Collectors.toMap(entry -> entry[0], entry -> entry[1], (first, ignored) -> first));
     }

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisServiceInstanceValidator.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisServiceInstanceValidator.java
@@ -26,6 +26,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 import com.datasophon.api.enums.Status;
 import com.datasophon.api.service.ClusterServiceInstanceService;
+import com.datasophon.api.service.instance.K8sServiceInstanceService;
 import com.datasophon.dao.entity.ClusterServiceInstanceEntity;
 
 import org.springframework.stereotype.Component;
@@ -36,19 +37,34 @@ import org.springframework.web.server.ResponseStatusException;
 public class DorisServiceInstanceValidator {
 
     private final ClusterServiceInstanceService serviceInstanceService;
+    private final K8sServiceInstanceService k8sServiceInstanceService;
 
-    public DorisServiceInstanceValidator(ClusterServiceInstanceService serviceInstanceService) {
+    public DorisServiceInstanceValidator(ClusterServiceInstanceService serviceInstanceService,
+                                         K8sServiceInstanceService k8sServiceInstanceService) {
         this.serviceInstanceService = serviceInstanceService;
+        this.k8sServiceInstanceService = k8sServiceInstanceService;
     }
 
     public ClusterServiceInstanceEntity requireDorisInstance(Integer clusterId, Integer instanceId) {
         ClusterServiceInstanceEntity instance = instanceId == null
                 ? null
                 : serviceInstanceService.getById(instanceId);
-        if (clusterId == null || instance == null || !clusterId.equals(instance.getClusterId())
-                || !"DORIS".equalsIgnoreCase(instance.getServiceName())) {
-            throw new ResponseStatusException(BAD_REQUEST, Status.INSTANCE_MISMATCH.getMsg());
+        if (clusterId != null && instance != null && clusterId.equals(instance.getClusterId())
+                && "DORIS".equalsIgnoreCase(instance.getServiceName())) {
+            return instance;
         }
-        return instance;
+        if (clusterId != null && instanceId != null
+                && k8sServiceInstanceService.getVoById(instanceId)
+                        .filter(k8sInstance -> clusterId.equals(k8sInstance.getClusterId())
+                                && isK8sDoris(k8sInstance.getServiceName()))
+                        .isPresent()) {
+            return null;
+        }
+        throw new ResponseStatusException(BAD_REQUEST, Status.INSTANCE_MISMATCH.getMsg());
+    }
+
+    private static boolean isK8sDoris(String serviceName) {
+        return "doris-coupled".equalsIgnoreCase(serviceName)
+                || "doris-disaggregated".equalsIgnoreCase(serviceName);
     }
 }

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisServiceInstanceValidator.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisServiceInstanceValidator.java
@@ -22,14 +22,14 @@
 
 package com.datasophon.api.service.doris;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
 import com.datasophon.api.enums.Status;
 import com.datasophon.api.service.ClusterServiceInstanceService;
 import com.datasophon.dao.entity.ClusterServiceInstanceEntity;
 
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
-
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 /** 校验活动任务查询的服务实例确实属于请求集群且为 Doris。 */
 @Component

--- a/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisServiceInstanceValidator.java
+++ b/datasophon-api/src/main/java/com/datasophon/api/service/doris/DorisServiceInstanceValidator.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.service.doris;
+
+import com.datasophon.api.enums.Status;
+import com.datasophon.api.service.ClusterServiceInstanceService;
+import com.datasophon.dao.entity.ClusterServiceInstanceEntity;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+/** 校验活动任务查询的服务实例确实属于请求集群且为 Doris。 */
+@Component
+public class DorisServiceInstanceValidator {
+
+    private final ClusterServiceInstanceService serviceInstanceService;
+
+    public DorisServiceInstanceValidator(ClusterServiceInstanceService serviceInstanceService) {
+        this.serviceInstanceService = serviceInstanceService;
+    }
+
+    public ClusterServiceInstanceEntity requireDorisInstance(Integer clusterId, Integer instanceId) {
+        ClusterServiceInstanceEntity instance = instanceId == null
+                ? null
+                : serviceInstanceService.getById(instanceId);
+        if (clusterId == null || instance == null || !clusterId.equals(instance.getClusterId())
+                || !"DORIS".equalsIgnoreCase(instance.getServiceName())) {
+            throw new ResponseStatusException(BAD_REQUEST, Status.INSTANCE_MISMATCH.getMsg());
+        }
+        return instance;
+    }
+}

--- a/datasophon-api/src/test/java/com/datasophon/api/doris/DorisAdminReaderFactoryTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/doris/DorisAdminReaderFactoryTest.java
@@ -1,0 +1,197 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.doris;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.datasophon.api.observability.ExternalOtelDatasourceProvider;
+import com.datasophon.api.observability.OtelCredentialService;
+import com.datasophon.api.observability.OtelCredentials;
+import com.datasophon.api.service.ClusterServiceRoleInstanceService;
+import com.datasophon.api.service.ClusterVariableService;
+import com.datasophon.dao.entity.ClusterServiceRoleInstanceEntity;
+import com.datasophon.dao.entity.ClusterVariable;
+import com.datasophon.dao.enums.ServiceRoleState;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+class DorisAdminReaderFactoryTest {
+
+    @Test
+    void physicalClusterUsesRootAndExposesActualEndpoint() {
+        ClusterServiceRoleInstanceService roles = mock(ClusterServiceRoleInstanceService.class);
+        ClusterVariableService variables = mock(ClusterVariableService.class);
+        when(roles.getServiceRoleInstanceListByClusterIdAndRoleName(7, "DorisFE"))
+                .thenReturn(List.of(role("ddh-01", ServiceRoleState.RUNNING)));
+        when(variables.getVariableByVariableName(7, "DORIS", "query_port"))
+                .thenReturn(variable("query_port", "19030"));
+        when(variables.getVariableByVariableName(7, "DORIS", "root_password"))
+                .thenReturn(variable("root_password", "root-secret"));
+
+        DorisAdminReaderFactory factory = factory(roles, variables, noExternal(), dataSource -> true);
+        DorisAdminReaderFactory.DorisAdminConnection connection = factory.create(7);
+
+        assertThat(connection.username()).isEqualTo("root");
+        assertThat(connection.hostPort()).isEqualTo("ddh-01:19030");
+        assertThat(connection.degraded()).isFalse();
+        assertThat(factory.dataSourceForTest(7).getConnectionTimeout()).isEqualTo(5_000);
+        assertThat(factory.dataSourceForTest(7).getJdbcUrl())
+                .contains("ddh-01:19030")
+                .contains("connectTimeout=5000")
+                .contains("socketTimeout=10000");
+    }
+
+    @Test
+    void importedClusterUsesReaderAccountAndExternalEndpoint() {
+        ClusterServiceRoleInstanceService roles = mock(ClusterServiceRoleInstanceService.class);
+        ClusterVariableService variables = mock(ClusterVariableService.class);
+        ExternalOtelDatasourceProvider provider = external("10.0.0.9", "29030");
+        OtelCredentialService credentials = mock(OtelCredentialService.class);
+        when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
+        DorisAdminReaderFactory factory = new DorisAdminReaderFactory(
+                roles, variables, credentials, provider, dataSource -> true);
+
+        DorisAdminReaderFactory.DorisAdminConnection connection = factory.create(7);
+
+        assertThat(connection.username()).isEqualTo("otel_reader");
+        assertThat(connection.hostPort()).isEqualTo("10.0.0.9:29030");
+        assertThat(connection.degraded()).isFalse();
+        verify(roles, never()).getServiceRoleInstanceListByClusterIdAndRoleName(anyInt(), anyString());
+    }
+
+    @Test
+    void missingRootPasswordFallsBackToReaderWithDegradedFlag() {
+        ClusterServiceRoleInstanceService roles = mock(ClusterServiceRoleInstanceService.class);
+        ClusterVariableService variables = mock(ClusterVariableService.class);
+        when(roles.getServiceRoleInstanceListByClusterIdAndRoleName(7, "DorisFE"))
+                .thenReturn(List.of(role("ddh-01", ServiceRoleState.RUNNING)));
+        when(variables.getVariableByVariableName(7, "DORIS", "query_port"))
+                .thenReturn(variable("query_port", "9030"));
+        OtelCredentialService credentials = mock(OtelCredentialService.class);
+        when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
+        DorisAdminReaderFactory factory = new DorisAdminReaderFactory(
+                roles, variables, credentials, noExternal(), dataSource -> true);
+
+        DorisAdminReaderFactory.DorisAdminConnection connection = factory.create(7);
+
+        assertThat(connection.username()).isEqualTo("otel_reader");
+        assertThat(connection.degraded()).isTrue();
+        assertThat(connection.degradedReason()).isEqualTo(DorisAdminReaderFactory.ROOT_FALLBACK_REASON);
+    }
+
+    @Test
+    void rejectedRootFallsBackAndChangedSettingsReplaceAndCloseTheOldPool() {
+        ClusterServiceRoleInstanceService roles = mock(ClusterServiceRoleInstanceService.class);
+        ClusterVariableService variables = mock(ClusterVariableService.class);
+        when(roles.getServiceRoleInstanceListByClusterIdAndRoleName(7, "DorisFE"))
+                .thenReturn(List.of(role("ddh-01", ServiceRoleState.RUNNING)));
+        when(variables.getVariableByVariableName(7, "DORIS", "query_port"))
+                .thenReturn(variable("query_port", "9030"));
+        when(variables.getVariableByVariableName(7, "DORIS", "root_password"))
+                .thenReturn(variable("root_password", "bad-root"), variable("root_password", "good-root"));
+        OtelCredentialService credentials = mock(OtelCredentialService.class);
+        when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
+        DorisAdminReaderFactory.ConnectionVerifier verifier = dataSource -> {
+            if ("root".equals(dataSource.getUsername()) && "bad-root".equals(dataSource.getPassword())) {
+                return false;
+            }
+            return true;
+        };
+        DorisAdminReaderFactory factory = new DorisAdminReaderFactory(
+                roles, variables, credentials, noExternal(), verifier);
+
+        DorisAdminReaderFactory.DorisAdminConnection degraded = factory.create(7);
+        HikariDataSource oldReaderPool = factory.dataSourceForTest(7);
+        DorisAdminReaderFactory.DorisAdminConnection root = factory.create(7);
+
+        assertThat(degraded.username()).isEqualTo("otel_reader");
+        assertThat(degraded.degraded()).isTrue();
+        assertThat(root.username()).isEqualTo("root");
+        assertThat(root.degraded()).isFalse();
+        assertThat(oldReaderPool.isClosed()).isTrue();
+        assertThat(factory.poolSizeForTest()).isEqualTo(1);
+    }
+
+    @Test
+    void readerFailureIsReportedAsSafeConnectionFailure() {
+        ClusterServiceRoleInstanceService roles = mock(ClusterServiceRoleInstanceService.class);
+        ClusterVariableService variables = mock(ClusterVariableService.class);
+        when(roles.getServiceRoleInstanceListByClusterIdAndRoleName(7, "DorisFE"))
+                .thenReturn(List.of(role("ddh-01", ServiceRoleState.RUNNING)));
+        OtelCredentialService credentials = mock(OtelCredentialService.class);
+        when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
+        DorisAdminReaderFactory factory = factory(roles, variables, noExternal(), dataSource -> false);
+
+        assertThatThrownBy(() -> factory.create(7))
+                .isInstanceOf(DorisAdminReaderFactory.DorisConnectionException.class)
+                .hasMessage("Doris connection unavailable");
+    }
+
+    private static DorisAdminReaderFactory factory(ClusterServiceRoleInstanceService roles,
+                                                   ClusterVariableService variables,
+                                                   ExternalOtelDatasourceProvider provider,
+                                                   DorisAdminReaderFactory.ConnectionVerifier verifier) {
+        OtelCredentialService credentials = mock(OtelCredentialService.class);
+        when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
+        return new DorisAdminReaderFactory(roles, variables, credentials, provider, verifier);
+    }
+
+    private static ExternalOtelDatasourceProvider noExternal() {
+        ExternalOtelDatasourceProvider provider = mock(ExternalOtelDatasourceProvider.class);
+        when(provider.find(anyInt())).thenReturn(Optional.empty());
+        return provider;
+    }
+
+    private static ExternalOtelDatasourceProvider external(String host, String port) {
+        ExternalOtelDatasourceProvider provider = mock(ExternalOtelDatasourceProvider.class);
+        when(provider.find(anyInt())).thenReturn(
+                Optional.of(new ExternalOtelDatasourceProvider.ExternalDatasource(host, port)));
+        return provider;
+    }
+
+    private static ClusterServiceRoleInstanceEntity role(String hostname, ServiceRoleState state) {
+        ClusterServiceRoleInstanceEntity role = new ClusterServiceRoleInstanceEntity();
+        role.setHostname(hostname);
+        role.setServiceRoleState(state);
+        return role;
+    }
+
+    private static ClusterVariable variable(String name, String value) {
+        ClusterVariable variable = new ClusterVariable();
+        variable.setVariableName(name);
+        variable.setVariableValue(value);
+        return variable;
+    }
+}

--- a/datasophon-api/src/test/java/com/datasophon/api/doris/DorisAdminReaderFactoryTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/doris/DorisAdminReaderFactoryTest.java
@@ -49,6 +49,8 @@ import com.zaxxer.hikari.HikariDataSource;
 
 class DorisAdminReaderFactoryTest {
 
+    private static final String V4_VERSION = "Doris version doris-4.1.3-rc02-7126cf65d96";
+
     @Test
     void physicalClusterUsesRootAndExposesActualEndpoint() {
         ClusterServiceRoleInstanceService roles = mock(ClusterServiceRoleInstanceService.class);
@@ -60,7 +62,7 @@ class DorisAdminReaderFactoryTest {
         when(variables.getVariableByVariableName(7, "DORIS", "root_password"))
                 .thenReturn(variable("root_password", "root-secret"));
 
-        DorisAdminReaderFactory factory = factory(roles, variables, noExternal(), dataSource -> true);
+        DorisAdminReaderFactory factory = factory(roles, variables, noExternal(), dataSource -> V4_VERSION);
         DorisAdminReaderFactory.DorisAdminConnection connection = factory.create(7);
 
         assertThat(connection.username()).isEqualTo("root");
@@ -81,7 +83,7 @@ class DorisAdminReaderFactoryTest {
         OtelCredentialService credentials = mock(OtelCredentialService.class);
         when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
         DorisAdminReaderFactory factory = new DorisAdminReaderFactory(
-                roles, variables, credentials, provider, dataSource -> true);
+                roles, variables, credentials, provider, dataSource -> V4_VERSION);
 
         DorisAdminReaderFactory.DorisAdminConnection connection = factory.create(7);
 
@@ -102,7 +104,7 @@ class DorisAdminReaderFactoryTest {
         OtelCredentialService credentials = mock(OtelCredentialService.class);
         when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
         DorisAdminReaderFactory factory = new DorisAdminReaderFactory(
-                roles, variables, credentials, noExternal(), dataSource -> true);
+                roles, variables, credentials, noExternal(), dataSource -> V4_VERSION);
 
         DorisAdminReaderFactory.DorisAdminConnection connection = factory.create(7);
 
@@ -123,11 +125,11 @@ class DorisAdminReaderFactoryTest {
                 .thenReturn(variable("root_password", "bad-root"), variable("root_password", "good-root"));
         OtelCredentialService credentials = mock(OtelCredentialService.class);
         when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
-        DorisAdminReaderFactory.ConnectionVerifier verifier = dataSource -> {
+        DorisAdminReaderFactory.VersionProbe verifier = dataSource -> {
             if ("root".equals(dataSource.getUsername()) && "bad-root".equals(dataSource.getPassword())) {
-                return false;
+                return null;
             }
-            return true;
+            return V4_VERSION;
         };
         DorisAdminReaderFactory factory = new DorisAdminReaderFactory(
                 roles, variables, credentials, noExternal(), verifier);
@@ -152,7 +154,7 @@ class DorisAdminReaderFactoryTest {
                 .thenReturn(List.of(role("ddh-01", ServiceRoleState.RUNNING)));
         OtelCredentialService credentials = mock(OtelCredentialService.class);
         when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
-        DorisAdminReaderFactory factory = factory(roles, variables, noExternal(), dataSource -> false);
+        DorisAdminReaderFactory factory = factory(roles, variables, noExternal(), dataSource -> null);
 
         assertThatThrownBy(() -> factory.create(7))
                 .isInstanceOf(DorisAdminReaderFactory.DorisConnectionException.class)
@@ -162,7 +164,7 @@ class DorisAdminReaderFactoryTest {
     private static DorisAdminReaderFactory factory(ClusterServiceRoleInstanceService roles,
                                                    ClusterVariableService variables,
                                                    ExternalOtelDatasourceProvider provider,
-                                                   DorisAdminReaderFactory.ConnectionVerifier verifier) {
+                                                   DorisAdminReaderFactory.VersionProbe verifier) {
         OtelCredentialService credentials = mock(OtelCredentialService.class);
         when(credentials.getOrCreate(7)).thenReturn(new OtelCredentials("collector", "reader-secret"));
         return new DorisAdminReaderFactory(roles, variables, credentials, provider, verifier);

--- a/datasophon-api/src/test/java/com/datasophon/api/doris/DorisVersionProfileTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/doris/DorisVersionProfileTest.java
@@ -1,0 +1,107 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.doris;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * 断言绑定到两个环境的 <b>实测</b> schema（2026-09-03）：
+ * 远端 K8s 存算分离 doris-3.0.8-rc01 Cloud Mode，与 ddh-01 doris-4.1.3-rc02。
+ */
+class DorisVersionProfileTest {
+
+    private static final String V3_COMMENT = "Doris version doris-3.0.8-rc01-09b0cc49a6 (Cloud Mode)";
+    private static final String V4_COMMENT = "Doris version doris-4.1.3-rc02-7126cf65d96";
+
+    @Test
+    void mapsMajorVersionFromVersionComment() {
+        assertThat(DorisVersionProfile.of("Doris version doris-2.1.11-rc01")).isEqualTo(DorisVersionProfile.V2);
+        assertThat(DorisVersionProfile.of(V3_COMMENT)).isEqualTo(DorisVersionProfile.V3);
+        assertThat(DorisVersionProfile.of(V4_COMMENT)).isEqualTo(DorisVersionProfile.V4);
+    }
+
+    @Test
+    void fallsBackToNewestKnownProfileForUnreadableVersion() {
+        assertThat(DorisVersionProfile.of("Doris version doris-5.0.0")).isEqualTo(DorisVersionProfile.V4);
+        assertThat(DorisVersionProfile.of("SomeVendorDB 1.2")).isEqualTo(DorisVersionProfile.V4);
+        assertThat(DorisVersionProfile.of(null)).isEqualTo(DorisVersionProfile.V4);
+        assertThat(DorisVersionProfile.of("")).isEqualTo(DorisVersionProfile.V4);
+    }
+
+    @Test
+    void twoPointXIsReservedAndUnsupported() {
+        assertThat(DorisVersionProfile.V2.supported()).isFalse();
+        assertThat(DorisVersionProfile.V2.activeQueriesSql()).isNull();
+        assertThat(DorisVersionProfile.V3.supported()).isTrue();
+        assertThat(DorisVersionProfile.V4.supported()).isTrue();
+    }
+
+    @Test
+    void threePointXOmitsColumnsThatDoNotExistThere() {
+        // 3.0.8 实测：active_queries 无 USER，backend_active_tasks 无 WORKLOAD_GROUP_ID / 无 SPILL_*。
+        assertThat(DorisVersionProfile.V3.activeQueriesSql()).doesNotContain("USER");
+        assertThat(DorisVersionProfile.V3.backendActiveTasksSql())
+                .doesNotContain("WORKLOAD_GROUP_ID")
+                .doesNotContain("SPILL_");
+        assertThat(DorisVersionProfile.V3.unsupportedFields())
+                .containsExactlyInAnyOrder("spillBytes", "loadWorkloadGroup");
+    }
+
+    @Test
+    void fourPointXKeepsTheFullColumnSet() {
+        assertThat(DorisVersionProfile.V4.activeQueriesSql()).contains("`USER`");
+        assertThat(DorisVersionProfile.V4.backendActiveTasksSql())
+                .contains("WORKLOAD_GROUP_ID")
+                .contains("SPILL_WRITE_BYTES_TO_LOCAL_STORAGE")
+                .contains("SPILL_READ_BYTES_FROM_LOCAL_STORAGE");
+        assertThat(DorisVersionProfile.V4.unsupportedFields()).isEmpty();
+    }
+
+    @Test
+    void processlistColumnsAreAliasedToOneNamingAcrossVersions() {
+        // 3.x 用 QUERY_ID/HOST/USER，4.x 用 QueryId/Host/User；别名让下游只认一套 key。
+        assertThat(DorisVersionProfile.V3.processlistSql())
+                .contains("QUERY_ID AS QueryId")
+                .contains("HOST AS Host")
+                .contains("`USER` AS `User`");
+        assertThat(DorisVersionProfile.V4.processlistSql())
+                .contains("QueryId")
+                .contains("Host")
+                .contains("`User`");
+    }
+
+    @Test
+    void everySupportedProfileFiltersProcesslistAndBoundsRowCount() {
+        for (DorisVersionProfile profile : DorisVersionProfile.values()) {
+            if (!profile.supported()) {
+                continue;
+            }
+            assertThat(profile.processlistSql()).contains("WHERE Command = 'Query'");
+            assertThat(profile.activeQueriesSql()).endsWith("LIMIT " + DorisVersionProfile.SOURCE_LIMIT);
+            assertThat(profile.backendActiveTasksSql()).endsWith("LIMIT " + DorisVersionProfile.SOURCE_LIMIT);
+            assertThat(profile.processlistSql()).endsWith("LIMIT " + DorisVersionProfile.SOURCE_LIMIT);
+        }
+    }
+}

--- a/datasophon-api/src/test/java/com/datasophon/api/security/SystemAdminGuardTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/security/SystemAdminGuardTest.java
@@ -22,6 +22,7 @@
 
 package com.datasophon.api.security;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;

--- a/datasophon-api/src/test/java/com/datasophon/api/security/SystemAdminGuardTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/security/SystemAdminGuardTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 
 import com.datasophon.api.enums.Status;
 import com.datasophon.common.Constants;
@@ -36,8 +37,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.web.server.ResponseStatusException;
 
 import jakarta.servlet.http.HttpServletRequest;
-
-import static org.springframework.http.HttpStatus.FORBIDDEN;
 
 class SystemAdminGuardTest {
 

--- a/datasophon-api/src/test/java/com/datasophon/api/security/SystemAdminGuardTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/security/SystemAdminGuardTest.java
@@ -1,0 +1,94 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.security;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datasophon.api.enums.Status;
+import com.datasophon.common.Constants;
+import com.datasophon.dao.entity.UserInfoEntity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
+class SystemAdminGuardTest {
+
+    private HttpServletRequest request;
+    private SystemAdminGuard guard;
+
+    @BeforeEach
+    void setUp() {
+        request = mock(HttpServletRequest.class);
+        guard = new SystemAdminGuard(request);
+    }
+
+    @Test
+    void systemAdminIsAllowed() {
+        givenUser(1);
+
+        assertThatCode(() -> guard.requireAdmin()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void clusterManagerIsRejectedWithForbidden() {
+        assertForbiddenForUser(2);
+    }
+
+    @Test
+    void ordinaryUserIsRejectedWithForbidden() {
+        assertForbiddenForUser(3);
+    }
+
+    @Test
+    void missingUserIsRejectedWithForbidden() {
+        assertThatThrownBy(() -> guard.requireAdmin())
+                .isInstanceOfSatisfying(ResponseStatusException.class, exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(FORBIDDEN);
+                    assertThat(exception.getReason()).isEqualTo(Status.USER_NO_OPERATION_PERM.getMsg());
+                });
+    }
+
+    private void assertForbiddenForUser(int userId) {
+        givenUser(userId);
+
+        assertThatThrownBy(() -> guard.requireAdmin())
+                .isInstanceOfSatisfying(ResponseStatusException.class, exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(FORBIDDEN);
+                    assertThat(exception.getReason()).isEqualTo(Status.USER_NO_OPERATION_PERM.getMsg());
+                });
+    }
+
+    private void givenUser(int id) {
+        UserInfoEntity user = new UserInfoEntity();
+        user.setId(id);
+        when(request.getAttribute(Constants.SESSION_USER)).thenReturn(user);
+    }
+}

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskFacadeTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskFacadeTest.java
@@ -24,6 +24,8 @@ package com.datasophon.api.service.doris;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -36,7 +38,6 @@ import com.datasophon.api.controller.v2.V2ApiExceptionHandler;
 import com.datasophon.api.doris.DorisAdminReaderFactory;
 import com.datasophon.api.dto.ApiResponse;
 import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
-import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
 import com.datasophon.api.enums.Status;
 import com.datasophon.api.security.SystemAdminGuard;
 
@@ -67,7 +68,7 @@ class DorisActiveTaskFacadeTest {
     void preservesForbiddenStatusFromTheAdminGuard() {
         ResponseStatusException forbidden = new ResponseStatusException(
                 FORBIDDEN, Status.USER_NO_OPERATION_PERM.getMsg());
-        when(adminGuard.requireAdmin()).thenThrow(forbidden);
+        doThrow(forbidden).when(adminGuard).requireAdmin();
 
         assertThatThrownBy(() -> facade.query(7, 8, null)).isSameAs(forbidden);
         verify(instanceValidator, never()).requireDorisInstance(7, 8);
@@ -101,8 +102,9 @@ class DorisActiveTaskFacadeTest {
         when(queryService.query(7, connection, new DorisActiveTaskQueryDTO()))
                 .thenThrow(new RuntimeException("jdbc:mysql://user:password@fe:9030/secret"));
 
-        ResponseStatusException exception = (ResponseStatusException) assertThatThrownBy(
-                () -> facade.query(7, 8, null)).isInstanceOf(ResponseStatusException.class).actual();
+        Throwable thrown = catchThrowable(() -> facade.query(7, 8, null));
+        assertThat(thrown).isInstanceOf(ResponseStatusException.class);
+        ResponseStatusException exception = (ResponseStatusException) thrown;
         assertThat(exception.getStatusCode()).isEqualTo(BAD_GATEWAY);
         assertThat(exception.getReason()).isEqualTo(Status.DORIS_CONNECT_FAILED.getMsg());
 

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskFacadeTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskFacadeTest.java
@@ -1,0 +1,114 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.service.doris;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_GATEWAY;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
+
+import com.datasophon.api.controller.v2.V2ApiExceptionHandler;
+import com.datasophon.api.doris.DorisAdminReaderFactory;
+import com.datasophon.api.dto.ApiResponse;
+import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
+import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
+import com.datasophon.api.enums.Status;
+import com.datasophon.api.security.SystemAdminGuard;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.web.server.ResponseStatusException;
+
+class DorisActiveTaskFacadeTest {
+
+    private final SystemAdminGuard adminGuard = mock(SystemAdminGuard.class);
+    private final DorisServiceInstanceValidator instanceValidator = mock(DorisServiceInstanceValidator.class);
+    private final DorisAdminReaderFactory readerFactory = mock(DorisAdminReaderFactory.class);
+    private final DorisActiveTaskQueryService queryService = mock(DorisActiveTaskQueryService.class);
+    private final DorisActiveTaskFacade facade = new DorisActiveTaskFacade(
+            adminGuard, instanceValidator, readerFactory, queryService);
+    private final DorisAdminReaderFactory.DorisAdminConnection connection =
+            new DorisAdminReaderFactory.DorisAdminConnection(
+                    mock(JdbcClient.class), "ddh-01", 9030, "root", false, null);
+
+    @BeforeEach
+    void setUp() {
+        when(readerFactory.create(7)).thenReturn(connection);
+    }
+
+    @Test
+    void preservesForbiddenStatusFromTheAdminGuard() {
+        ResponseStatusException forbidden = new ResponseStatusException(
+                FORBIDDEN, Status.USER_NO_OPERATION_PERM.getMsg());
+        when(adminGuard.requireAdmin()).thenThrow(forbidden);
+
+        assertThatThrownBy(() -> facade.query(7, 8, null)).isSameAs(forbidden);
+        verify(instanceValidator, never()).requireDorisInstance(7, 8);
+        verify(readerFactory, never()).create(7);
+    }
+
+    @Test
+    void preservesBadRequestStatusFromTheInstanceValidator() {
+        ResponseStatusException badRequest = new ResponseStatusException(
+                org.springframework.http.HttpStatus.BAD_REQUEST, Status.INSTANCE_MISMATCH.getMsg());
+        when(instanceValidator.requireDorisInstance(7, 8)).thenThrow(badRequest);
+
+        assertThatThrownBy(() -> facade.query(7, 8, null)).isSameAs(badRequest);
+        verify(readerFactory, never()).create(7);
+    }
+
+    @Test
+    void mapsMissingCapabilityToNotImplemented() {
+        when(queryService.query(7, connection, new DorisActiveTaskQueryDTO()))
+                .thenThrow(new DorisActiveTaskQueryService.CapabilityUnsupportedException());
+
+        assertThatThrownBy(() -> facade.query(7, 8, null))
+                .isInstanceOfSatisfying(ResponseStatusException.class, exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(NOT_IMPLEMENTED);
+                    assertThat(exception.getReason()).isEqualTo(Status.DORIS_CAPABILITY_UNSUPPORTED.getMsg());
+                });
+    }
+
+    @Test
+    void mapsConnectionFailureToSafeBadGatewayResponse() {
+        when(queryService.query(7, connection, new DorisActiveTaskQueryDTO()))
+                .thenThrow(new RuntimeException("jdbc:mysql://user:password@fe:9030/secret"));
+
+        ResponseStatusException exception = (ResponseStatusException) assertThatThrownBy(
+                () -> facade.query(7, 8, null)).isInstanceOf(ResponseStatusException.class).actual();
+        assertThat(exception.getStatusCode()).isEqualTo(BAD_GATEWAY);
+        assertThat(exception.getReason()).isEqualTo(Status.DORIS_CONNECT_FAILED.getMsg());
+
+        ResponseEntity<ApiResponse<Void>> response = new V2ApiExceptionHandler().handleException(exception);
+        assertThat(response.getStatusCode()).isEqualTo(BAD_GATEWAY);
+        assertThat(response.getBody().getErrorMessage()).isEqualTo(Status.DORIS_CONNECT_FAILED.getMsg());
+        assertThat(response.getBody().getErrorMessage()).doesNotContain("jdbc:");
+    }
+}

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskFacadeTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskFacadeTest.java
@@ -25,7 +25,9 @@ package com.datasophon.api.service.doris;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -88,7 +90,7 @@ class DorisActiveTaskFacadeTest {
 
     @Test
     void mapsMissingCapabilityToNotImplemented() {
-        when(queryService.query(7, connection, new DorisActiveTaskQueryDTO()))
+        when(queryService.query(eq(7), eq(connection), eq(new DorisActiveTaskQueryDTO()), anyLong()))
                 .thenThrow(new DorisActiveTaskQueryService.CapabilityUnsupportedException());
 
         assertThatThrownBy(() -> facade.query(7, 8, null))
@@ -100,7 +102,7 @@ class DorisActiveTaskFacadeTest {
 
     @Test
     void mapsConnectionFailureToSafeBadGatewayResponse() {
-        when(queryService.query(7, connection, new DorisActiveTaskQueryDTO()))
+        when(queryService.query(eq(7), eq(connection), eq(new DorisActiveTaskQueryDTO()), anyLong()))
                 .thenThrow(new RuntimeException("jdbc:mysql://user:password@fe:9030/secret"));
 
         Throwable thrown = catchThrowable(() -> facade.query(7, 8, null));
@@ -119,7 +121,7 @@ class DorisActiveTaskFacadeTest {
     void delegatesDetailQueryAfterApplyingTheSameGuards() {
         DorisActiveTaskVO detail = new DorisActiveTaskVO();
         detail.setTaskId("q-1");
-        when(queryService.queryDetail(7, connection, "q-1")).thenReturn(detail);
+        when(queryService.queryDetail(eq(7), eq(connection), eq("q-1"), anyLong())).thenReturn(detail);
 
         assertThat(facade.queryDetail(7, 8, "q-1")).isSameAs(detail);
         verify(adminGuard).requireAdmin();

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskFacadeTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskFacadeTest.java
@@ -38,6 +38,7 @@ import com.datasophon.api.controller.v2.V2ApiExceptionHandler;
 import com.datasophon.api.doris.DorisAdminReaderFactory;
 import com.datasophon.api.dto.ApiResponse;
 import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
+import com.datasophon.api.dto.v2.DorisActiveTaskVO;
 import com.datasophon.api.enums.Status;
 import com.datasophon.api.security.SystemAdminGuard;
 
@@ -112,5 +113,16 @@ class DorisActiveTaskFacadeTest {
         assertThat(response.getStatusCode()).isEqualTo(BAD_GATEWAY);
         assertThat(response.getBody().getErrorMessage()).isEqualTo(Status.DORIS_CONNECT_FAILED.getMsg());
         assertThat(response.getBody().getErrorMessage()).doesNotContain("jdbc:");
+    }
+
+    @Test
+    void delegatesDetailQueryAfterApplyingTheSameGuards() {
+        DorisActiveTaskVO detail = new DorisActiveTaskVO();
+        detail.setTaskId("q-1");
+        when(queryService.queryDetail(7, connection, "q-1")).thenReturn(detail);
+
+        assertThat(facade.queryDetail(7, 8, "q-1")).isSameAs(detail);
+        verify(adminGuard).requireAdmin();
+        verify(instanceValidator).requireDorisInstance(7, 8);
     }
 }

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
@@ -38,7 +38,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.simple.JdbcClient;
@@ -195,7 +194,7 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void marksAnySourceAtExactlyTwentyThousandRows() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        for (int index = 0; index < DorisActiveTaskQueryService.SOURCE_LIMIT; index++) {
+        for (int index = 0; index < DorisVersionProfile.SOURCE_LIMIT; index++) {
             rows.get(DorisVersionProfile.V4.backendActiveTasksSql()).add(
                     row("QUERY_ID", "load-" + index, "QUERY_TYPE", "LOAD"));
         }
@@ -208,7 +207,7 @@ class DorisActiveTaskQueryServiceTest {
         Map<String, List<Map<String, Object>>> rows = baseRows();
         AtomicInteger calls = new AtomicInteger();
         long[] now = {0L};
-        DorisActiveTaskQueryService service = new DorisActiveTaskQueryService(null, (client, sql) -> {
+        DorisActiveTaskQueryService service = new DorisActiveTaskQueryService(null, (client, sql, args) -> {
             calls.incrementAndGet();
             now[0] = DorisActiveTaskQueryService.REQUEST_TIMEOUT_MS * 1_000_000L;
             return rows.getOrDefault(sql, List.of());
@@ -223,7 +222,7 @@ class DorisActiveTaskQueryServiceTest {
     void reportsOptionalSourceFailureWithoutDroppingMainRows() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
         rows.get(DorisVersionProfile.V4.activeQueriesSql()).add(row("QUERY_ID", "q1"));
-        BiFunction<JdbcClient, String, List<Map<String, Object>>> source = (client, sql) -> {
+        DorisActiveTaskQueryService.RowQuery source = (client, sql, args) -> {
             if (DorisVersionProfile.V4.processlistSql().equals(sql)) {
                 throw new IllegalStateException("processlist unavailable");
             }
@@ -239,7 +238,7 @@ class DorisActiveTaskQueryServiceTest {
 
     @Test
     void rejectsMissingRequiredTableAsCapabilityError() {
-        BiFunction<JdbcClient, String, List<Map<String, Object>>> source = (client, sql) -> {
+        DorisActiveTaskQueryService.RowQuery source = (client, sql, args) -> {
             throw new IllegalStateException("Table information_schema.active_queries doesn't exist");
         };
 
@@ -268,7 +267,7 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void rejectsTwoPointXBeforeIssuingAnyStatement() {
         AtomicInteger calls = new AtomicInteger();
-        BiFunction<JdbcClient, String, List<Map<String, Object>>> source = (client, sql) -> {
+        DorisActiveTaskQueryService.RowQuery source = (client, sql, args) -> {
             calls.incrementAndGet();
             return List.of();
         };
@@ -305,8 +304,33 @@ class DorisActiveTaskQueryServiceTest {
         assertThat(onFour.getUnsupportedFields()).isEmpty();
     }
 
+    @Test
+    void detailPushesTaskIdIntoSqlAsBoundParameter() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisVersionProfile.V4.activeQueriesSql()).add(row("QUERY_ID", "q1", "SQL", "select 1"));
+        Map<String, Object[]> issued = new HashMap<>();
+        DorisActiveTaskQueryService.RowQuery capturing = (client, sql, args) -> {
+            issued.put(sql, args);
+            return rows.getOrDefault(sql, List.of());
+        };
+
+        new DorisActiveTaskQueryService(null, capturing).queryDetail(7, connection(false), "q1");
+
+        // 两张会随负载涨到 SOURCE_LIMIT 的表必须走带 WHERE 的变体，且 taskId 以绑定参数下发，
+        // 不拼进 SQL 文本（3.0.8 与 4.1.3 均实测 WHERE QUERY_ID 生效）。
+        assertThat(issued).containsKeys(DorisVersionProfile.V4.activeQueriesByIdSql(),
+                DorisVersionProfile.V4.backendActiveTasksByIdSql());
+        assertThat(issued).doesNotContainKeys(DorisVersionProfile.V4.activeQueriesSql(),
+                DorisVersionProfile.V4.backendActiveTasksSql());
+        assertThat(issued.get(DorisVersionProfile.V4.activeQueriesByIdSql())).containsExactly("q1");
+        assertThat(issued.get(DorisVersionProfile.V4.backendActiveTasksByIdSql())).containsExactly("q1");
+        assertThat(DorisVersionProfile.V4.activeQueriesByIdSql()).doesNotContain("q1");
+        // 侧查表行数由连接数/配置决定（实测 3.x 1 行、4.x 6 行），不下推，故仍是无参全量。
+        assertThat(issued.get(DorisVersionProfile.V4.processlistSql())).isEmpty();
+    }
+
     private static DorisActiveTaskQueryService service(Map<String, List<Map<String, Object>>> rows) {
-        return new DorisActiveTaskQueryService(null, (client, sql) -> rows.getOrDefault(sql, List.of()));
+        return new DorisActiveTaskQueryService(null, (client, sql, args) -> rows.getOrDefault(sql, List.of()));
     }
 
     private static DorisAdminReaderFactory.DorisAdminConnection connection(boolean degraded) {
@@ -326,8 +350,14 @@ class DorisActiveTaskQueryServiceTest {
 
     private static Map<String, List<Map<String, Object>>> baseRows(DorisVersionProfile profile) {
         Map<String, List<Map<String, Object>>> rows = new HashMap<>();
-        rows.put(profile.activeQueriesSql(), new ArrayList<>());
-        rows.put(profile.backendActiveTasksSql(), new ArrayList<>());
+        List<Map<String, Object>> activeQueries = new ArrayList<>();
+        List<Map<String, Object>> backendTasks = new ArrayList<>();
+        rows.put(profile.activeQueriesSql(), activeQueries);
+        rows.put(profile.backendActiveTasksSql(), backendTasks);
+        // 详情路径走带 QUERY_ID 占位符的变体，指向同一份 fixture：假数据源不模拟 SQL 过滤，
+        // 收敛到单条仍由服务自身的 detailTaskId 判断完成。
+        rows.put(profile.activeQueriesByIdSql(), activeQueries);
+        rows.put(profile.backendActiveTasksByIdSql(), backendTasks);
         rows.put(profile.processlistSql(), new ArrayList<>());
         rows.put(DorisActiveTaskQueryService.WORKLOAD_GROUPS_SQL, new ArrayList<>());
         return rows;

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
@@ -31,6 +31,7 @@ import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
 import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
 import com.datasophon.api.dto.v2.DorisActiveTaskVO;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -144,7 +145,13 @@ class DorisActiveTaskQueryServiceTest {
         assertThat(task.getSql().getBytes(java.nio.charset.StandardCharsets.UTF_8).length)
                 .isLessThanOrEqualTo(DorisActiveTaskQueryService.LIST_SQL_LIMIT_BYTES);
         assertThat(task.getSql().charAt(task.getSql().length() - 1)).isEqualTo('中');
-        assertThat(task.getTruncated()).isTrue();
+        assertThat(task.getDetailSql()).isNull();
+
+        DorisActiveTaskVO detailTask = service(rows).queryDetail(7, connection(false), "q1");
+        assertThat(detailTask.getDetailSql()).isEqualTo(sql);
+        assertThat(detailTask.getDetailSql().getBytes(StandardCharsets.UTF_8).length)
+                .isLessThanOrEqualTo(DorisActiveTaskQueryService.DETAIL_SQL_LIMIT_BYTES);
+        assertThat(detailTask.getTruncated()).isFalse();
         assertThat(detail.truncated()).isFalse();
     }
 

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
@@ -1,0 +1,236 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.service.doris;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.datasophon.api.doris.DorisAdminReaderFactory;
+import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
+import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
+import com.datasophon.api.dto.v2.DorisActiveTaskVO;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.simple.JdbcClient;
+
+class DorisActiveTaskQueryServiceTest {
+
+    @Test
+    void fullOuterJoinKeepsQueryLoadAndResourceOnlySelect() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row("QUERY_ID", "q-meta", "USER", "alice"));
+        rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).addAll(List.of(
+                row("QUERY_ID", "q-meta", "QUERY_TYPE", "SELECT"),
+                row("QUERY_ID", "load-1", "QUERY_TYPE", "LOAD"),
+                row("QUERY_ID", "select-only", "QUERY_TYPE", "SELECT")));
+
+        DorisActiveTaskResponseVO response = service(rows).query(7, connection(false), null);
+
+        assertThat(response.getTasks()).extracting(DorisActiveTaskVO::getTaskId)
+                .containsExactlyInAnyOrder("q-meta", "load-1", "select-only");
+        assertThat(response.getTasks()).filteredOn(task -> task.getTaskId().equals("load-1"))
+                .singleElement().extracting(DorisActiveTaskVO::getType).isEqualTo("LOAD");
+        assertThat(response.getTasks()).filteredOn(task -> task.getTaskId().equals("select-only"))
+                .singleElement().extracting(DorisActiveTaskVO::getType).isEqualTo("QUERY");
+    }
+
+    @Test
+    void sumsCurrentMemoryButUsesMaximumPeakMemory() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).addAll(List.of(
+                row("QUERY_ID", "q1", "QUERY_TYPE", "SELECT", "CURRENT_USED_MEMORY_BYTES", 10L,
+                        "BE_PEAK_MEMORY_BYTES", 100L),
+                row("QUERY_ID", "q1", "QUERY_TYPE", "SELECT", "CURRENT_USED_MEMORY_BYTES", 20L,
+                        "BE_PEAK_MEMORY_BYTES", 80L)));
+
+        DorisActiveTaskVO task = service(rows).query(7, connection(false), null).getTasks().get(0);
+
+        assertThat(task.getCurrentMemoryBytes()).isEqualTo(30L);
+        assertThat(task.getPeakMemoryBytes()).isEqualTo(100L).isNotEqualTo(180L);
+    }
+
+    @Test
+    void loadScanBytesAndStartTimeAreNotApplicable() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).add(
+                row("QUERY_ID", "load-1", "QUERY_TYPE", "LOAD", "TASK_TIME_MS", 4_000L,
+                        "SCAN_BYTES", 0L));
+
+        DorisActiveTaskVO task = service(rows).query(7, connection(false), null).getTasks().get(0);
+
+        assertThat(task.getScanBytes()).isNull();
+        assertThat(task.getStartTime()).isNull();
+        assertThat(task.getElapsedMs()).isEqualTo(4_000L);
+    }
+
+    @Test
+    void blankQueryStatusAndQueueTimesBecomeMissing() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row(
+                "QUERY_ID", "q1", "QUERY_STATUS", "", "QUEUE_START_TIME", "", "QUEUE_END_TIME", " "));
+
+        DorisActiveTaskVO task = service(rows).query(7, connection(false), null).getTasks().get(0);
+
+        assertThat(task.getQueryStatus()).isNull();
+        assertThat(task.getQueueStartTime()).isNull();
+        assertThat(task.getQueueEndTime()).isNull();
+    }
+
+    @Test
+    void processlistOnlyUsesQueryRows() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row("QUERY_ID", "q1"));
+        rows.get(DorisActiveTaskQueryService.PROCESSLIST_SQL).addAll(List.of(
+                row("QueryId", "q1", "Command", "Sleep", "Host", "stale-host"),
+                row("QueryId", "q1", "Command", "Query", "Host", "real-host")));
+
+        DorisActiveTaskVO task = service(rows).query(7, connection(false), null).getTasks().get(0);
+
+        assertThat(task.getClientAddress()).isEqualTo("real-host");
+    }
+
+    @Test
+    void truncatesUtf8SqlAtListAndDetailBoundaries() {
+        String sql = "中".repeat(600);
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row("QUERY_ID", "q1", "SQL", sql));
+
+        DorisActiveTaskVO task = service(rows).query(7, connection(false), null).getTasks().get(0);
+        DorisActiveTaskQueryService.TruncatedText detail = DorisActiveTaskQueryService.truncateSql(
+                sql, DorisActiveTaskQueryService.DETAIL_SQL_LIMIT_BYTES);
+
+        assertThat(task.getSql().getBytes(java.nio.charset.StandardCharsets.UTF_8).length)
+                .isLessThanOrEqualTo(DorisActiveTaskQueryService.LIST_SQL_LIMIT_BYTES);
+        assertThat(task.getSql().charAt(task.getSql().length() - 1)).isEqualTo('中');
+        assertThat(task.getTruncated()).isTrue();
+        assertThat(detail.truncated()).isFalse();
+    }
+
+    @Test
+    void filtersBeforeTheTwoThousandRowLimit() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        for (int index = 0; index < DorisActiveTaskQueryService.RESPONSE_LIMIT + 1; index++) {
+            rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(
+                    row("QUERY_ID", "q-" + index, "USER", index == 2_000 ? "target" : "other"));
+        }
+        DorisActiveTaskQueryDTO filter = new DorisActiveTaskQueryDTO();
+        filter.setUser("TARGET");
+
+        DorisActiveTaskResponseVO response = service(rows).query(7, connection(false), filter);
+
+        assertThat(response.getTotal()).isEqualTo(1);
+        assertThat(response.getReturned()).isEqualTo(1);
+        assertThat(response.isTruncated()).isFalse();
+        assertThat(response.getTasks()).extracting(DorisActiveTaskVO::getTaskId).containsExactly("q-2000");
+    }
+
+    @Test
+    void sortsByMemoryThenElapsedThenId() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).addAll(List.of(
+                row("QUERY_ID", "b", "QUERY_TYPE", "LOAD", "CURRENT_USED_MEMORY_BYTES", 10L,
+                        "TASK_TIME_MS", 2L),
+                row("QUERY_ID", "a", "QUERY_TYPE", "LOAD", "CURRENT_USED_MEMORY_BYTES", 10L,
+                        "TASK_TIME_MS", 2L),
+                row("QUERY_ID", "c", "QUERY_TYPE", "LOAD", "CURRENT_USED_MEMORY_BYTES", 20L,
+                        "TASK_TIME_MS", 1L)));
+
+        DorisActiveTaskResponseVO response = service(rows).query(7, connection(false), null);
+
+        assertThat(response.getTasks()).extracting(DorisActiveTaskVO::getTaskId)
+                .containsExactly("c", "a", "b");
+    }
+
+    @Test
+    void marksAnySourceAtExactlyTwentyThousandRows() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        for (int index = 0; index < DorisActiveTaskQueryService.SOURCE_LIMIT; index++) {
+            rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).add(
+                    row("QUERY_ID", "load-" + index, "QUERY_TYPE", "LOAD"));
+        }
+
+        assertThat(service(rows).query(7, connection(false), null).isSourceTruncated()).isTrue();
+    }
+
+    @Test
+    void reportsOptionalSourceFailureWithoutDroppingMainRows() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row("QUERY_ID", "q1"));
+        BiFunction<JdbcClient, String, List<Map<String, Object>>> source = (client, sql) -> {
+            if (DorisActiveTaskQueryService.PROCESSLIST_SQL.equals(sql)) {
+                throw new IllegalStateException("processlist unavailable");
+            }
+            return rows.get(sql);
+        };
+
+        DorisActiveTaskResponseVO response = new DorisActiveTaskQueryService(null, source)
+                .query(7, connection(false), null);
+
+        assertThat(response.getTasks()).hasSize(1);
+        assertThat(response.getPartialFailures()).containsExactly("clientAddress");
+    }
+
+    @Test
+    void rejectsMissingRequiredTableAsCapabilityError() {
+        BiFunction<JdbcClient, String, List<Map<String, Object>>> source = (client, sql) -> {
+            throw new IllegalStateException("Table information_schema.active_queries doesn't exist");
+        };
+
+        assertThatThrownBy(() -> new DorisActiveTaskQueryService(null, source)
+                .query(7, connection(false), null))
+                .isInstanceOf(DorisActiveTaskQueryService.CapabilityUnsupportedException.class);
+    }
+
+    private static DorisActiveTaskQueryService service(Map<String, List<Map<String, Object>>> rows) {
+        return new DorisActiveTaskQueryService(null, (client, sql) -> rows.getOrDefault(sql, List.of()));
+    }
+
+    private static DorisAdminReaderFactory.DorisAdminConnection connection(boolean degraded) {
+        return new DorisAdminReaderFactory.DorisAdminConnection(
+                mock(JdbcClient.class), "ddh-01", 9030, "root", degraded, degraded ? "fallback" : null);
+    }
+
+    private static Map<String, List<Map<String, Object>>> baseRows() {
+        Map<String, List<Map<String, Object>>> rows = new HashMap<>();
+        rows.put(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL, new ArrayList<>());
+        rows.put(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL, new ArrayList<>());
+        rows.put(DorisActiveTaskQueryService.PROCESSLIST_SQL, new ArrayList<>());
+        rows.put(DorisActiveTaskQueryService.WORKLOAD_GROUPS_SQL, new ArrayList<>());
+        return rows;
+    }
+
+    private static Map<String, Object> row(Object... values) {
+        Map<String, Object> row = new HashMap<>();
+        for (int index = 0; index < values.length; index += 2) {
+            row.put(String.valueOf(values[index]), values[index + 1]);
+        }
+        return row;
+    }
+}

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 
 import org.junit.jupiter.api.Test;
@@ -199,6 +200,22 @@ class DorisActiveTaskQueryServiceTest {
         }
 
         assertThat(service(rows).query(7, connection(false), null).isSourceTruncated()).isTrue();
+    }
+
+    @Test
+    void enforcesOverallRequestDeadlineBetweenSourceQueries() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        AtomicInteger calls = new AtomicInteger();
+        long[] now = {0L};
+        DorisActiveTaskQueryService service = new DorisActiveTaskQueryService(null, (client, sql) -> {
+            calls.incrementAndGet();
+            now[0] = DorisActiveTaskQueryService.REQUEST_TIMEOUT_MS * 1_000_000L;
+            return rows.getOrDefault(sql, List.of());
+        }, () -> now[0]);
+
+        assertThatThrownBy(() -> service.query(7, connection(false), null))
+                .isInstanceOf(DorisActiveTaskQueryService.RequestTimeoutException.class);
+        assertThat(calls).hasValue(1);
     }
 
     @Test

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import com.datasophon.api.doris.DorisAdminReaderFactory;
+import com.datasophon.api.doris.DorisVersionProfile;
 import com.datasophon.api.dto.v2.DorisActiveTaskQueryDTO;
 import com.datasophon.api.dto.v2.DorisActiveTaskResponseVO;
 import com.datasophon.api.dto.v2.DorisActiveTaskVO;
@@ -47,8 +48,8 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void fullOuterJoinKeepsQueryLoadAndResourceOnlySelect() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row("QUERY_ID", "q-meta", "USER", "alice"));
-        rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).addAll(List.of(
+        rows.get(DorisVersionProfile.V4.activeQueriesSql()).add(row("QUERY_ID", "q-meta", "USER", "alice"));
+        rows.get(DorisVersionProfile.V4.backendActiveTasksSql()).addAll(List.of(
                 row("QUERY_ID", "q-meta", "QUERY_TYPE", "SELECT"),
                 row("QUERY_ID", "load-1", "QUERY_TYPE", "LOAD"),
                 row("QUERY_ID", "select-only", "QUERY_TYPE", "SELECT")));
@@ -66,7 +67,7 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void sumsCurrentMemoryButUsesMaximumPeakMemory() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).addAll(List.of(
+        rows.get(DorisVersionProfile.V4.backendActiveTasksSql()).addAll(List.of(
                 row("QUERY_ID", "q1", "QUERY_TYPE", "SELECT", "CURRENT_USED_MEMORY_BYTES", 10L,
                         "BE_PEAK_MEMORY_BYTES", 100L),
                 row("QUERY_ID", "q1", "QUERY_TYPE", "SELECT", "CURRENT_USED_MEMORY_BYTES", 20L,
@@ -81,7 +82,7 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void loadScanBytesAndStartTimeAreNotApplicable() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).add(
+        rows.get(DorisVersionProfile.V4.backendActiveTasksSql()).add(
                 row("QUERY_ID", "load-1", "QUERY_TYPE", "LOAD", "TASK_TIME_MS", 4_000L,
                         "SCAN_BYTES", 0L));
 
@@ -95,7 +96,7 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void blankQueryStatusAndQueueTimesBecomeMissing() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row(
+        rows.get(DorisVersionProfile.V4.activeQueriesSql()).add(row(
                 "QUERY_ID", "q1", "QUERY_STATUS", "", "QUEUE_START_TIME", "", "QUEUE_END_TIME", " "));
 
         DorisActiveTaskVO task = service(rows).query(7, connection(false), null).getTasks().get(0);
@@ -108,7 +109,7 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void queuedTypeFilterMatchesQueuedQueriesOnly() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).addAll(List.of(
+        rows.get(DorisVersionProfile.V4.activeQueriesSql()).addAll(List.of(
                 row("QUERY_ID", "queued", "QUERY_STATUS", "Queued"),
                 row("QUERY_ID", "running", "QUERY_STATUS", "RUNNING")));
         DorisActiveTaskQueryDTO filter = new DorisActiveTaskQueryDTO();
@@ -123,8 +124,8 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void processlistOnlyUsesQueryRows() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row("QUERY_ID", "q1"));
-        rows.get(DorisActiveTaskQueryService.PROCESSLIST_SQL).addAll(List.of(
+        rows.get(DorisVersionProfile.V4.activeQueriesSql()).add(row("QUERY_ID", "q1"));
+        rows.get(DorisVersionProfile.V4.processlistSql()).addAll(List.of(
                 row("QueryId", "q1", "Command", "Sleep", "Host", "stale-host"),
                 row("QueryId", "q1", "Command", "Query", "Host", "real-host")));
 
@@ -137,7 +138,7 @@ class DorisActiveTaskQueryServiceTest {
     void truncatesUtf8SqlAtListAndDetailBoundaries() {
         String sql = "中".repeat(600);
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row("QUERY_ID", "q1", "SQL", sql));
+        rows.get(DorisVersionProfile.V4.activeQueriesSql()).add(row("QUERY_ID", "q1", "SQL", sql));
 
         DorisActiveTaskVO task = service(rows).query(7, connection(false), null).getTasks().get(0);
         DorisActiveTaskQueryService.TruncatedText detail = DorisActiveTaskQueryService.truncateSql(
@@ -160,7 +161,7 @@ class DorisActiveTaskQueryServiceTest {
     void filtersBeforeTheTwoThousandRowLimit() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
         for (int index = 0; index < DorisActiveTaskQueryService.RESPONSE_LIMIT + 1; index++) {
-            rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(
+            rows.get(DorisVersionProfile.V4.activeQueriesSql()).add(
                     row("QUERY_ID", "q-" + index, "USER", index == 2_000 ? "target" : "other"));
         }
         DorisActiveTaskQueryDTO filter = new DorisActiveTaskQueryDTO();
@@ -177,7 +178,7 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void sortsByMemoryThenElapsedThenId() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).addAll(List.of(
+        rows.get(DorisVersionProfile.V4.backendActiveTasksSql()).addAll(List.of(
                 row("QUERY_ID", "b", "QUERY_TYPE", "LOAD", "CURRENT_USED_MEMORY_BYTES", 10L,
                         "TASK_TIME_MS", 2L),
                 row("QUERY_ID", "a", "QUERY_TYPE", "LOAD", "CURRENT_USED_MEMORY_BYTES", 10L,
@@ -195,7 +196,7 @@ class DorisActiveTaskQueryServiceTest {
     void marksAnySourceAtExactlyTwentyThousandRows() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
         for (int index = 0; index < DorisActiveTaskQueryService.SOURCE_LIMIT; index++) {
-            rows.get(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL).add(
+            rows.get(DorisVersionProfile.V4.backendActiveTasksSql()).add(
                     row("QUERY_ID", "load-" + index, "QUERY_TYPE", "LOAD"));
         }
 
@@ -221,9 +222,9 @@ class DorisActiveTaskQueryServiceTest {
     @Test
     void reportsOptionalSourceFailureWithoutDroppingMainRows() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
-        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row("QUERY_ID", "q1"));
+        rows.get(DorisVersionProfile.V4.activeQueriesSql()).add(row("QUERY_ID", "q1"));
         BiFunction<JdbcClient, String, List<Map<String, Object>>> source = (client, sql) -> {
-            if (DorisActiveTaskQueryService.PROCESSLIST_SQL.equals(sql)) {
+            if (DorisVersionProfile.V4.processlistSql().equals(sql)) {
                 throw new IllegalStateException("processlist unavailable");
             }
             return rows.get(sql);
@@ -247,6 +248,63 @@ class DorisActiveTaskQueryServiceTest {
                 .isInstanceOf(DorisActiveTaskQueryService.CapabilityUnsupportedException.class);
     }
 
+    @Test
+    void shortensKubernetesPodFqdnToPodAndNamespace() {
+        // 实测 3.0.8 Cloud Mode 报的就是这个 96 字符的 Pod FQDN。
+        String fqdn = "doris-disaggregated-cluster-fe-0"
+                + ".doris-disaggregated-cluster-fe-internal.doris.svc.cluster.local";
+        Map<String, List<Map<String, Object>>> rows = baseRows(DorisVersionProfile.V3);
+        rows.get(DorisVersionProfile.V3.activeQueriesSql()).addAll(List.of(
+                row("QUERY_ID", "on-k8s", "FRONTEND_INSTANCE", fqdn),
+                row("QUERY_ID", "on-metal", "FRONTEND_INSTANCE", "192.168.10.131")));
+
+        List<DorisActiveTaskVO> tasks = service(rows)
+                .query(7, connection(DorisVersionProfile.V3), null).getTasks();
+
+        assertThat(tasks).extracting(DorisActiveTaskVO::getFeHost)
+                .containsExactlyInAnyOrder("doris-disaggregated-cluster-fe-0.doris", "192.168.10.131");
+    }
+
+    @Test
+    void rejectsTwoPointXBeforeIssuingAnyStatement() {
+        AtomicInteger calls = new AtomicInteger();
+        BiFunction<JdbcClient, String, List<Map<String, Object>>> source = (client, sql) -> {
+            calls.incrementAndGet();
+            return List.of();
+        };
+
+        assertThatThrownBy(() -> new DorisActiveTaskQueryService(null, source)
+                .query(7, connection(DorisVersionProfile.V2), null))
+                .isInstanceOf(DorisActiveTaskQueryService.CapabilityUnsupportedException.class);
+        assertThat(calls).hasValue(0);
+    }
+
+    @Test
+    void threePointXTakesUserFromProcesslistBecauseActiveQueriesHasNoUserColumn() {
+        Map<String, List<Map<String, Object>>> rows = baseRows(DorisVersionProfile.V3);
+        rows.get(DorisVersionProfile.V3.activeQueriesSql()).add(row("QUERY_ID", "q1"));
+        rows.get(DorisVersionProfile.V3.processlistSql())
+                .add(row("QueryId", "q1", "Command", "Query", "Host", "10.0.0.7:5555", "User", "alice"));
+
+        DorisActiveTaskVO task = service(rows).query(7, connection(DorisVersionProfile.V3), null)
+                .getTasks().get(0);
+
+        assertThat(task.getUser()).isEqualTo("alice");
+        assertThat(task.getClientAddress()).isEqualTo("10.0.0.7:5555");
+    }
+
+    @Test
+    void reportsVersionAndTheFieldsThatVersionCannotProvide() {
+        DorisActiveTaskResponseVO onThree = service(baseRows(DorisVersionProfile.V3))
+                .query(7, connection(DorisVersionProfile.V3), null);
+        DorisActiveTaskResponseVO onFour = service(baseRows(DorisVersionProfile.V4))
+                .query(7, connection(DorisVersionProfile.V4), null);
+
+        assertThat(onThree.getUnsupportedFields()).containsExactlyInAnyOrder("spillBytes", "loadWorkloadGroup");
+        assertThat(onThree.getServerVersion()).contains("doris-3.");
+        assertThat(onFour.getUnsupportedFields()).isEmpty();
+    }
+
     private static DorisActiveTaskQueryService service(Map<String, List<Map<String, Object>>> rows) {
         return new DorisActiveTaskQueryService(null, (client, sql) -> rows.getOrDefault(sql, List.of()));
     }
@@ -256,11 +314,21 @@ class DorisActiveTaskQueryServiceTest {
                 mock(JdbcClient.class), "ddh-01", 9030, "root", degraded, degraded ? "fallback" : null);
     }
 
+    private static DorisAdminReaderFactory.DorisAdminConnection connection(DorisVersionProfile profile) {
+        return new DorisAdminReaderFactory.DorisAdminConnection(
+                mock(JdbcClient.class), "doris-fe", 9030, "otel_reader", false, null, null,
+                profile, "Doris version doris-" + profile.name().charAt(1) + ".0.8");
+    }
+
     private static Map<String, List<Map<String, Object>>> baseRows() {
+        return baseRows(DorisVersionProfile.V4);
+    }
+
+    private static Map<String, List<Map<String, Object>>> baseRows(DorisVersionProfile profile) {
         Map<String, List<Map<String, Object>>> rows = new HashMap<>();
-        rows.put(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL, new ArrayList<>());
-        rows.put(DorisActiveTaskQueryService.BACKEND_ACTIVE_TASKS_SQL, new ArrayList<>());
-        rows.put(DorisActiveTaskQueryService.PROCESSLIST_SQL, new ArrayList<>());
+        rows.put(profile.activeQueriesSql(), new ArrayList<>());
+        rows.put(profile.backendActiveTasksSql(), new ArrayList<>());
+        rows.put(profile.processlistSql(), new ArrayList<>());
         rows.put(DorisActiveTaskQueryService.WORKLOAD_GROUPS_SQL, new ArrayList<>());
         return rows;
     }

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisActiveTaskQueryServiceTest.java
@@ -104,6 +104,21 @@ class DorisActiveTaskQueryServiceTest {
     }
 
     @Test
+    void queuedTypeFilterMatchesQueuedQueriesOnly() {
+        Map<String, List<Map<String, Object>>> rows = baseRows();
+        rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).addAll(List.of(
+                row("QUERY_ID", "queued", "QUERY_STATUS", "Queued"),
+                row("QUERY_ID", "running", "QUERY_STATUS", "RUNNING")));
+        DorisActiveTaskQueryDTO filter = new DorisActiveTaskQueryDTO();
+        filter.setTypes(List.of("QUEUED"));
+
+        DorisActiveTaskResponseVO response = service(rows).query(7, connection(false), filter);
+
+        assertThat(response.getTasks()).extracting(DorisActiveTaskVO::getTaskId)
+                .containsExactly("queued");
+    }
+
+    @Test
     void processlistOnlyUsesQueryRows() {
         Map<String, List<Map<String, Object>>> rows = baseRows();
         rows.get(DorisActiveTaskQueryService.ACTIVE_QUERIES_SQL).add(row("QUERY_ID", "q1"));

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisServiceInstanceValidatorTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisServiceInstanceValidatorTest.java
@@ -23,6 +23,7 @@
 package com.datasophon.api.service.doris;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -30,7 +31,11 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 import com.datasophon.api.enums.Status;
 import com.datasophon.api.service.ClusterServiceInstanceService;
+import com.datasophon.api.service.instance.K8sServiceInstanceService;
 import com.datasophon.dao.entity.ClusterServiceInstanceEntity;
+import com.datasophon.dao.vo.instance.K8sServiceInstanceVO;
+
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,12 +44,14 @@ import org.springframework.web.server.ResponseStatusException;
 class DorisServiceInstanceValidatorTest {
 
     private ClusterServiceInstanceService service;
+    private K8sServiceInstanceService k8sService;
     private DorisServiceInstanceValidator validator;
 
     @BeforeEach
     void setUp() {
         service = mock(ClusterServiceInstanceService.class);
-        validator = new DorisServiceInstanceValidator(service);
+        k8sService = mock(K8sServiceInstanceService.class);
+        validator = new DorisServiceInstanceValidator(service, k8sService);
     }
 
     @Test
@@ -74,6 +81,38 @@ class DorisServiceInstanceValidatorTest {
         assertBadRequest(validator, 7, 44);
     }
 
+    @Test
+    void allowsK8sDorisInstanceFromTheSameCluster() {
+        when(k8sService.getVoById(44))
+                .thenReturn(Optional.of(k8sInstance(7, "doris-disaggregated")));
+
+        assertThatCode(() -> validator.requireDorisInstance(7, 44)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void allowsK8sCoupledDorisInstanceFromTheSameCluster() {
+        when(k8sService.getVoById(44))
+                .thenReturn(Optional.of(k8sInstance(7, "doris-coupled")));
+
+        assertThatCode(() -> validator.requireDorisInstance(7, 44)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsNonDorisK8sInstance() {
+        when(k8sService.getVoById(44))
+                .thenReturn(Optional.of(k8sInstance(7, "nacos")));
+
+        assertBadRequest(validator, 7, 44);
+    }
+
+    @Test
+    void rejectsK8sInstanceFromAnotherCluster() {
+        when(k8sService.getVoById(44))
+                .thenReturn(Optional.of(k8sInstance(8, "doris-disaggregated")));
+
+        assertBadRequest(validator, 7, 44);
+    }
+
     private static void assertBadRequest(
                                          DorisServiceInstanceValidator validator, Integer clusterId, Integer instanceId) {
         assertThatThrownBy(() -> validator.requireDorisInstance(clusterId, instanceId))
@@ -85,6 +124,13 @@ class DorisServiceInstanceValidatorTest {
 
     private static ClusterServiceInstanceEntity instance(Integer clusterId, String serviceName) {
         ClusterServiceInstanceEntity instance = new ClusterServiceInstanceEntity();
+        instance.setClusterId(clusterId);
+        instance.setServiceName(serviceName);
+        return instance;
+    }
+
+    private static K8sServiceInstanceVO k8sInstance(Integer clusterId, String serviceName) {
+        K8sServiceInstanceVO instance = new K8sServiceInstanceVO();
         instance.setClusterId(clusterId);
         instance.setServiceName(serviceName);
         return instance;

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisServiceInstanceValidatorTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisServiceInstanceValidatorTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 import com.datasophon.api.enums.Status;
 import com.datasophon.api.service.ClusterServiceInstanceService;
@@ -34,8 +35,6 @@ import com.datasophon.dao.entity.ClusterServiceInstanceEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.server.ResponseStatusException;
-
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 class DorisServiceInstanceValidatorTest {
 
@@ -76,7 +75,7 @@ class DorisServiceInstanceValidatorTest {
     }
 
     private static void assertBadRequest(
-            DorisServiceInstanceValidator validator, Integer clusterId, Integer instanceId) {
+                                         DorisServiceInstanceValidator validator, Integer clusterId, Integer instanceId) {
         assertThatThrownBy(() -> validator.requireDorisInstance(clusterId, instanceId))
                 .isInstanceOfSatisfying(ResponseStatusException.class, exception -> {
                     assertThat(exception.getStatusCode()).isEqualTo(BAD_REQUEST);

--- a/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisServiceInstanceValidatorTest.java
+++ b/datasophon-api/src/test/java/com/datasophon/api/service/doris/DorisServiceInstanceValidatorTest.java
@@ -1,0 +1,93 @@
+/*
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.datasophon.api.service.doris;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datasophon.api.enums.Status;
+import com.datasophon.api.service.ClusterServiceInstanceService;
+import com.datasophon.dao.entity.ClusterServiceInstanceEntity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+class DorisServiceInstanceValidatorTest {
+
+    private ClusterServiceInstanceService service;
+    private DorisServiceInstanceValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(ClusterServiceInstanceService.class);
+        validator = new DorisServiceInstanceValidator(service);
+    }
+
+    @Test
+    void returnsInstanceWhenClusterAndDorisTypeMatch() {
+        ClusterServiceInstanceEntity instance = instance(7, "doris");
+        when(service.getById(44)).thenReturn(instance);
+
+        assertThat(validator.requireDorisInstance(7, 44)).isSameAs(instance);
+    }
+
+    @Test
+    void rejectsMissingInstance() {
+        assertBadRequest(validator, 7, 44);
+    }
+
+    @Test
+    void rejectsInstanceFromAnotherCluster() {
+        when(service.getById(44)).thenReturn(instance(8, "DORIS"));
+
+        assertBadRequest(validator, 7, 44);
+    }
+
+    @Test
+    void rejectsNonDorisService() {
+        when(service.getById(44)).thenReturn(instance(7, "HDFS"));
+
+        assertBadRequest(validator, 7, 44);
+    }
+
+    private static void assertBadRequest(
+            DorisServiceInstanceValidator validator, Integer clusterId, Integer instanceId) {
+        assertThatThrownBy(() -> validator.requireDorisInstance(clusterId, instanceId))
+                .isInstanceOfSatisfying(ResponseStatusException.class, exception -> {
+                    assertThat(exception.getStatusCode()).isEqualTo(BAD_REQUEST);
+                    assertThat(exception.getReason()).isEqualTo(Status.INSTANCE_MISMATCH.getMsg());
+                });
+    }
+
+    private static ClusterServiceInstanceEntity instance(Integer clusterId, String serviceName) {
+        ClusterServiceInstanceEntity instance = new ClusterServiceInstanceEntity();
+        instance.setClusterId(clusterId);
+        instance.setServiceName(serviceName);
+        return instance;
+    }
+}

--- a/datasophon-ui-v2/src/locales/en-US.ts
+++ b/datasophon-ui-v2/src/locales/en-US.ts
@@ -4,6 +4,7 @@ import apisixMonitor from './en-US/apisixMonitor';
 import clusterDashboard from './en-US/clusterDashboard';
 import component from './en-US/component';
 import dolphinSchedulerMonitor from './en-US/dolphinSchedulerMonitor';
+import dorisActiveTask from './en-US/dorisActiveTask';
 import dorisMonitor from './en-US/dorisMonitor';
 import dsWorkflow from './en-US/dsWorkflow';
 import globalHeader from './en-US/globalHeader';
@@ -40,6 +41,7 @@ export default {
   ...dolphinSchedulerMonitor,
   ...dsWorkflow,
   ...dorisMonitor,
+  ...dorisActiveTask,
   ...nacosMonitor,
   ...gravitinoMonitor,
   ...nginxMonitor,

--- a/datasophon-ui-v2/src/locales/en-US/dorisActiveTask.ts
+++ b/datasophon-ui-v2/src/locales/en-US/dorisActiveTask.ts
@@ -1,0 +1,4 @@
+export default {
+  'dorisActiveTask.tab': 'Active Tasks',
+  'dorisActiveTask.loading': 'Loading',
+};

--- a/datasophon-ui-v2/src/locales/zh-CN.ts
+++ b/datasophon-ui-v2/src/locales/zh-CN.ts
@@ -4,6 +4,7 @@ import apisixMonitor from './zh-CN/apisixMonitor';
 import clusterDashboard from './zh-CN/clusterDashboard';
 import component from './zh-CN/component';
 import dolphinSchedulerMonitor from './zh-CN/dolphinSchedulerMonitor';
+import dorisActiveTask from './zh-CN/dorisActiveTask';
 import dorisMonitor from './zh-CN/dorisMonitor';
 import dsWorkflow from './zh-CN/dsWorkflow';
 import globalHeader from './zh-CN/globalHeader';
@@ -40,6 +41,7 @@ export default {
   ...dolphinSchedulerMonitor,
   ...dsWorkflow,
   ...dorisMonitor,
+  ...dorisActiveTask,
   ...nacosMonitor,
   ...gravitinoMonitor,
   ...nginxMonitor,

--- a/datasophon-ui-v2/src/locales/zh-CN/dorisActiveTask.ts
+++ b/datasophon-ui-v2/src/locales/zh-CN/dorisActiveTask.ts
@@ -1,0 +1,4 @@
+export default {
+  'dorisActiveTask.tab': '活动任务',
+  'dorisActiveTask.loading': '加载中',
+};

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/ActiveTaskTable.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/ActiveTaskTable.test.tsx
@@ -1,0 +1,21 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ActiveTaskTable from './ActiveTaskTable';
+import type { DorisActiveTask } from './types';
+
+const tasks: DorisActiveTask[] = [
+  { taskId: 'q-1', type: 'QUERY', user: 'alice' },
+  { taskId: 'load-1', type: 'LOAD' },
+];
+
+describe('ActiveTaskTable', () => {
+  it('renders Query and Load rows and forwards row selection', () => {
+    const onOpen = vi.fn();
+    render(<ActiveTaskTable tasks={tasks} onOpen={onOpen} />);
+
+    expect(screen.getByText('q-1')).toBeInTheDocument();
+    expect(screen.getByText('load-1')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('q-1').closest('tr') as HTMLElement);
+    expect(onOpen).toHaveBeenCalledWith(tasks[0]);
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/ActiveTaskTable.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/ActiveTaskTable.tsx
@@ -1,0 +1,32 @@
+import { Table } from 'antd';
+import { ACTIVE_TASK_COLUMNS } from './columns';
+import type { DorisActiveTask } from './types';
+
+interface ActiveTaskTableProps {
+  tasks: DorisActiveTask[];
+  loading?: boolean;
+  onOpen?: (task: DorisActiveTask) => void;
+}
+
+const ActiveTaskTable: React.FC<ActiveTaskTableProps> = ({
+  tasks,
+  loading = false,
+  onOpen,
+}) => (
+  <div data-testid="doris-active-task-table">
+    <Table<DorisActiveTask>
+      rowKey="taskId"
+      columns={ACTIVE_TASK_COLUMNS}
+      dataSource={tasks}
+      loading={loading}
+      pagination={false}
+      scroll={{ x: 2_200 }}
+      size="small"
+      onRow={(task) => ({
+        onClick: () => onOpen?.(task),
+      })}
+    />
+  </div>
+);
+
+export default ActiveTaskTable;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/DorisActiveTask.module.less
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/DorisActiveTask.module.less
@@ -1,0 +1,4 @@
+.panel {
+  min-height: 240px;
+  padding: 24px;
+}

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/FilterBar.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/FilterBar.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import FilterBar, { TYPE_OPTIONS } from './FilterBar';
+
+describe('FilterBar', () => {
+  it('submits keyword filters and labels queue controls as experimental', () => {
+    const onChange = vi.fn();
+    render(
+      <FilterBar
+        value={{}}
+        autoRefresh={false}
+        onChange={onChange}
+        onRefresh={vi.fn()}
+        onAutoRefreshChange={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByRole('textbox', { name: '搜索任务 ID、用户或 SQL' }),
+      {
+        target: { value: 'Q-1' },
+      },
+    );
+    fireEvent.click(screen.getByRole('button', { name: '查询活动任务' }));
+
+    expect(onChange).toHaveBeenCalledWith({ keyword: 'Q-1' });
+    expect(screen.getByText('排队类型筛选 / 分组排序：实验性')).toHaveAttribute(
+      'data-experimental',
+      'queue-features',
+    );
+    expect(TYPE_OPTIONS).toContainEqual({
+      label: '排队 Query（实验性）',
+      value: 'QUEUED',
+    });
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/FilterBar.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/FilterBar.tsx
@@ -1,0 +1,116 @@
+import { Button, Input, InputNumber, Select, Space, Switch, Tag } from 'antd';
+import { useEffect, useState } from 'react';
+import type { DorisActiveTaskQuery } from './types';
+
+interface FilterBarProps {
+  value: DorisActiveTaskQuery;
+  loading?: boolean;
+  autoRefresh: boolean;
+  onChange: (value: DorisActiveTaskQuery) => void;
+  onRefresh: () => void;
+  onAutoRefreshChange: (enabled: boolean) => void;
+}
+
+export const TYPE_OPTIONS = [
+  { label: 'Query', value: 'QUERY' },
+  { label: 'Load', value: 'LOAD' },
+  { label: '排队 Query（实验性）', value: 'QUEUED' },
+];
+
+const FilterBar: React.FC<FilterBarProps> = ({
+  value,
+  loading = false,
+  autoRefresh,
+  onChange,
+  onRefresh,
+  onAutoRefreshChange,
+}) => {
+  const [draft, setDraft] = useState<DorisActiveTaskQuery>(value);
+
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+
+  const update = <K extends keyof DorisActiveTaskQuery>(
+    key: K,
+    nextValue: DorisActiveTaskQuery[K],
+  ) => {
+    setDraft((current) => ({ ...current, [key]: nextValue }));
+  };
+
+  return (
+    <Space wrap data-testid="doris-active-task-filters">
+      <Input
+        aria-label="搜索任务 ID、用户或 SQL"
+        placeholder="任务 ID / 用户 / SQL"
+        value={draft.keyword ?? ''}
+        onChange={(event) => update('keyword', event.target.value)}
+        onPressEnter={() => onChange(draft)}
+        style={{ width: 230 }}
+      />
+      <Select
+        aria-label="任务类型"
+        mode="multiple"
+        allowClear
+        placeholder="任务类型"
+        options={TYPE_OPTIONS}
+        value={draft.types ?? []}
+        onChange={(types: string[]) => update('types', types)}
+        style={{ width: 220 }}
+      />
+      <Input
+        aria-label="用户"
+        placeholder="用户"
+        value={draft.user ?? ''}
+        onChange={(event) => update('user', event.target.value)}
+        style={{ width: 130 }}
+      />
+      <Input
+        aria-label="来源 FE"
+        placeholder="来源 FE"
+        value={draft.feHost ?? ''}
+        onChange={(event) => update('feHost', event.target.value)}
+        style={{ width: 140 }}
+      />
+      <InputNumber
+        aria-label="内存大于等于"
+        min={0}
+        placeholder="内存 ≥ bytes"
+        value={draft.minMemoryBytes ?? null}
+        onChange={(nextValue) => update('minMemoryBytes', nextValue)}
+        style={{ width: 150 }}
+      />
+      <InputNumber
+        aria-label="时长大于等于"
+        min={0}
+        placeholder="时长 ≥ ms"
+        value={draft.minElapsedMs ?? null}
+        onChange={(nextValue) => update('minElapsedMs', nextValue)}
+        style={{ width: 140 }}
+      />
+      <Button
+        aria-label="查询活动任务"
+        type="primary"
+        onClick={() => onChange(draft)}
+      >
+        查询
+      </Button>
+      <Button onClick={onRefresh} loading={loading}>
+        手动刷新
+      </Button>
+      <Space size={4}>
+        <Switch
+          aria-label="10 秒自动刷新"
+          checked={autoRefresh}
+          onChange={onAutoRefreshChange}
+        />
+        <span>10 秒自动刷新</span>
+      </Space>
+      <Tag color="gold" data-experimental="queue-features">
+        排队类型筛选 / 分组排序：实验性
+      </Tag>
+    </Space>
+  );
+};
+
+export default FilterBar;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/StatusBanners.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/StatusBanners.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import StatusBanners from './StatusBanners';
+import type { DorisActiveTaskResponse } from './types';
+
+const response = (
+  overrides: Partial<DorisActiveTaskResponse> = {},
+): DorisActiveTaskResponse => ({
+  tasks: [],
+  degraded: false,
+  partialFailures: [],
+  truncated: false,
+  sourceTruncated: false,
+  total: 0,
+  returned: 0,
+  connectedHostPort: 'ddh-01:9030',
+  ...overrides,
+});
+
+describe('StatusBanners', () => {
+  it('renders degraded, partial, and truncation notices', () => {
+    render(
+      <StatusBanners
+        response={response({
+          degraded: true,
+          partialFailures: ['clientAddress'],
+          truncated: true,
+          sourceTruncated: true,
+          total: 2_001,
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText('当前以只读账号连接，部分字段不可用'),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/部分数据不可用/)).toBeInTheDocument();
+    expect(screen.getByText(/仅显示前 2000 条/)).toBeInTheDocument();
+    expect(
+      screen.getByText('数据源返回量超出上限，结果可能不完整'),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps empty and overall failure as different visual states', () => {
+    const { rerender } = render(<StatusBanners response={response()} />);
+    expect(screen.getByTestId('doris-active-task-status')).toHaveAttribute(
+      'data-status',
+      'empty',
+    );
+
+    rerender(<StatusBanners error={new Error('hidden')} />);
+    expect(screen.getByTestId('doris-active-task-status')).toHaveAttribute(
+      'data-status',
+      'failed',
+    );
+    expect(
+      screen.getByText('活动任务查询失败，旧快照已清除'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('hidden')).not.toBeInTheDocument();
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/StatusBanners.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/StatusBanners.test.tsx
@@ -41,6 +41,20 @@ describe('StatusBanners', () => {
     ).toBeInTheDocument();
   });
 
+  it('names the fields the connected Doris version cannot provide', () => {
+    render(
+      <StatusBanners
+        response={response({
+          unsupportedFields: ['spillBytes', 'loadWorkloadGroup'],
+        })}
+      />,
+    );
+
+    const banner = screen.getByText(/当前 Doris 版本不支持以下字段/);
+    expect(banner).toHaveTextContent('溢写字节');
+    expect(banner).toHaveTextContent('Load 任务的 Workload Group');
+  });
+
   it('keeps empty and overall failure as different visual states', () => {
     const { rerender } = render(<StatusBanners response={response()} />);
     expect(screen.getByTestId('doris-active-task-status')).toHaveAttribute(

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/StatusBanners.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/StatusBanners.tsx
@@ -12,6 +12,12 @@ const FAILURE_LABELS: Record<string, string> = {
   workloadGroup: 'Workload Group',
 };
 
+// 与后端 DorisVersionProfile.unsupportedFields 的取值一一对应。
+const UNSUPPORTED_LABELS: Record<string, string> = {
+  spillBytes: '溢写字节',
+  loadWorkloadGroup: 'Load 任务的 Workload Group',
+};
+
 const StatusBanners: React.FC<StatusBannersProps> = ({
   response,
   error,
@@ -42,6 +48,7 @@ const StatusBanners: React.FC<StatusBannersProps> = ({
   }
 
   const partialFailures = response.partialFailures ?? [];
+  const unsupportedFields = response.unsupportedFields ?? [];
   return (
     <Space
       orientation="vertical"
@@ -64,6 +71,16 @@ const StatusBanners: React.FC<StatusBannersProps> = ({
           data-status="partial"
           title={`部分数据不可用：${partialFailures
             .map((failure) => FAILURE_LABELS[failure] ?? '部分视图')
+            .join('、')}`}
+        />
+      ) : null}
+      {unsupportedFields.length > 0 ? (
+        <Alert
+          showIcon
+          type="info"
+          data-status="version-unsupported"
+          title={`当前 Doris 版本不支持以下字段，列内显示为空：${unsupportedFields
+            .map((field) => UNSUPPORTED_LABELS[field] ?? field)
             .join('、')}`}
         />
       ) : null}

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/StatusBanners.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/StatusBanners.tsx
@@ -1,0 +1,95 @@
+import { Alert, Empty, Space, Spin } from 'antd';
+import type { DorisActiveTaskResponse } from './types';
+
+interface StatusBannersProps {
+  response?: DorisActiveTaskResponse | null;
+  error?: unknown;
+  loading?: boolean;
+}
+
+const FAILURE_LABELS: Record<string, string> = {
+  clientAddress: '客户端地址',
+  workloadGroup: 'Workload Group',
+};
+
+const StatusBanners: React.FC<StatusBannersProps> = ({
+  response,
+  error,
+  loading = false,
+}) => {
+  if (error) {
+    return (
+      <div data-status="failed" data-testid="doris-active-task-status">
+        <Alert showIcon type="error" title="活动任务查询失败，旧快照已清除" />
+      </div>
+    );
+  }
+
+  if (!response && loading) {
+    return (
+      <div data-status="loading" data-testid="doris-active-task-status">
+        <Spin tip="加载中" />
+      </div>
+    );
+  }
+
+  if (!response) {
+    return (
+      <div data-status="empty" data-testid="doris-active-task-status">
+        <Empty description="暂无活动任务" />
+      </div>
+    );
+  }
+
+  const partialFailures = response.partialFailures ?? [];
+  return (
+    <Space
+      orientation="vertical"
+      style={{ width: '100%' }}
+      data-status={response.tasks.length === 0 ? 'empty' : undefined}
+      data-testid="doris-active-task-status"
+    >
+      {response.degraded ? (
+        <Alert
+          showIcon
+          type="warning"
+          data-status="degraded"
+          title="当前以只读账号连接，部分字段不可用"
+        />
+      ) : null}
+      {partialFailures.length > 0 ? (
+        <Alert
+          showIcon
+          type="warning"
+          data-status="partial"
+          title={`部分数据不可用：${partialFailures
+            .map((failure) => FAILURE_LABELS[failure] ?? '部分视图')
+            .join('、')}`}
+        />
+      ) : null}
+      {response.truncated ? (
+        <Alert
+          showIcon
+          type="info"
+          data-status="truncated"
+          title={`仅显示前 2000 条，共 ${response.total} 条`}
+        />
+      ) : null}
+      {response.sourceTruncated ? (
+        <Alert
+          showIcon
+          type="info"
+          data-status="source-truncated"
+          title="数据源返回量超出上限，结果可能不完整"
+        />
+      ) : null}
+      {response.tasks.length === 0 ? (
+        <div data-status="empty">
+          <Empty description="暂无活动任务" />
+        </div>
+      ) : null}
+    </Space>
+  );
+};
+
+export default StatusBanners;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.test.tsx
@@ -8,6 +8,7 @@ const query: DorisActiveTask = {
   type: 'QUERY',
   user: 'alice',
   sql: 'select * from orders',
+  detailSql: 'select * from orders where customer_id = 42',
   truncated: true,
   beDetails: [
     {
@@ -45,7 +46,7 @@ describe('TaskDetailDrawer', () => {
       screen.getByText('SQL 已截断，复制内容仅包含当前返回内容'),
     ).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: '复制当前返回内容' }));
-    expect(writeText).toHaveBeenCalledWith(query.sql);
+    expect(writeText).toHaveBeenCalledWith(query.detailSql);
   });
 
   it('keeps resource details for Load without exposing an SQL drawer', () => {

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import TaskDetailDrawer from './TaskDetailDrawer';
 import type { DorisActiveTask } from './types';
@@ -7,6 +7,17 @@ const query: DorisActiveTask = {
   taskId: 'q-1',
   type: 'QUERY',
   user: 'alice',
+  startTime: '2026-09-03 12:00:00',
+  elapsedMs: 1234,
+  currentMemoryBytes: 10,
+  peakMemoryBytes: 20,
+  scanRows: 42,
+  scanBytes: 1_000_000,
+  cpuTimeMs: 321,
+  shuffleSendBytes: 2_000_000,
+  shuffleSendRows: 43,
+  spillWriteBytesToLocalStorage: 3_000_000,
+  spillReadBytesFromLocalStorage: 4_000_000,
   sql: 'select * from orders',
   detailSql: 'select * from orders where customer_id = 42',
   truncated: true,
@@ -24,7 +35,10 @@ const query: DorisActiveTask = {
 const load: DorisActiveTask = {
   taskId: 'load-1',
   type: 'LOAD',
-  beDetails: query.beDetails,
+  beDetails: query.beDetails?.map((detail) => ({
+    ...detail,
+    scanBytes: null,
+  })),
 };
 
 describe('TaskDetailDrawer', () => {
@@ -42,6 +56,13 @@ describe('TaskDetailDrawer', () => {
     render(<TaskDetailDrawer task={query} open onClose={vi.fn()} />);
 
     expect(screen.getByText('be-1')).toBeInTheDocument();
+    expect(screen.getByText('2026-09-03 12:00:00')).toBeInTheDocument();
+    expect(screen.getByText('1234 ms')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('976.6 KB')).toBeInTheDocument();
+    expect(screen.getByText('1.9 MB')).toBeInTheDocument();
+    expect(screen.getByText('2.9 MB')).toBeInTheDocument();
+    expect(screen.getByText('3.8 MB')).toBeInTheDocument();
     expect(
       screen.getByText('SQL 已截断，复制内容仅包含当前返回内容'),
     ).toBeInTheDocument();
@@ -52,7 +73,9 @@ describe('TaskDetailDrawer', () => {
   it('keeps resource details for Load without exposing an SQL drawer', () => {
     render(<TaskDetailDrawer task={load} open onClose={vi.fn()} />);
 
-    expect(screen.getByText('be-1')).toBeInTheDocument();
+    const beRow = screen.getByText('be-1').closest('tr');
+    expect(beRow).not.toBeNull();
+    expect(within(beRow as HTMLElement).getByText('不适用')).toBeInTheDocument();
     expect(
       screen.queryByTestId('doris-active-task-sql'),
     ).not.toBeInTheDocument();

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import TaskDetailDrawer from './TaskDetailDrawer';
+import type { DorisActiveTask } from './types';
+
+const query: DorisActiveTask = {
+  taskId: 'q-1',
+  type: 'QUERY',
+  user: 'alice',
+  sql: 'select * from orders',
+  truncated: true,
+  beDetails: [
+    {
+      beId: 'be-1',
+      peakMemoryBytes: 20,
+      currentMemoryBytes: 10,
+      scanRows: 3,
+      scanBytes: 30,
+    },
+  ],
+};
+
+const load: DorisActiveTask = {
+  taskId: 'load-1',
+  type: 'LOAD',
+  beDetails: query.beDetails,
+};
+
+describe('TaskDetailDrawer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows BE resources, warns about SQL truncation, and copies returned SQL only', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    render(<TaskDetailDrawer task={query} open onClose={vi.fn()} />);
+
+    expect(screen.getByText('be-1')).toBeInTheDocument();
+    expect(
+      screen.getByText('SQL 已截断，复制内容仅包含当前返回内容'),
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: '复制当前返回内容' }));
+    expect(writeText).toHaveBeenCalledWith(query.sql);
+  });
+
+  it('keeps resource details for Load without exposing an SQL drawer', () => {
+    render(<TaskDetailDrawer task={load} open onClose={vi.fn()} />);
+
+    expect(screen.getByText('be-1')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('doris-active-task-sql'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.tsx
@@ -1,0 +1,144 @@
+import {
+  Alert,
+  Button,
+  Descriptions,
+  Drawer,
+  Empty,
+  Table,
+  Typography,
+} from 'antd';
+import { formatBytes } from '@/pages/Cluster/Lineage/lineageFormatters';
+import { displayValue } from './columns';
+import type { DorisActiveTask, DorisBeTaskDetail } from './types';
+
+interface TaskDetailDrawerProps {
+  task?: DorisActiveTask;
+  open: boolean;
+  onClose: () => void;
+}
+
+function displayBytes(value: number | null | undefined): string {
+  return value == null ? '–' : formatBytes(value);
+}
+
+function displayNumber(value: number | null | undefined): string {
+  return value == null ? '–' : new Intl.NumberFormat('zh-CN').format(value);
+}
+
+const BE_COLUMNS = [
+  {
+    title: 'BE ID',
+    dataIndex: 'beId',
+    render: (value: string | null | undefined) => displayValue(value),
+  },
+  {
+    title: '峰值内存',
+    dataIndex: 'peakMemoryBytes',
+    render: (value: number | null | undefined) => displayBytes(value),
+  },
+  {
+    title: '当前内存',
+    dataIndex: 'currentMemoryBytes',
+    render: (value: number | null | undefined) => displayBytes(value),
+  },
+  {
+    title: '扫描行数',
+    dataIndex: 'scanRows',
+    render: (value: number | null | undefined) => displayNumber(value),
+  },
+  {
+    title: '扫描字节',
+    dataIndex: 'scanBytes',
+    render: (value: number | null | undefined) => displayBytes(value),
+  },
+];
+
+const TaskDetailDrawer: React.FC<TaskDetailDrawerProps> = ({
+  task,
+  open,
+  onClose,
+}) => {
+  const isLoad = task?.type.toUpperCase() === 'LOAD';
+
+  const copyReturnedSql = async () => {
+    if (!task?.sql) return;
+    await navigator.clipboard.writeText(task.sql);
+  };
+
+  return (
+    <Drawer
+      title={task ? `活动任务：${task.taskId}` : '活动任务详情'}
+      open={open}
+      onClose={onClose}
+      size={560}
+    >
+      {!task ? (
+        <Empty description="未选择任务" />
+      ) : (
+        <>
+          <Descriptions column={1} size="small">
+            <Descriptions.Item label="类型">
+              {displayValue(task.type)}
+            </Descriptions.Item>
+            <Descriptions.Item label="任务 ID">
+              {displayValue(task.taskId)}
+            </Descriptions.Item>
+            <Descriptions.Item label="用户">
+              {displayValue(task.user, isLoad)}
+            </Descriptions.Item>
+            <Descriptions.Item label="客户端地址">
+              {displayValue(task.clientAddress, isLoad)}
+            </Descriptions.Item>
+            <Descriptions.Item label="来源 FE">
+              {displayValue(task.feHost)}
+            </Descriptions.Item>
+            <Descriptions.Item label="Workload Group">
+              {displayValue(task.workloadGroupName ?? task.workloadGroupId)}
+            </Descriptions.Item>
+            <Descriptions.Item label="当前内存">
+              {displayBytes(task.currentMemoryBytes)}
+            </Descriptions.Item>
+            <Descriptions.Item label="峰值内存（单 BE 最大）">
+              {displayBytes(task.peakMemoryBytes)}
+            </Descriptions.Item>
+            <Descriptions.Item label="CPU 时间">
+              {displayValue(
+                task.cpuTimeMs == null ? null : `${task.cpuTimeMs} ms`,
+              )}
+            </Descriptions.Item>
+          </Descriptions>
+
+          {!isLoad && task.sql != null ? (
+            <section data-testid="doris-active-task-sql">
+              <Typography.Title level={5}>SQL</Typography.Title>
+              {task.truncated ? (
+                <Alert
+                  type="warning"
+                  showIcon
+                  title="SQL 已截断，复制内容仅包含当前返回内容"
+                />
+              ) : null}
+              <Typography.Paragraph copyable={false} ellipsis={false}>
+                <pre>{task.sql}</pre>
+              </Typography.Paragraph>
+              <Button onClick={() => void copyReturnedSql()}>
+                复制当前返回内容
+              </Button>
+            </section>
+          ) : null}
+
+          <Typography.Title level={5}>各 BE 资源明细</Typography.Title>
+          <Table<DorisBeTaskDetail>
+            rowKey={(detail, index) => `${detail.beId ?? 'unknown'}-${index}`}
+            size="small"
+            pagination={false}
+            dataSource={task.beDetails ?? []}
+            columns={BE_COLUMNS}
+          />
+        </>
+      )}
+    </Drawer>
+  );
+};
+
+export default TaskDetailDrawer;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.tsx
@@ -59,10 +59,11 @@ const TaskDetailDrawer: React.FC<TaskDetailDrawerProps> = ({
   onClose,
 }) => {
   const isLoad = task?.type.toUpperCase() === 'LOAD';
+  const returnedSql = task?.detailSql ?? task?.sql;
 
   const copyReturnedSql = async () => {
-    if (!task?.sql) return;
-    await navigator.clipboard.writeText(task.sql);
+    if (!returnedSql) return;
+    await navigator.clipboard.writeText(returnedSql);
   };
 
   return (
@@ -108,7 +109,7 @@ const TaskDetailDrawer: React.FC<TaskDetailDrawerProps> = ({
             </Descriptions.Item>
           </Descriptions>
 
-          {!isLoad && task.sql != null ? (
+          {!isLoad && returnedSql != null ? (
             <section data-testid="doris-active-task-sql">
               <Typography.Title level={5}>SQL</Typography.Title>
               {task.truncated ? (
@@ -119,7 +120,7 @@ const TaskDetailDrawer: React.FC<TaskDetailDrawerProps> = ({
                 />
               ) : null}
               <Typography.Paragraph copyable={false} ellipsis={false}>
-                <pre>{task.sql}</pre>
+                <pre>{returnedSql}</pre>
               </Typography.Paragraph>
               <Button onClick={() => void copyReturnedSql()}>
                 复制当前返回内容

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/TaskDetailDrawer.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from 'antd';
 import { formatBytes } from '@/pages/Cluster/Lineage/lineageFormatters';
-import { displayValue } from './columns';
+import { displayValue, NOT_APPLICABLE_VALUE } from './columns';
 import type { DorisActiveTask, DorisBeTaskDetail } from './types';
 
 interface TaskDetailDrawerProps {
@@ -17,41 +17,52 @@ interface TaskDetailDrawerProps {
   onClose: () => void;
 }
 
-function displayBytes(value: number | null | undefined): string {
-  return value == null ? '–' : formatBytes(value);
+function displayBytes(
+  value: number | null | undefined,
+  notApplicable = false,
+): string {
+  if (notApplicable) return NOT_APPLICABLE_VALUE;
+  return value == null || !Number.isFinite(value) ? '–' : formatBytes(value);
 }
 
 function displayNumber(value: number | null | undefined): string {
   return value == null ? '–' : new Intl.NumberFormat('zh-CN').format(value);
 }
 
-const BE_COLUMNS = [
-  {
-    title: 'BE ID',
-    dataIndex: 'beId',
-    render: (value: string | null | undefined) => displayValue(value),
-  },
-  {
-    title: '峰值内存',
-    dataIndex: 'peakMemoryBytes',
-    render: (value: number | null | undefined) => displayBytes(value),
-  },
-  {
-    title: '当前内存',
-    dataIndex: 'currentMemoryBytes',
-    render: (value: number | null | undefined) => displayBytes(value),
-  },
-  {
-    title: '扫描行数',
-    dataIndex: 'scanRows',
-    render: (value: number | null | undefined) => displayNumber(value),
-  },
-  {
-    title: '扫描字节',
-    dataIndex: 'scanBytes',
-    render: (value: number | null | undefined) => displayBytes(value),
-  },
-];
+function displayDuration(value: number | null | undefined): string {
+  return value == null || !Number.isFinite(value) ? '–' : `${value} ms`;
+}
+
+function beColumns(isLoad: boolean) {
+  return [
+    {
+      title: 'BE ID',
+      dataIndex: 'beId',
+      render: (value: string | null | undefined) => displayValue(value),
+    },
+    {
+      title: '峰值内存',
+      dataIndex: 'peakMemoryBytes',
+      render: (value: number | null | undefined) => displayBytes(value),
+    },
+    {
+      title: '当前内存',
+      dataIndex: 'currentMemoryBytes',
+      render: (value: number | null | undefined) => displayBytes(value),
+    },
+    {
+      title: '扫描行数',
+      dataIndex: 'scanRows',
+      render: (value: number | null | undefined) => displayNumber(value),
+    },
+    {
+      title: '扫描字节',
+      dataIndex: 'scanBytes',
+      render: (value: number | null | undefined) =>
+        displayBytes(value, isLoad),
+    },
+  ];
+}
 
 const TaskDetailDrawer: React.FC<TaskDetailDrawerProps> = ({
   task,
@@ -96,6 +107,12 @@ const TaskDetailDrawer: React.FC<TaskDetailDrawerProps> = ({
             <Descriptions.Item label="Workload Group">
               {displayValue(task.workloadGroupName ?? task.workloadGroupId)}
             </Descriptions.Item>
+            <Descriptions.Item label="开始时间">
+              {displayValue(task.startTime, isLoad)}
+            </Descriptions.Item>
+            <Descriptions.Item label="已运行时长">
+              {displayDuration(task.elapsedMs)}
+            </Descriptions.Item>
             <Descriptions.Item label="当前内存">
               {displayBytes(task.currentMemoryBytes)}
             </Descriptions.Item>
@@ -106,6 +123,24 @@ const TaskDetailDrawer: React.FC<TaskDetailDrawerProps> = ({
               {displayValue(
                 task.cpuTimeMs == null ? null : `${task.cpuTimeMs} ms`,
               )}
+            </Descriptions.Item>
+            <Descriptions.Item label="扫描行数">
+              {displayNumber(task.scanRows)}
+            </Descriptions.Item>
+            <Descriptions.Item label="扫描字节">
+              {displayBytes(task.scanBytes, isLoad)}
+            </Descriptions.Item>
+            <Descriptions.Item label="Shuffle 发送字节">
+              {displayBytes(task.shuffleSendBytes)}
+            </Descriptions.Item>
+            <Descriptions.Item label="Shuffle 发送行数">
+              {displayNumber(task.shuffleSendRows)}
+            </Descriptions.Item>
+            <Descriptions.Item label="Spill 写入本地存储">
+              {displayBytes(task.spillWriteBytesToLocalStorage)}
+            </Descriptions.Item>
+            <Descriptions.Item label="Spill 读取本地存储">
+              {displayBytes(task.spillReadBytesFromLocalStorage)}
             </Descriptions.Item>
           </Descriptions>
 
@@ -134,7 +169,7 @@ const TaskDetailDrawer: React.FC<TaskDetailDrawerProps> = ({
             size="small"
             pagination={false}
             dataSource={task.beDetails ?? []}
-            columns={BE_COLUMNS}
+            columns={beColumns(isLoad)}
           />
         </>
       )}

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/columns.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/columns.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { ColumnType } from 'antd/es/table';
 import {
   ACTIVE_TASK_COLUMNS,
   displayValue,
@@ -41,7 +42,8 @@ const queryWithMissingClient: DorisActiveTask = {
 
 function rendered(dataIndex: string, task: DorisActiveTask): unknown {
   const column = ACTIVE_TASK_COLUMNS.find(
-    (candidate) => candidate.dataIndex === dataIndex,
+    (candidate): candidate is ColumnType<DorisActiveTask> =>
+      'dataIndex' in candidate && candidate.dataIndex === dataIndex,
   );
   if (!column?.render) throw new Error(`missing column ${dataIndex}`);
   return column.render(task[dataIndex as keyof DorisActiveTask], task, 0);
@@ -49,8 +51,8 @@ function rendered(dataIndex: string, task: DorisActiveTask): unknown {
 
 describe('Doris active task columns', () => {
   it('does not expose the removed database or progress columns', () => {
-    const fields = ACTIVE_TASK_COLUMNS.map((column) =>
-      String(column.dataIndex),
+    const fields = ACTIVE_TASK_COLUMNS.flatMap((column) =>
+      'dataIndex' in column ? [String(column.dataIndex)] : [],
     );
     const titles = ACTIVE_TASK_COLUMNS.map((column) => String(column.title));
 

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/columns.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/columns.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ACTIVE_TASK_COLUMNS,
+  displayValue,
+  MISSING_VALUE,
+  NOT_APPLICABLE_VALUE,
+} from './columns';
+import type { DorisActiveTask } from './types';
+
+const query: DorisActiveTask = {
+  taskId: 'q-1',
+  type: 'QUERY',
+  user: 'alice',
+  clientAddress: '10.0.0.1:1234',
+  sql: 'select 1',
+  elapsedMs: 0,
+  currentMemoryBytes: 0,
+  peakMemoryBytes: 0,
+  scanRows: 0,
+  scanBytes: 0,
+  cpuTimeMs: 0,
+  workloadGroupId: 7,
+  feHost: 'fe-1',
+};
+
+const load: DorisActiveTask = {
+  taskId: 'load-1',
+  type: 'LOAD',
+  elapsedMs: 0,
+  currentMemoryBytes: 0,
+  peakMemoryBytes: 0,
+  scanRows: 0,
+  scanBytes: null,
+  cpuTimeMs: 0,
+};
+
+const queryWithMissingClient: DorisActiveTask = {
+  ...query,
+  clientAddress: null,
+};
+
+function rendered(dataIndex: string, task: DorisActiveTask): unknown {
+  const column = ACTIVE_TASK_COLUMNS.find(
+    (candidate) => candidate.dataIndex === dataIndex,
+  );
+  if (!column?.render) throw new Error(`missing column ${dataIndex}`);
+  return column.render(task[dataIndex as keyof DorisActiveTask], task, 0);
+}
+
+describe('Doris active task columns', () => {
+  it('does not expose the removed database or progress columns', () => {
+    const fields = ACTIVE_TASK_COLUMNS.map((column) =>
+      String(column.dataIndex),
+    );
+    const titles = ACTIVE_TASK_COLUMNS.map((column) => String(column.title));
+
+    expect(fields).not.toContain('database');
+    expect(fields).not.toContain('progress');
+    expect(titles.join(' ')).not.toContain('数据库');
+    expect(titles.join(' ')).not.toContain('进度');
+  });
+
+  it('keeps zero as a real value and distinguishes missing from not applicable', () => {
+    expect(rendered('currentMemoryBytes', query)).toBe('0 B');
+    expect(rendered('user', load)).toBe(NOT_APPLICABLE_VALUE);
+    expect(rendered('scanBytes', load)).toBe(NOT_APPLICABLE_VALUE);
+    expect(rendered('clientAddress', queryWithMissingClient)).toBe(
+      MISSING_VALUE,
+    );
+    expect(displayValue(0)).toBe('0');
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/columns.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/columns.tsx
@@ -1,0 +1,149 @@
+import type { ColumnsType } from 'antd/es/table';
+import { formatBytes } from '@/pages/Cluster/Lineage/lineageFormatters';
+import type { DorisActiveTask } from './types';
+
+export const MISSING_VALUE = '–';
+export const NOT_APPLICABLE_VALUE = '不适用';
+
+export function isLoadTask(task: DorisActiveTask): boolean {
+  return task.type.toUpperCase() === 'LOAD';
+}
+
+export function displayValue(
+  value: string | number | null | undefined,
+  notApplicable = false,
+): string {
+  if (notApplicable) return NOT_APPLICABLE_VALUE;
+  return value == null || value === '' ? MISSING_VALUE : String(value);
+}
+
+function displayNumber(
+  value: number | null | undefined,
+  notApplicable = false,
+): string {
+  if (notApplicable) return NOT_APPLICABLE_VALUE;
+  return value == null || !Number.isFinite(value)
+    ? MISSING_VALUE
+    : new Intl.NumberFormat('zh-CN').format(value);
+}
+
+function displayBytes(
+  value: number | null | undefined,
+  notApplicable = false,
+): string {
+  if (notApplicable) return NOT_APPLICABLE_VALUE;
+  return value == null || !Number.isFinite(value)
+    ? MISSING_VALUE
+    : formatBytes(value);
+}
+
+function displayDuration(value: number | null | undefined): string {
+  return value == null || !Number.isFinite(value)
+    ? MISSING_VALUE
+    : `${value} ms`;
+}
+
+function displayQueueDuration(task: DorisActiveTask): string {
+  if (isLoadTask(task)) return NOT_APPLICABLE_VALUE;
+  if (!task.queueStartTime || !task.queueEndTime) return MISSING_VALUE;
+  const duration =
+    new Date(task.queueEndTime).getTime() -
+    new Date(task.queueStartTime).getTime();
+  return Number.isFinite(duration) && duration >= 0
+    ? `${duration} ms`
+    : MISSING_VALUE;
+}
+
+export const ACTIVE_TASK_COLUMNS: ColumnsType<DorisActiveTask> = [
+  {
+    title: '类型',
+    dataIndex: 'type',
+    width: 90,
+  },
+  {
+    title: '任务 ID',
+    dataIndex: 'taskId',
+    width: 220,
+    ellipsis: true,
+  },
+  {
+    title: '用户',
+    dataIndex: 'user',
+    width: 140,
+    render: (_, task) => displayValue(task.user, isLoadTask(task)),
+  },
+  {
+    title: '客户端地址',
+    dataIndex: 'clientAddress',
+    width: 180,
+    render: (_, task) => displayValue(task.clientAddress, isLoadTask(task)),
+  },
+  {
+    title: 'SQL',
+    dataIndex: 'sql',
+    width: 280,
+    ellipsis: true,
+    render: (_, task) => displayValue(task.sql, isLoadTask(task)),
+  },
+  {
+    title: '已运行时长',
+    dataIndex: 'elapsedMs',
+    width: 130,
+    render: (_, task) => displayDuration(task.elapsedMs),
+  },
+  {
+    title: '当前内存',
+    dataIndex: 'currentMemoryBytes',
+    width: 130,
+    render: (_, task) => displayBytes(task.currentMemoryBytes),
+  },
+  {
+    title: '峰值内存（单 BE 最大）',
+    dataIndex: 'peakMemoryBytes',
+    width: 180,
+    render: (_, task) => displayBytes(task.peakMemoryBytes),
+  },
+  {
+    title: '扫描行数',
+    dataIndex: 'scanRows',
+    width: 130,
+    render: (_, task) => displayNumber(task.scanRows),
+  },
+  {
+    title: '扫描字节',
+    dataIndex: 'scanBytes',
+    width: 130,
+    render: (_, task) => displayBytes(task.scanBytes, isLoadTask(task)),
+  },
+  {
+    title: 'CPU 时间',
+    dataIndex: 'cpuTimeMs',
+    width: 120,
+    render: (_, task) => displayDuration(task.cpuTimeMs),
+  },
+  {
+    title: 'Workload Group',
+    dataIndex: 'workloadGroupName',
+    width: 180,
+    render: (_, task) =>
+      displayValue(task.workloadGroupName ?? task.workloadGroupId),
+  },
+  {
+    title: '来源 FE',
+    dataIndex: 'feHost',
+    width: 160,
+    render: (_, task) => displayValue(task.feHost),
+  },
+  {
+    title: '排队状态（实验性）',
+    dataIndex: 'queryStatus',
+    width: 150,
+    render: (_, task) => displayValue(task.queryStatus, isLoadTask(task)),
+  },
+  {
+    title: '排队时长（实验性）',
+    dataIndex: 'queueEndTime',
+    width: 160,
+    render: (_, task) => displayQueueDuration(task),
+  },
+];

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/hooks/useActiveTaskPolling.test.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/hooks/useActiveTaskPolling.test.ts
@@ -56,6 +56,23 @@ describe('useActiveTaskPolling', () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
+  it('does not poll until a manual refresh when auto refresh is disabled', async () => {
+    const fetcher = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValue('snapshot');
+    const { result } = renderHook(() =>
+      useActiveTaskPolling({ fetcher, autoRefresh: false }),
+    );
+
+    await act(async () => {});
+    expect(fetcher).not.toHaveBeenCalled();
+
+    act(() => result.current.refresh());
+    await act(async () => {});
+    expect(result.current.data).toBe('snapshot');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
   it('stops while hidden or inactive, preserves the snapshot, and resumes when visible', async () => {
     const fetcher = vi
       .fn<() => Promise<string>>()

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/hooks/useActiveTaskPolling.test.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/hooks/useActiveTaskPolling.test.ts
@@ -1,0 +1,109 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useActiveTaskPolling } from './useActiveTaskPolling';
+
+describe('useActiveTaskPolling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-03T00:00:00.000Z'));
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('loads initially and supports a manual refresh with an update timestamp', async () => {
+    const fetcher = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValueOnce('second');
+    const { result } = renderHook(() =>
+      useActiveTaskPolling({ fetcher, intervalMs: 10_000 }),
+    );
+
+    await act(async () => {});
+    expect(result.current.data).toBe('first');
+    expect(result.current.lastUpdatedAt).toBe(
+      Date.parse('2026-09-03T00:00:00.000Z'),
+    );
+
+    act(() => result.current.refresh());
+    await act(async () => {});
+    expect(result.current.data).toBe('second');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes every ten seconds but does not overlap an in-flight request', async () => {
+    let resolve: ((value: string) => void) | undefined;
+    const fetcher = vi.fn(
+      () =>
+        new Promise<string>((done) => {
+          resolve = done;
+        }),
+    );
+    renderHook(() => useActiveTaskPolling({ fetcher }));
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    await act(async () => resolve?.('done'));
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops while hidden or inactive, preserves the snapshot, and resumes when visible', async () => {
+    const fetcher = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValue('snapshot');
+    const { result, rerender, unmount } = renderHook(
+      ({ active }) => useActiveTaskPolling({ fetcher, active }),
+      { initialProps: { active: true } },
+    );
+    await act(async () => {});
+    expect(result.current.data).toBe('snapshot');
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    rerender({ active: false });
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: false,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(result.current.data).toBe('snapshot');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    rerender({ active: true });
+    await act(async () => {});
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    unmount();
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes request errors without discarding the previous snapshot', async () => {
+    const fetcher = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('snapshot')
+      .mockRejectedValueOnce(new Error('unavailable'));
+    const { result } = renderHook(() => useActiveTaskPolling({ fetcher }));
+    await act(async () => {});
+    act(() => result.current.refresh());
+    await act(async () => {});
+
+    expect(result.current.data).toBe('snapshot');
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/hooks/useActiveTaskPolling.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/hooks/useActiveTaskPolling.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 export interface UseActiveTaskPollingOptions<T> {
   fetcher: () => Promise<T>;
   active?: boolean;
+  autoRefresh?: boolean;
   intervalMs?: number;
 }
 
@@ -19,6 +20,7 @@ const DEFAULT_INTERVAL_MS = 10_000;
 export function useActiveTaskPolling<T>({
   fetcher,
   active = true,
+  autoRefresh = true,
   intervalMs = DEFAULT_INTERVAL_MS,
 }: UseActiveTaskPollingOptions<T>): ActiveTaskPollingResult<T> {
   const fetcherRef = useRef(fetcher);
@@ -70,13 +72,14 @@ export function useActiveTaskPolling<T>({
     };
 
     const start = () => {
-      if (!active || document.hidden || timer !== undefined) return;
+      if (!autoRefresh || !active || document.hidden || timer !== undefined)
+        return;
       refresh();
       timer = setInterval(refresh, intervalMs);
     };
 
     const handleVisibilityChange = () => {
-      if (document.hidden || !active) stop();
+      if (document.hidden || !active || !autoRefresh) stop();
       else start();
     };
 
@@ -86,7 +89,7 @@ export function useActiveTaskPolling<T>({
       stop();
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [active, intervalMs, refresh]);
+  }, [active, autoRefresh, intervalMs, refresh]);
 
   return { data, error, loading, lastUpdatedAt, refresh };
 }

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/hooks/useActiveTaskPolling.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/hooks/useActiveTaskPolling.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UseActiveTaskPollingOptions<T> {
+  fetcher: () => Promise<T>;
+  active?: boolean;
+  intervalMs?: number;
+}
+
+export interface ActiveTaskPollingResult<T> {
+  data?: T;
+  error?: unknown;
+  loading: boolean;
+  lastUpdatedAt?: number;
+  refresh: () => void;
+}
+
+const DEFAULT_INTERVAL_MS = 10_000;
+
+export function useActiveTaskPolling<T>({
+  fetcher,
+  active = true,
+  intervalMs = DEFAULT_INTERVAL_MS,
+}: UseActiveTaskPollingOptions<T>): ActiveTaskPollingResult<T> {
+  const fetcherRef = useRef(fetcher);
+  const inFlightRef = useRef(false);
+  const mountedRef = useRef(true);
+  const [data, setData] = useState<T>();
+  const [error, setError] = useState<unknown>();
+  const [loading, setLoading] = useState(false);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number>();
+
+  fetcherRef.current = fetcher;
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(() => {
+    if (!active || document.hidden || inFlightRef.current) return;
+
+    inFlightRef.current = true;
+    setLoading(true);
+    setError(undefined);
+    void fetcherRef
+      .current()
+      .then((value) => {
+        if (!mountedRef.current) return;
+        setData(value);
+        setLastUpdatedAt(Date.now());
+      })
+      .catch((requestError: unknown) => {
+        if (mountedRef.current) setError(requestError);
+      })
+      .finally(() => {
+        inFlightRef.current = false;
+        if (mountedRef.current) setLoading(false);
+      });
+  }, [active]);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setInterval> | undefined;
+
+    const stop = () => {
+      if (timer === undefined) return;
+      clearInterval(timer);
+      timer = undefined;
+    };
+
+    const start = () => {
+      if (!active || document.hidden || timer !== undefined) return;
+      refresh();
+      timer = setInterval(refresh, intervalMs);
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden || !active) stop();
+      else start();
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    start();
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [active, intervalMs, refresh]);
+
+  return { data, error, loading, lastUpdatedAt, refresh };
+}

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.test.tsx
@@ -23,6 +23,7 @@ vi.mock('./hooks/useActiveTaskPolling', () => ({
 
 vi.mock('./service', () => ({
   getDorisActiveTasks: vi.fn(),
+  getDorisActiveTaskDetail: vi.fn(),
 }));
 
 vi.mock('./ActiveTaskTable', () => ({

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DorisActiveTask from './index';
+import type { DorisActiveTaskResponse } from './types';
+
+const { pollingOptions, pollingState } = vi.hoisted(() => ({
+  pollingOptions: [] as Array<{ autoRefresh?: boolean }>,
+  pollingState: {
+    data: undefined as DorisActiveTaskResponse | undefined,
+    error: undefined as unknown,
+    loading: false,
+    lastUpdatedAt: undefined as number | undefined,
+    refresh: vi.fn(),
+  },
+}));
+
+vi.mock('./hooks/useActiveTaskPolling', () => ({
+  useActiveTaskPolling: (options: { autoRefresh?: boolean }) => {
+    pollingOptions.push(options);
+    return pollingState;
+  },
+}));
+
+vi.mock('./service', () => ({
+  getDorisActiveTasks: vi.fn(),
+}));
+
+vi.mock('./ActiveTaskTable', () => ({
+  default: ({ tasks }: { tasks: Array<{ taskId: string }> }) => (
+    <div data-testid="doris-active-task-table">
+      {tasks.map((task) => task.taskId)}
+    </div>
+  ),
+}));
+
+vi.mock('./TaskDetailDrawer', () => ({
+  default: () => null,
+}));
+
+const response = (overrides: Partial<DorisActiveTaskResponse> = {}) => ({
+  tasks: [{ taskId: 'q-1', type: 'QUERY' }],
+  degraded: false,
+  partialFailures: [],
+  truncated: false,
+  sourceTruncated: false,
+  total: 1,
+  returned: 1,
+  connectedHostPort: 'ddh-01:9030',
+  ...overrides,
+});
+
+describe('DorisActiveTask page assembly', () => {
+  beforeEach(() => {
+    pollingOptions.length = 0;
+    pollingState.data = response();
+    pollingState.error = undefined;
+    pollingState.loading = false;
+    pollingState.lastUpdatedAt = undefined;
+    pollingState.refresh.mockClear();
+  });
+
+  it('starts in manual mode, displays the actual endpoint, and clears the table on failure', async () => {
+    const view = render(<DorisActiveTask clusterId={7} instanceId={8} />);
+
+    expect(
+      screen.getByTestId('doris-active-task-connected-host'),
+    ).toHaveTextContent('ddh-01:9030');
+    expect(screen.getByTestId('doris-active-task-table')).toHaveTextContent(
+      'q-1',
+    );
+    expect(pollingOptions[0]).toMatchObject({ autoRefresh: false });
+
+    fireEvent.click(screen.getByRole('switch', { name: '10 秒自动刷新' }));
+    await waitFor(() =>
+      expect(pollingOptions.at(-1)).toMatchObject({ autoRefresh: true }),
+    );
+
+    pollingState.error = new Error('raw backend detail');
+    view.rerender(<DorisActiveTask clusterId={7} instanceId={8} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('doris-active-task-status')).toHaveAttribute(
+        'data-status',
+        'failed',
+      ),
+    );
+    expect(
+      screen.queryByTestId('doris-active-task-table'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('raw backend detail')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(pollingOptions.at(-1)).toMatchObject({ autoRefresh: false }),
+    );
+  });
+
+  it('keeps empty and degraded page states visually distinct', () => {
+    const view = render(<DorisActiveTask clusterId={7} instanceId={8} />);
+
+    pollingState.data = response({ tasks: [], total: 0, returned: 0 });
+    view.rerender(<DorisActiveTask clusterId={7} instanceId={8} />);
+    expect(screen.getByTestId('doris-active-task-status')).toHaveAttribute(
+      'data-status',
+      'empty',
+    );
+
+    pollingState.data = response({ degraded: true });
+    view.rerender(<DorisActiveTask clusterId={7} instanceId={8} />);
+    expect(
+      screen.getByText('当前以只读账号连接，部分字段不可用'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('doris-active-task-status')).not.toHaveAttribute(
+      'data-status',
+      'empty',
+    );
+  });
+});

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.tsx
@@ -6,7 +6,7 @@ import styles from './DorisActiveTask.module.less';
 import FilterBar from './FilterBar';
 import { useActiveTaskPolling } from './hooks/useActiveTaskPolling';
 import StatusBanners from './StatusBanners';
-import { getDorisActiveTasks } from './service';
+import { getDorisActiveTaskDetail, getDorisActiveTasks } from './service';
 import TaskDetailDrawer from './TaskDetailDrawer';
 import type {
   DorisActiveTaskQuery,
@@ -81,6 +81,19 @@ const DorisActiveTask: React.FC<DorisActiveTaskProps> = ({
     setFilters(nextFilters);
   };
 
+  const handleOpen = (task: DorisActiveTaskRow) => {
+    setSelectedTask(task);
+    if (task.type.toUpperCase() === 'LOAD') return;
+    void getDorisActiveTaskDetail(clusterId, instanceId, task.taskId)
+      .then((detailResponse) => {
+        if (getApiFailureMessage(detailResponse) || !detailResponse.data) return;
+        setSelectedTask((current) =>
+          current?.taskId === task.taskId ? detailResponse.data : current,
+        );
+      })
+      .catch(() => undefined);
+  };
+
   return (
     <div
       ref={anchorRef}
@@ -121,7 +134,7 @@ const DorisActiveTask: React.FC<DorisActiveTaskProps> = ({
           <ActiveTaskTable
             tasks={response.tasks}
             loading={polling.loading}
-            onOpen={setSelectedTask}
+            onOpen={handleOpen}
           />
         ) : null}
         <TaskDetailDrawer

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.tsx
@@ -108,6 +108,14 @@ const DorisActiveTask: React.FC<DorisActiveTaskProps> = ({
           <Typography.Text data-testid="doris-active-task-connected-host">
             {response?.connectedHostPort || '–'}
           </Typography.Text>
+          {response?.serverVersion ? (
+            <Typography.Text
+              type="secondary"
+              data-testid="doris-active-task-server-version"
+            >
+              {response.serverVersion}
+            </Typography.Text>
+          ) : null}
           <Tag color="gold" data-experimental="queue-features">
             排队相关字段与分组排序：实验性
           </Tag>

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.tsx
@@ -1,25 +1,136 @@
-import { useIntl } from '@umijs/max';
-import { Spin } from 'antd';
-import React from 'react';
+import { Button, Space, Tag, Typography } from 'antd';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { getApiFailureMessage } from '@/utils/apiResponse';
+import ActiveTaskTable from './ActiveTaskTable';
 import styles from './DorisActiveTask.module.less';
+import FilterBar from './FilterBar';
+import { useActiveTaskPolling } from './hooks/useActiveTaskPolling';
+import StatusBanners from './StatusBanners';
+import { getDorisActiveTasks } from './service';
+import TaskDetailDrawer from './TaskDetailDrawer';
+import type {
+  DorisActiveTaskQuery,
+  DorisActiveTask as DorisActiveTaskRow,
+} from './types';
 
 interface DorisActiveTaskProps {
   clusterId: number;
   instanceId: number;
 }
 
+function useTabPanelActive() {
+  const anchorRef = useRef<HTMLDivElement>(null);
+  const [active, setActive] = useState(true);
+
+  useEffect(() => {
+    const panel = anchorRef.current?.closest<HTMLElement>('[role="tabpanel"]');
+    if (!panel) return;
+
+    const update = () => {
+      setActive(
+        panel.getAttribute('aria-hidden') !== 'true' &&
+          !panel.classList.contains('ant-tabs-tabpane-hidden'),
+      );
+    };
+    update();
+    const observer = new MutationObserver(update);
+    observer.observe(panel, {
+      attributes: true,
+      attributeFilter: ['aria-hidden', 'class'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  return { anchorRef, active };
+}
+
 const DorisActiveTask: React.FC<DorisActiveTaskProps> = ({
   clusterId,
   instanceId,
 }) => {
-  const intl = useIntl();
+  const { anchorRef, active: tabActive } = useTabPanelActive();
+  const [filters, setFilters] = useState<DorisActiveTaskQuery>({});
+  const [autoRefresh, setAutoRefresh] = useState(false);
+  const [selectedTask, setSelectedTask] = useState<DorisActiveTaskRow>();
+  const fetcher = useCallback(async () => {
+    const response = await getDorisActiveTasks(clusterId, instanceId, filters);
+    const failure = getApiFailureMessage(response);
+    if (failure) throw new Error(failure);
+    if (!response.data) throw new Error('活动任务响应无数据');
+    return response.data;
+  }, [clusterId, filters, instanceId]);
+  const polling = useActiveTaskPolling({
+    fetcher,
+    active: tabActive,
+    autoRefresh,
+  });
+  const response = polling.error ? undefined : polling.data;
+
+  useEffect(() => {
+    if (tabActive) polling.refresh();
+  }, [filters, polling.refresh, tabActive]);
+
+  useEffect(() => {
+    if (polling.error) {
+      setAutoRefresh(false);
+      setSelectedTask(undefined);
+    }
+  }, [polling.error]);
+
+  const handleFilterChange = (nextFilters: DorisActiveTaskQuery) => {
+    setFilters(nextFilters);
+  };
+
   return (
     <div
+      ref={anchorRef}
       className={styles.panel}
       data-cluster-id={clusterId}
       data-instance-id={instanceId}
+      data-tab-active={tabActive}
     >
-      <Spin tip={intl.formatMessage({ id: 'dorisActiveTask.loading' })} />
+      <Space direction="vertical" size="middle" style={{ width: '100%' }}>
+        <Space wrap>
+          <Typography.Text strong>连接地址：</Typography.Text>
+          <Typography.Text data-testid="doris-active-task-connected-host">
+            {response?.connectedHostPort || '–'}
+          </Typography.Text>
+          <Tag color="gold" data-experimental="queue-features">
+            排队相关字段与分组排序：实验性
+          </Tag>
+          {polling.lastUpdatedAt ? (
+            <Typography.Text data-testid="doris-active-task-last-updated">
+              最后更新：{new Date(polling.lastUpdatedAt).toLocaleTimeString()}
+            </Typography.Text>
+          ) : null}
+        </Space>
+        <FilterBar
+          value={filters}
+          loading={polling.loading}
+          autoRefresh={autoRefresh}
+          onChange={handleFilterChange}
+          onRefresh={polling.refresh}
+          onAutoRefreshChange={setAutoRefresh}
+        />
+        <StatusBanners
+          response={response}
+          error={polling.error}
+          loading={polling.loading}
+        />
+        {response ? (
+          <ActiveTaskTable
+            tasks={response.tasks}
+            loading={polling.loading}
+            onOpen={setSelectedTask}
+          />
+        ) : null}
+        <TaskDetailDrawer
+          task={selectedTask}
+          open={selectedTask != null}
+          onClose={() => setSelectedTask(undefined)}
+        />
+        {polling.error ? <Button onClick={polling.refresh}>重试</Button> : null}
+      </Space>
     </div>
   );
 };

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/index.tsx
@@ -1,0 +1,27 @@
+import { useIntl } from '@umijs/max';
+import { Spin } from 'antd';
+import React from 'react';
+import styles from './DorisActiveTask.module.less';
+
+interface DorisActiveTaskProps {
+  clusterId: number;
+  instanceId: number;
+}
+
+const DorisActiveTask: React.FC<DorisActiveTaskProps> = ({
+  clusterId,
+  instanceId,
+}) => {
+  const intl = useIntl();
+  return (
+    <div
+      className={styles.panel}
+      data-cluster-id={clusterId}
+      data-instance-id={instanceId}
+    >
+      <Spin tip={intl.formatMessage({ id: 'dorisActiveTask.loading' })} />
+    </div>
+  );
+};
+
+export default DorisActiveTask;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/service.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/service.ts
@@ -1,0 +1,13 @@
+import { request } from '@umijs/max';
+import type { DorisActiveTaskQuery, DorisActiveTaskResponse } from './types';
+
+export async function getDorisActiveTasks(
+  clusterId: number,
+  instanceId: number,
+  query: DorisActiveTaskQuery = {},
+) {
+  return request<{ data: DorisActiveTaskResponse }>(
+    `/cluster/${clusterId}/service/${instanceId}/doris/active-tasks`,
+    { method: 'POST', data: query, skipErrorHandler: true },
+  );
+}

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/service.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/service.ts
@@ -1,5 +1,9 @@
 import { request } from '@umijs/max';
-import type { DorisActiveTaskQuery, DorisActiveTaskResponse } from './types';
+import type {
+  DorisActiveTask,
+  DorisActiveTaskQuery,
+  DorisActiveTaskResponse,
+} from './types';
 
 export async function getDorisActiveTasks(
   clusterId: number,
@@ -9,5 +13,16 @@ export async function getDorisActiveTasks(
   return request<{ data: DorisActiveTaskResponse }>(
     `/cluster/${clusterId}/service/${instanceId}/doris/active-tasks`,
     { method: 'POST', data: query, skipErrorHandler: true },
+  );
+}
+
+export async function getDorisActiveTaskDetail(
+  clusterId: number,
+  instanceId: number,
+  taskId: string,
+) {
+  return request<{ data: DorisActiveTask }>(
+    `/cluster/${clusterId}/service/${instanceId}/doris/active-tasks/${encodeURIComponent(taskId)}`,
+    { method: 'GET', skipErrorHandler: true },
   );
 }

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/types.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/types.ts
@@ -21,6 +21,7 @@ export interface DorisActiveTask {
   user?: string | null;
   clientAddress?: string | null;
   sql?: string | null;
+  detailSql?: string | null;
   elapsedMs?: number | null;
   startTime?: string | null;
   currentMemoryBytes?: number | null;

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/types.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/types.ts
@@ -53,4 +53,8 @@ export interface DorisActiveTaskResponse {
   total: number;
   returned: number;
   connectedHostPort: string;
+  /** 服务端版本串（@@version_comment 原文）。 */
+  serverVersion?: string | null;
+  /** 当前 Doris 大版本确定拿不到的字段，与后端 DorisVersionProfile.unsupportedFields 一一对应。 */
+  unsupportedFields?: string[] | null;
 }

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/types.ts
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/DorisActiveTask/types.ts
@@ -1,0 +1,55 @@
+export interface DorisActiveTaskQuery {
+  keyword?: string | null;
+  types?: string[] | null;
+  user?: string | null;
+  feHost?: string | null;
+  minMemoryBytes?: number | null;
+  minElapsedMs?: number | null;
+}
+
+export interface DorisBeTaskDetail {
+  beId: string;
+  peakMemoryBytes?: number | null;
+  currentMemoryBytes?: number | null;
+  scanRows?: number | null;
+  scanBytes?: number | null;
+}
+
+export interface DorisActiveTask {
+  taskId: string;
+  type: string;
+  user?: string | null;
+  clientAddress?: string | null;
+  sql?: string | null;
+  elapsedMs?: number | null;
+  startTime?: string | null;
+  currentMemoryBytes?: number | null;
+  peakMemoryBytes?: number | null;
+  scanRows?: number | null;
+  scanBytes?: number | null;
+  cpuTimeMs?: number | null;
+  shuffleSendBytes?: number | null;
+  shuffleSendRows?: number | null;
+  spillWriteBytesToLocalStorage?: number | null;
+  spillReadBytesFromLocalStorage?: number | null;
+  workloadGroupId?: number | null;
+  workloadGroupName?: string | null;
+  feHost?: string | null;
+  queryStatus?: string | null;
+  queueStartTime?: string | null;
+  queueEndTime?: string | null;
+  truncated?: boolean | null;
+  beDetails?: DorisBeTaskDetail[] | null;
+}
+
+export interface DorisActiveTaskResponse {
+  tasks: DorisActiveTask[];
+  degraded: boolean;
+  degradedReason?: string | null;
+  partialFailures: string[];
+  truncated: boolean;
+  sourceTruncated: boolean;
+  total: number;
+  returned: number;
+  connectedHostPort: string;
+}

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.test.tsx
@@ -42,6 +42,7 @@ const {
 
 vi.mock('@umijs/max', () => ({
   history: { replace: vi.fn() },
+  useAccess: () => ({ canAdmin: false }),
   useIntl: () => ({
     formatMessage: ({ id }: { id: string }) =>
       id === 'dsWorkflow.tab' ? '工作流' : id,

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.test.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.test.tsx
@@ -24,6 +24,7 @@ const {
   kyuubiDashboardSpy,
   juicefsDashboardSpy,
   routeParams,
+  accessState,
 } = vi.hoisted(() => ({
   apisixDashboardSpy: vi.fn(),
   apisixGatewaySpy: vi.fn(),
@@ -38,14 +39,19 @@ const {
   kyuubiDashboardSpy: vi.fn(),
   juicefsDashboardSpy: vi.fn(),
   routeParams: { clusterId: '7', instanceId: '9' },
+  accessState: { canAdmin: false },
 }));
 
 vi.mock('@umijs/max', () => ({
   history: { replace: vi.fn() },
-  useAccess: () => ({ canAdmin: false }),
+  useAccess: () => accessState,
   useIntl: () => ({
     formatMessage: ({ id }: { id: string }) =>
-      id === 'dsWorkflow.tab' ? '工作流' : id,
+      id === 'dsWorkflow.tab'
+        ? '工作流'
+        : id === 'dorisActiveTask.tab'
+          ? '活动任务'
+          : id,
   }),
   useParams: () => routeParams,
 }));
@@ -484,6 +490,7 @@ describe('DS service instance tabs', () => {
 describe('DORIS service instance tabs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    accessState.canAdmin = false;
     routeParams.clusterId = '7';
     routeParams.instanceId = '44';
     vi.mocked(getServiceInstance).mockResolvedValue({
@@ -518,6 +525,27 @@ describe('DORIS service instance tabs', () => {
         embedded: true,
       }),
     );
+  });
+
+  it('shows the activity tab after monitoring for admins', async () => {
+    accessState.canAdmin = true;
+    render(
+      <ClusterContext.Provider
+        value={{ clusterInfo: { archType: 'physical' } } as never}
+      >
+        <ServiceInstance />
+      </ClusterContext.Provider>,
+    );
+
+    await screen.findByText('Doris dashboard cluster 7');
+
+    expect(screen.getAllByRole('tab').map((tab) => tab.textContent)).toEqual([
+      '监控',
+      '活动任务',
+      '概览',
+      '实例',
+      '配置',
+    ]);
   });
 });
 

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.tsx
@@ -59,6 +59,9 @@ const K8S_MONITOR_DASHBOARDS: Record<
   zookeeper: ZooKeeperDashboard,
 };
 
+/** 活动任务 Tab 适用的 K8s Doris chart（存算一体 / 存算分离）。 */
+const K8S_DORIS_CHARTS: string[] = ['doris-coupled', 'doris-disaggregated'];
+
 const ServiceInstance: React.FC = () => {
   const intl = useIntl();
   const { clusterId, instanceId } = useParams<{
@@ -199,7 +202,7 @@ const ServiceInstance: React.FC = () => {
 
   // ── K8s 实例页：资源 Tab（动态）+ 配置 Tab ─────────────────────────
   if (isK8s) {
-    const isDoris = ['doris-coupled', 'doris-disaggregated'].includes(
+    const isDoris = K8S_DORIS_CHARTS.includes(
       k8sInstance?.serviceName?.toLowerCase() ?? '',
     );
     const K8sMonitorDashboard = k8sInstance?.serviceName

--- a/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.tsx
+++ b/datasophon-ui-v2/src/pages/Cluster/ServiceInstance/index.tsx
@@ -1,4 +1,4 @@
-import { history, useIntl, useParams } from '@umijs/max';
+import { history, useAccess, useIntl, useParams } from '@umijs/max';
 import type { TabsProps } from 'antd';
 import { Button, Dropdown, message, Popconfirm, Space, Spin, Tabs } from 'antd';
 import React, { useContext, useEffect, useMemo, useState } from 'react';
@@ -25,6 +25,7 @@ import {
   getServiceWebUis,
 } from '@/services/service';
 import ApisixGatewayPanel from './ApisixGateway';
+import DorisActiveTask from './DorisActiveTask';
 import DsWorkflowPanel from './DsWorkflow';
 import InstanceTab from './Instance';
 import K8sResource from './K8sResource';
@@ -69,6 +70,8 @@ const ServiceInstance: React.FC = () => {
 
   const clusterCtx = useContext(ClusterContext);
   const isK8s = clusterCtx?.clusterInfo?.archType === 'k8s';
+  const access = useAccess?.() as { canAdmin?: boolean } | undefined;
+  const canAdmin = Boolean(access?.canAdmin);
 
   // ── 物理集群状态 ───────────────────────────────────────
   const [serviceInfo, setServiceInfo] =
@@ -196,6 +199,9 @@ const ServiceInstance: React.FC = () => {
 
   // ── K8s 实例页：资源 Tab（动态）+ 配置 Tab ─────────────────────────
   if (isK8s) {
+    const isDoris = ['doris-coupled', 'doris-disaggregated'].includes(
+      k8sInstance?.serviceName?.toLowerCase() ?? '',
+    );
     const K8sMonitorDashboard = k8sInstance?.serviceName
       ? K8S_MONITOR_DASHBOARDS[k8sInstance.serviceName.toLowerCase()]
       : undefined;
@@ -211,6 +217,20 @@ const ServiceInstance: React.FC = () => {
                   embedded
                   job={k8sInstance?.metricsJob}
                   monitorProfile={k8sInstance?.monitorProfile}
+                />
+              ),
+            },
+          ]
+        : []),
+      ...(isDoris && canAdmin
+        ? [
+            {
+              key: 'dorisActiveTask',
+              label: intl.formatMessage({ id: 'dorisActiveTask.tab' }),
+              children: (
+                <DorisActiveTask
+                  clusterId={numericClusterId}
+                  instanceId={numericInstanceId}
                 />
               ),
             },
@@ -315,6 +335,18 @@ const ServiceInstance: React.FC = () => {
       key: 'monitor',
       label: '监控',
       children: primaryMonitor,
+    });
+  }
+  if (isDoris && canAdmin) {
+    items.push({
+      key: 'dorisActiveTask',
+      label: intl.formatMessage({ id: 'dorisActiveTask.tab' }),
+      children: (
+        <DorisActiveTask
+          clusterId={numericClusterId}
+          instanceId={numericInstanceId}
+        />
+      ),
     });
   }
   if (isApisix) {


### PR DESCRIPTION
## 做了什么

在 Doris 服务详情页新增「活动任务」Tab：以只读方式展示当前正在执行的 Query 与 Load Task，
含资源数值、筛选排序、详情抽屉与自动刷新。仅系统管理员可见。

支持 **物理集群**（走平台已存的 `DORIS/root_password`）与 **K8s Imported 集群**
（无 root 凭据来源，回落已provisioned 的 `otel_reader` 并展示降级 banner），
K8s Managed 形态列为 Out of scope。

## 按 Doris 大版本区分的兼容设计

最初实现的 4 条固定 SQL 只对 4.x 成立。3.0.8（存算分离 Cloud Mode）上
`information_schema` 的列有增删与命名风格切换，前三条语句全部报错，又被
Facade 的 `catch (RuntimeException)` 无声吞掉，统一兜成 502「连接 Doris FE 失败」——
故障表象与真因完全脱节。

两个环境各自 `DESC` 实测的差异：

| 表 | 3.x（K8s 存算分离，`doris-3.0.8-rc01` Cloud Mode） | 4.x（`doris-4.1.3-rc02`） |
|---|---|---|
| `active_queries` | 10 列，**无 `USER`** | 11 列 |
| `backend_active_tasks` | 12 列，**无 `WORKLOAD_GROUP_ID`、无两个 `SPILL_*`** | 15 列 |
| `processlist` | `QUERY_ID`/`HOST`/`USER` | `QueryId`/`Host`/`User` |
| `workload_groups` | `ID`/`NAME` | 一致，不分档位 |

新增 `DorisVersionProfile`（枚举，按大版本持列清单并生成 SQL）：

- **版本探测**用 `SELECT @@version_comment` —— `version()` 为 MySQL 协议兼容恒返回
  `5.7.99`，不可用。探测与连接可用性验证合并为同一次握手，结果随连接池缓存。
- **列名别名归一**：3.x 的 SELECT 写 `QUERY_ID AS QueryId`，使下游合并/聚合/筛选读到的
  key 与 4.x 完全一致 —— 版本差异到 SQL 为止，不外溢。
- **缺失列不静默留空**：经响应新字段 `unsupportedFields` 显式声明，页面出 info banner。
- **2.x 留档位、直接返回 501**：列清单留空待实测，凭文档猜列正是本次故障的成因。
  未识别版本按最新已知档位尝试（新版本通常加列而非删列），不直接判死。

附带修复：

- Facade 补 `log.warn` 落盘真实异常（对外仍只给固定文案，不泄露 jdbc 串）。
- K8s 上的 Pod FQDN 来源 FE 只显示 `<pod>.<namespace>`，不再是 96 字符全称。

## 验证

- **3.x 端到端**：`POST /v2/cluster/16/service/54/doris/active-tasks` 返回 200 与真实任务行；
  页面显示版本串、`123.117.153.171:9030`、不支持字段 banner、来源 FE
  `doris-disaggregated-cluster-fe-0.doris`；LOAD 行结构性不适用字段显示「不适用」而非 0。
- **4.x 回归**：ddh-01 上 `processlist` 新增的 `` `User` `` 列查询成功并返回真实用户行。
- **单元测试**：后端 Doris 定向 34 项、前端 `ServiceInstance` 20 files / 85 tests 全绿；
  Spotless、Biome、tsc 通过。

## 已知待办（如实列出，未隐含通过）

| # | 项 | 说明 |
|---|---|---|
| V1 | 排队查询字段形态 | 未造出排队场景。`QUERY_STATUS` 真值、`QUEUE_*` 填充形式、排队行是否进 `backend_active_tasks` 均未知。**相关 UI 已标「实验性」**；筛选是精确等值匹配，真值不符会静默失效 |
| V3 | 多 FE 的「来源 FE」归一 | 3.x 已闭合（两源同为 Pod FQDN）；**物理多 FE 未验**（`FRONTEND_INSTANCE` 与 `FE_HOST` 是否同表示法） |
| V5 | Routine / Broker Load | 只见过 Stream Load。类型判定为白名单 + 兜底归 LOAD，未知取值有确定归宿，风险低 |
| V6 | 3.x「用户/客户端地址」对瞬时查询恒空 | join 方向 `active_queries → processlist`，两条语句先后执行，短查询在第二条执行时已结束。持续运行的查询可正常取到；4.x 从 `active_queries` 直取不受影响 |

已闭合：V2（同一连接返回 fe-0/fe-1 两台的行，证明 `active_queries`/`backend_active_tasks`
是集群级）、V4（K8s Imported 现场验收通过）。

**全量 `./mvnw test` 未跑绿**：`datasophon-common` 的 5 failures / 4 errors 已复核为**既有**
本机路径与真实网络依赖测试（`/usr/bin/docker`、`/usr/bin/helmify`、推镜像到
`192.168.2.200:8091`、真跑 kubectl），与本 PR 无关。

## 不含

设计文档（`docs/monitoring/doris-active-task-tab-*.md`）与实测证据（`.scratch/`）
按仓库惯例未进本 PR。

https://claude.ai/code/session_01FaSqSrgsWQUrMdUdjii3wB
